### PR TITLE
fix: migrate from deprecated ClipboardManager to Clipboard API

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -1,5 +1,6 @@
 package dev.hossain.highlight.ui
 
+import android.content.ClipData
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -24,12 +25,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ClipboardManager
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -38,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightTheme
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Displays syntax-highlighted code in a styled block.
@@ -121,7 +124,8 @@ fun SyntaxHighlightedCode(
     lineHeight: TextUnit = 20.sp,
 ) {
     val highlightedState = rememberHighlightedCode(code, language, theme, onHighlightComplete)
-    val clipboardManager: ClipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     var copyConfirmed by remember { mutableStateOf(false) }
 
     val backgroundColor =
@@ -171,7 +175,11 @@ fun SyntaxHighlightedCode(
                                 if (handler != null) {
                                     handler(code)
                                 } else {
-                                    clipboardManager.setText(AnnotatedString(code))
+                                    scope.launch {
+                                        clipboard.setClipEntry(
+                                            ClipEntry(ClipData.newPlainText("code", code)),
+                                        )
+                                    }
                                 }
                                 copyConfirmed = true
                             },


### PR DESCRIPTION
## Problem

Three deprecation warnings were emitted during `compileReleaseKotlin`:
- `ClipboardManager` is deprecated — use `Clipboard` instead
- `LocalClipboardManager` is deprecated — use `LocalClipboard` instead

## Solution

Replaced the synchronous `ClipboardManager.setText(AnnotatedString)` approach with the new suspend-based `Clipboard.setClipEntry(ClipEntry)` API:

- `LocalClipboard.current` replaces `LocalClipboardManager.current`
- `rememberCoroutineScope()` added to launch the suspend call
- `ClipEntry(ClipData.newPlainText("code", code))` replaces `AnnotatedString(code)`

## Verification

`./gradlew :compose-highlight:compileReleaseKotlin` produces zero warnings.