### PR TITLE
fix: resolve all lint warnings (SDK 37, Gradle 9.5.0, launcher icon)

### DIFF
--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "dev.hossain.highlight"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "dev.hossain.highlight.sample"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <application
         android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:supportsRtl="true">
         <activity

--- a/sample/src/main/res/drawable/ic_launcher_background.xml
+++ b/sample/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#1E1E1E" />
+</shape>

--- a/sample/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/sample/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Design "code" icon (</>), scaled for adaptive icon safe zone -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#CCCCCC"
+        android:pathData="M44.1,67.8L27.3,54l16.8,-13.8L40,35 18,54l22,19 4.1,-5.2zM63.9,67.8L80.7,54 63.9,40.2 68,35l22,19 -22,19 -4.1,-5.2z" />
+</vector>

--- a/sample/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/sample/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Monochrome version of the code icon for Android 13+ themed icons -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M44.1,67.8L27.3,54l16.8,-13.8L40,35 18,54l22,19 4.1,-5.2zM63.9,67.8L80.7,54 63.9,40.2 68,35l22,19 -22,19 -4.1,-5.2z" />
+</vector>

--- a/sample/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/sample/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/sample/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/sample/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>


### PR DESCRIPTION
## Lint warnings fixed

Both `:compose-highlight` and `:sample` now report **0 errors or warnings**.

### Changes

| Issue | Fix |
|---|---|
| `GradleDependency`: compileSdk 36 → 37 | Updated both `compose-highlight/build.gradle.kts` and `sample/build.gradle.kts` |
| `OldTargetApi`: targetSdk 36 → 37 | Updated `sample/build.gradle.kts` |
| `AndroidGradlePluginVersion`: Gradle 9.4.1 → 9.5.0 | Updated `gradle-wrapper.properties` |
| `MissingApplicationIcon` | Added adaptive launcher icon (`</>" code icon) to sample app |
| `MonochromeIcon` | Added `ic_launcher_monochrome.xml` for Android 13+ themed icons |

### New files
- `sample/src/main/res/drawable/ic_launcher_background.xml` — dark `#1E1E1E` background
- `sample/src/main/res/drawable/ic_launcher_foreground.xml` — `</>` code icon
- `sample/src/main/res/drawable/ic_launcher_monochrome.xml` — monochrome variant
- `sample/src/main/res/mipmap-anydpi-v26/ic_launcher.xml` — adaptive icon
- `sample/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml` — round adaptive icon