### PR TITLE
fix: line numbers misalign when highlighted text has more lines than raw code

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -245,7 +245,8 @@ private fun LineNumberedCode(
     fontSize: TextUnit,
     lineHeight: TextUnit,
 ) {
-    val lines = code.lines()
+    // Count lines from the text that will actually be rendered so line numbers always align.
+    val lineCount = (highlighted?.text ?: code).lines().size
     val codeStyle =
         TextStyle(
             color = textColor,
@@ -264,7 +265,7 @@ private fun LineNumberedCode(
     Row(modifier = Modifier.padding(style.padding)) {
         // Line number gutter
         Column(modifier = Modifier.width(style.lineNumberWidth)) {
-            lines.forEachIndexed { index, _ ->
+            repeat(lineCount) { index ->
                 Text(
                     text = "${index + 1}",
                     style = lineNumStyle,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -263,15 +264,16 @@ private fun LineNumberedCode(
         )
 
     Row(modifier = Modifier.padding(style.padding)) {
-        // Line number gutter
-        Column(modifier = Modifier.width(style.lineNumberWidth)) {
-            repeat(lineCount) { index ->
-                Text(
-                    text = "${index + 1}",
-                    style = lineNumStyle,
-                )
-            }
-        }
+        // Line number gutter — rendered as a single Text to share the same line-height
+        // behaviour as the code Text, keeping numbers and code visually aligned.
+        val lineNumbers = (1..lineCount).joinToString("\n")
+        Text(
+            text = lineNumbers,
+            style = lineNumStyle,
+            modifier = Modifier.width(style.lineNumberWidth),
+            textAlign = TextAlign.End,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
         // Code text
         if (highlighted != null) {
             Text(text = highlighted, style = codeStyle)


### PR DESCRIPTION
## Problem

When `showLineNumbers = true`, the line number gutter was visually misaligned with the code after the first several lines.

**Root cause:** Line numbers were rendered as individual single-line `Text` composables inside a `Column`, one per line number:

```kotlin
Column {
    repeat(lineCount) { index ->
        Text(text = (index + 1).toString(), ...)
    }
}
```

The code itself is rendered as a single multi-line `Text`. Compose distributes `lineHeight` differently between a sequence of single-line `Text` composables and lines within a single multi-line `Text` — the first line of a multi-line `Text` receives top padding from the line height distribution. This caused cumulative drift: the gutter and code start together but diverge noticeably after 8-10 lines.

Additionally, `lineCount` was derived from `code.lines()` (the raw input), but highlight.js can append a trailing newline to its output HTML, making the highlighted `AnnotatedString` have one more line than the raw string. This left the last line(s) without a line number.

## Fix

1. **Render all line numbers as a single multi-line `Text`** by joining them with `\n`. Both the gutter and the code are now identical-style multi-line `Text` composables sharing the same `lineHeight` behaviour — no more drift regardless of line count.

2. **Derive `lineCount` from the displayed text**: `(highlighted?.text ?: code).lines().size` — uses the raw code before highlighting completes, then switches to the highlighted `AnnotatedString` so the gutter always matches exactly what is rendered.

```kotlin
// Before - individual Text per line (causes alignment drift)
Column {
    repeat(lineCount) { index ->
        Text(text = (index + 1).toString(), ...)
    }
}

// After - single multi-line Text (same lineHeight behaviour as code Text)
Text(
    text = (1..lineCount).joinToString("\n"),
    textAlign = TextAlign.End,
    ...
)
```
