### PR TITLE
feat: Performance benchmark screen, vector icons, new language samples, custom copy icon

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -102,6 +102,23 @@ import kotlinx.coroutines.launch
  * @param showLanguageLabel Whether to show the language badge in the header.
  * @param showCopyButton Whether to show the copy-to-clipboard button.
  * @param onCopyClick Optional custom copy handler. If `null`, copies to the system clipboard.
+ * @param copyButtonIcon Optional composable slot that replaces the default `⧉` copy icon.
+ *   Receives the recommended `tint` [Color] derived from the active theme so the icon blends
+ *   naturally with the code block background. Only used when [showCopyButton] is `true`.
+ *   Example:
+ *   ```kotlin
+ *   SyntaxHighlightedCode(
+ *       code = snippet,
+ *       language = "kotlin",
+ *       copyButtonIcon = { tint ->
+ *           Icon(
+ *               imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+ *               contentDescription = "Copy",
+ *               tint = tint,
+ *           )
+ *       },
+ *   )
+ *   ```
  * @param onHighlightComplete Optional callback invoked with the highlight duration in milliseconds
  *   when highlighting succeeds. Useful for performance metrics.
  * @param fontFamily Font family for the code text. Defaults to monospace.
@@ -119,6 +136,7 @@ fun SyntaxHighlightedCode(
     showLanguageLabel: Boolean = true,
     showCopyButton: Boolean = true,
     onCopyClick: ((String) -> Unit)? = null,
+    copyButtonIcon: (@Composable (tint: Color) -> Unit)? = null,
     onHighlightComplete: ((durationMs: Long) -> Unit)? = null,
     fontFamily: FontFamily = FontFamily.Monospace,
     fontSize: TextUnit = 13.sp,
@@ -171,6 +189,7 @@ fun SyntaxHighlightedCode(
                             copyConfirmed = copyConfirmed,
                             size = style.copyButtonSize,
                             tint = textColor.copy(alpha = 0.7f),
+                            customIcon = copyButtonIcon,
                             onClick = {
                                 val handler = onCopyClick
                                 if (handler != null) {
@@ -288,6 +307,7 @@ private fun CopyButton(
     copyConfirmed: Boolean,
     size: androidx.compose.ui.unit.Dp,
     tint: Color,
+    customIcon: (@Composable (tint: Color) -> Unit)?,
     onClick: () -> Unit,
 ) {
     if (copyConfirmed) {
@@ -300,11 +320,15 @@ private fun CopyButton(
             onClick = onClick,
             modifier = Modifier.size(size),
         ) {
-            // Use a simple text icon since we don't bundle icons
-            Text(
-                text = "⧉",
-                style = TextStyle(color = tint, fontSize = 16.sp),
-            )
+            if (customIcon != null) {
+                customIcon(tint)
+            } else {
+                // Default: simple text icon — no bundled icon dependency
+                Text(
+                    text = "⧉",
+                    style = TextStyle(color = tint, fontSize = 16.sp),
+                )
+            }
         }
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -311,6 +311,8 @@ private fun CopyButton(
     onClick: () -> Unit,
 ) {
     if (copyConfirmed) {
+        // TODO - expose this as a composable that user passes for more control over the "Copied!"
+        //  UI (e.g. add an optional checkmark icon, or animate the text)
         Text(
             text = "Copied!",
             style = TextStyle(color = tint, fontSize = 12.sp),

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".perf.PerfActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
+        android:theme="@style/Theme.ComposeSample"
         android:supportsRtl="true">
         <activity
             android:name=".MainActivity"

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoSections.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoSections.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -23,7 +24,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -33,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.CodeBlockStyle
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
@@ -361,6 +365,22 @@ internal fun CallbacksSection() {
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        // copyButtonIcon custom slot demo
+        SubSectionHeader("copyButtonIcon — custom vector icon")
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            copyButtonIcon = { tint ->
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                    contentDescription = "Copy code",
+                    tint = tint,
+                )
+            },
+        )
     }
 }
 

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoSections.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoSections.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -376,6 +377,7 @@ internal fun CallbacksSection() {
             copyButtonIcon = { tint ->
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                    modifier = Modifier.size(16.dp),
                     contentDescription = "Copy code",
                     tint = tint,
                 )

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -16,6 +16,10 @@ internal data class CodeSample(
  *
  * The list intentionally covers a range of use-cases:
  * - Short, focused snippets (Python, Kotlin, JavaScript, Java, SQL, JSON, XML)
+ * - Systems / low-level languages (Rust, C++, Go) showcasing templates, lifetimes, goroutines
+ * - Typed languages (TypeScript, Swift, C#) showcasing generics, protocols, LINQ, async/await
+ * - Shell script (Bash) showcasing variables, functions, case statements
+ * - Stylesheet (CSS) showcasing selectors, variables, media queries, keyframes
  * - A large, real-world Kotlin file (WeatherApp) to stress-test rendering performance
  * - An empty string edge case to verify graceful fallback
  */
@@ -321,6 +325,374 @@ data class CurrentWeatherInfo(
 )
 
 data class HourlyForecastInfo(val time: Instant, val temperature: Double, val description: String)
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "typescript",
+            code =
+                """
+interface Repository<T extends { id: number }> {
+  findById(id: number): Promise<T | null>;
+  save(entity: Omit<T, 'id'>): Promise<T>;
+  delete(id: number): Promise<void>;
+}
+
+type ApiResponse<T> = {
+  data: T;
+  status: number;
+  message?: string;
+};
+
+async function fetchWithRetry<T>(
+  url: string,
+  retries = 3,
+): Promise<ApiResponse<T>> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${'$'}{res.status}: ${'$'}{res.statusText}`);
+      const data: T = await res.json();
+      return { data, status: res.status };
+    } catch (err) {
+      if (attempt === retries - 1) throw err;
+      await new Promise(r => setTimeout(r, 2 ** attempt * 100));
+    }
+  }
+  throw new Error('unreachable');
+}
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "rust",
+            code =
+                """
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct LruCache<V> {
+    store: HashMap<String, V>,
+    capacity: usize,
+}
+
+impl<V> LruCache<V> {
+    pub fn new(capacity: usize) -> Self {
+        Self { store: HashMap::with_capacity(capacity), capacity }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&V> {
+        self.store.get(key)
+    }
+
+    /// Inserts a value; returns the old value if the key existed.
+    pub fn insert(&mut self, key: String, value: V) -> Result<Option<V>, &'static str> {
+        if self.store.len() >= self.capacity && !self.store.contains_key(&key) {
+            return Err("cache full — eviction not implemented");
+        }
+        Ok(self.store.insert(key, value))
+    }
+}
+
+fn main() {
+    let mut cache: LruCache<i32> = LruCache::new(4);
+    cache.insert("answer".to_owned(), 42).unwrap();
+    match cache.get("answer") {
+        Some(v) => println!("Found: {v}"),
+        None    => println!("Cache miss"),
+    }
+}
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "go",
+            code =
+                """
+package main
+
+import (
+    "context"
+    "fmt"
+    "sync"
+    "time"
+)
+
+type Result struct {
+    URL      string
+    Duration time.Duration
+    Err      error
+}
+
+func fetchAll(ctx context.Context, urls []string) []Result {
+    var mu sync.Mutex
+    results := make([]Result, 0, len(urls))
+    var wg sync.WaitGroup
+
+    for _, url := range urls {
+        wg.Add(1)
+        go func(u string) {
+            defer wg.Done()
+            start := time.Now()
+            select {
+            case <-ctx.Done():
+                mu.Lock()
+                results = append(results, Result{URL: u, Err: ctx.Err()})
+                mu.Unlock()
+            case <-time.After(50 * time.Millisecond):
+                mu.Lock()
+                results = append(results, Result{URL: u, Duration: time.Since(start)})
+                mu.Unlock()
+            }
+        }(url)
+    }
+    wg.Wait()
+    return results
+}
+
+func main() {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    urls := []string{"https://example.com", "https://golang.org", "https://pkg.go.dev"}
+    for _, r := range fetchAll(ctx, urls) {
+        if r.Err != nil {
+            fmt.Printf("ERR  %s: %v\n", r.URL, r.Err)
+        } else {
+            fmt.Printf("OK   %s  (%v)\n", r.URL, r.Duration)
+        }
+    }
+}
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "swift",
+            code =
+                """
+import Foundation
+
+protocol Fetchable {
+    associatedtype Resource: Decodable
+    var baseURL: URL { get }
+    func fetch(id: Int) async throws -> Resource
+}
+
+struct User: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let email: String?
+}
+
+enum NetworkError: LocalizedError {
+    case badStatus(Int)
+    case decodingFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .badStatus(let code): return "Server returned HTTP \(code)"
+        case .decodingFailed(let e): return "Decode error: \(e.localizedDescription)"
+        }
+    }
+}
+
+struct UserService: Fetchable {
+    typealias Resource = User
+    let baseURL = URL(string: "https://api.example.com")!
+
+    func fetch(id: Int) async throws -> User {
+        let url = baseURL.appendingPathComponent("users/\(id)")
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            throw NetworkError.badStatus((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        do {
+            return try JSONDecoder().decode(User.self, from: data)
+        } catch {
+            throw NetworkError.decodingFailed(error)
+        }
+    }
+}
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "cpp",
+            code =
+                """
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+template <typename T>
+class Stack {
+public:
+    void push(T value) { data_.push_back(std::move(value)); }
+
+    T pop() {
+        if (data_.empty()) throw std::underflow_error("Stack is empty");
+        T top = std::move(data_.back());
+        data_.pop_back();
+        return top;
+    }
+
+    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
+
+private:
+    std::vector<T> data_;
+};
+
+int main() {
+    auto s = std::make_unique<Stack<int>>();
+    for (int i : {3, 1, 4, 1, 5, 9, 2, 6}) s->push(i);
+
+    std::cout << "Size: " << s->size() << "\nPopping: ";
+    while (!s->empty()) std::cout << s->pop() << ' ';
+    std::cout << '\n';
+
+    // Lambda + algorithm example
+    std::vector<int> nums = {5, 3, 8, 1, 9, 2};
+    std::sort(nums.begin(), nums.end(), [](int a, int b) { return a > b; });
+    for (auto n : nums) std::cout << n << ' ';
+    return 0;
+}
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "csharp",
+            code =
+                """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public record Product(int Id, string Name, decimal Price, int Stock);
+
+public class ProductService(IEnumerable<Product> catalog)
+{
+    public IEnumerable<Product> Search(string query, decimal? maxPrice = null) =>
+        catalog
+            .Where(p => p.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Where(p => maxPrice is null || p.Price <= maxPrice)
+            .OrderBy(p => p.Price);
+
+    public async Task<Product?> FindCheapestAsync(string query)
+    {
+        await Task.Delay(10); // simulate DB round-trip
+        return Search(query).FirstOrDefault();
+    }
+}
+
+var catalog = new List<Product>
+{
+    new(1, "Kotlin Book",    29.99m, 100),
+    new(2, "Rust in Action", 34.99m,  50),
+    new(3, "Go Programming", 24.99m,  75),
+};
+
+var svc = new ProductService(catalog);
+var hit = await svc.FindCheapestAsync("kotlin");
+Console.WriteLine(hit is { } p
+    ? ${'$'}"Found: {p.Name} at ${'$'}{p.Price:C}"
+    : "Not found");
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "bash",
+            code =
+                """
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="${'$'}(cd "${'$'}(dirname "${'$'}{BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${'$'}{SCRIPT_DIR}/build"
+
+log()  { printf '[%s] %s\n' "${'$'}(date +%T)" "${'$'}*"; }
+fail() { log "ERROR: ${'$'}*" >&2; exit 1; }
+
+setup() {
+    mkdir -p "${'$'}BUILD_DIR"
+    [[ -f "gradle.properties" ]] || fail "Not a Gradle project"
+    log "Setup done → ${'$'}BUILD_DIR"
+}
+
+run_tests() {
+    local filter="${'$'}{1:-}"
+    if [[ -n "${'$'}filter" ]]; then
+        ./gradlew test --tests "${'$'}filter"
+    else
+        ./gradlew test
+    fi
+    log "Tests complete ✓"
+}
+
+publish() {
+    local version="${'$'}{1:?version required (e.g. 1.2.3)}"
+    [[ "${'$'}version" =~ ^[0-9]+\.[0-9]+\.[0-9]+${'$'} ]] \
+        || fail "Invalid semver: ${'$'}version"
+    ./gradlew publishToMavenLocal -Pversion="${'$'}version"
+    git tag "${'$'}version" && git push origin "${'$'}version"
+    log "Published ${'$'}version"
+}
+
+case "${'$'}{1:-help}" in
+    setup)   setup ;;
+    test)    run_tests "${'$'}{2:-}" ;;
+    publish) publish "${'$'}{2:-}" ;;
+    clean)   rm -rf "${'$'}BUILD_DIR" && log "Cleaned." ;;
+    *)       echo "Usage: ${'$'}0 {setup|test|publish <ver>|clean}" ;;
+esac
+                """.trimIndent(),
+        ),
+        CodeSample(
+            language = "css",
+            code =
+                """
+:root {
+    --color-primary:  #6200ea;
+    --color-surface:  #ffffff;
+    --color-on-surface: #1c1b1f;
+    --radius-md: 8px;
+    --transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-primary:    #bb86fc;
+        --color-surface:    #121212;
+        --color-on-surface: #e6e1e5;
+    }
+}
+
+.card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    color: var(--color-on-surface);
+    padding: 1.5rem;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0);   }
+}
+
+.card--animated {
+    animation: fadeIn 0.35s var(--transition) both;
+}
+
+.card__title {
+    color: var(--color-primary);
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    margin: 0 0 0.5rem;
+}
                 """.trimIndent(),
         ),
         CodeSample(language = "plaintext", code = ""), // empty edge case

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -103,8 +103,7 @@ fun SampleScreen() {
             topBar = {
                 TopAppBar(
                     title = { Text("Demo") },
-                    actions = {
-                        // Navigate to performance benchmark screen
+                    navigationIcon = {
                         IconButton(onClick = {
                             context.startActivity(Intent(context, PerfActivity::class.java))
                         }) {
@@ -113,6 +112,8 @@ fun SampleScreen() {
                                 contentDescription = "Performance benchmark",
                             )
                         }
+                    },
+                    actions = {
                         // Theme family picker
                         Box {
                             TextButton(onClick = { showThemeMenu = true }) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -1,5 +1,6 @@
 package dev.hossain.highlight.sample
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -26,9 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.sample.R
+import dev.hossain.highlight.sample.perf.PerfActivity
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
@@ -97,6 +104,15 @@ fun SampleScreen() {
                 TopAppBar(
                     title = { Text("Demo") },
                     actions = {
+                        // Navigate to performance benchmark screen
+                        IconButton(onClick = {
+                            context.startActivity(Intent(context, PerfActivity::class.java))
+                        }) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.speed_24dp),
+                                contentDescription = "Performance benchmark",
+                            )
+                        }
                         // Theme family picker
                         Box {
                             TextButton(onClick = { showThemeMenu = true }) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -63,7 +63,7 @@ import dev.hossain.highlight.ui.SyntaxHighlightedCode
 @Composable
 fun SampleScreen() {
     val context = LocalContext.current
-    var isDark by remember { mutableStateOf(false) }
+    var isDark by remember { mutableStateOf(true) }
     var showThemeMenu by remember { mutableStateOf(false) }
     var activeTab by remember { mutableIntStateOf(0) }
 
@@ -89,7 +89,7 @@ fun SampleScreen() {
             )
         }
 
-    var selectedThemeIndex by remember { mutableIntStateOf(0) }
+    var selectedThemeIndex by remember { mutableIntStateOf(2) } // Atom One
     val activePair = themePairs[selectedThemeIndex]
 
     HighlightThemeProvider(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -100,7 +100,7 @@ fun SampleScreen() {
         Scaffold(
             topBar = {
                 TopAppBar(
-                    title = { Text("Demo") },
+                    title = { Text("Highlight Demo") },
                     actions = {
                         // Performance benchmark screen
                         IconButton(onClick = {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,7 +18,6 @@ import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -116,8 +114,11 @@ fun SampleScreen() {
                     actions = {
                         // Theme family picker
                         Box {
-                            TextButton(onClick = { showThemeMenu = true }) {
-                                Text("🎨 ${activePair.name}")
+                            IconButton(onClick = { showThemeMenu = true }) {
+                                Icon(
+                                    imageVector = ImageVector.vectorResource(R.drawable.palette_24dp),
+                                    contentDescription = "Select theme: ${activePair.name}",
+                                )
                             }
                             DropdownMenu(
                                 expanded = showThemeMenu,
@@ -135,11 +136,17 @@ fun SampleScreen() {
                             }
                         }
                         // Light/dark variant toggle
-                        Button(
+                        IconButton(
                             onClick = { isDark = !isDark },
                             modifier = Modifier.padding(end = 8.dp),
                         ) {
-                            Text(if (isDark) "☀ Light" else "🌙 Dark")
+                            Icon(
+                                imageVector =
+                                    ImageVector.vectorResource(
+                                        if (isDark) R.drawable.light_mode_24dp else R.drawable.mode_night_24dp,
+                                    ),
+                                contentDescription = if (isDark) "Switch to light mode" else "Switch to dark mode",
+                            )
                         }
                     },
                 )

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -101,7 +101,8 @@ fun SampleScreen() {
             topBar = {
                 TopAppBar(
                     title = { Text("Demo") },
-                    navigationIcon = {
+                    actions = {
+                        // Performance benchmark screen
                         IconButton(onClick = {
                             context.startActivity(Intent(context, PerfActivity::class.java))
                         }) {
@@ -110,8 +111,6 @@ fun SampleScreen() {
                                 contentDescription = "Performance benchmark",
                             )
                         }
-                    },
-                    actions = {
                         // Theme family picker
                         Box {
                             IconButton(onClick = { showThemeMenu = true }) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfActivity.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfActivity.kt
@@ -1,0 +1,25 @@
+package dev.hossain.highlight.sample.perf
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.MaterialTheme
+
+/**
+ * Performance benchmark Activity that renders all code samples in a scrollable list and
+ * measures per-block highlighting timing, code size, and overall memory footprint.
+ *
+ * Launch this from [dev.hossain.highlight.sample.MainActivity] via the ⚡ button in the top bar.
+ */
+class PerfActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MaterialTheme {
+                PerfScreen()
+            }
+        }
+    }
+}

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -274,9 +274,21 @@ private fun PerfMetricCard(metrics: HighlightMetrics?) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (metrics != null) {
-                MetricChip(icon = "⏱", value = "${metrics.highlightMs} ms", label = "highlight")
-                MetricChip(icon = "📄", value = "${metrics.lineCount}", label = "lines")
-                MetricChip(icon = "🔤", value = "${metrics.charCount}", label = "chars")
+                MetricChip(
+                    icon = ImageVector.vectorResource(R.drawable.timer_24dp),
+                    value = "${metrics.highlightMs} ms",
+                    label = "highlight",
+                )
+                MetricChip(
+                    icon = ImageVector.vectorResource(R.drawable.format_line_spacing_24dp),
+                    value = "${metrics.lineCount}",
+                    label = "lines",
+                )
+                MetricChip(
+                    icon = ImageVector.vectorResource(R.drawable.type_specimen_24dp),
+                    value = "${metrics.charCount}",
+                    label = "chars",
+                )
             } else {
                 Text(
                     text = "Highlighting…",
@@ -290,12 +302,23 @@ private fun PerfMetricCard(metrics: HighlightMetrics?) {
 
 @Composable
 private fun MetricChip(
-    icon: String,
+    icon: ImageVector,
     value: String,
     label: String,
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(text = "$icon $value", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.height(14.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(text = value, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+        }
         Text(
             text = label,
             fontSize = 10.sp,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -63,8 +63,7 @@ internal data class HighlightMetrics(
 @Composable
 fun PerfScreen() {
     val context = LocalContext.current
-    val systemIsDark = isSystemInDarkTheme()
-    var isDark by remember { mutableStateOf(systemIsDark) }
+    var isDark by remember { mutableStateOf(true) }
 
     val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }
     var runId by remember { mutableIntStateOf(0) }
@@ -77,8 +76,8 @@ fun PerfScreen() {
     }
 
     HighlightThemeProvider(
-        lightHighlightTheme = HighlightTheme.tomorrow(context),
-        darkHighlightTheme = HighlightTheme.tomorrowNight(context),
+        lightHighlightTheme = HighlightTheme.atomOneLight(context),
+        darkHighlightTheme = HighlightTheme.atomOneDark(context),
         darkTheme = isDark,
     ) {
         Scaffold(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -63,7 +63,8 @@ internal data class HighlightMetrics(
 @Composable
 fun PerfScreen() {
     val context = LocalContext.current
-    val isDark = isSystemInDarkTheme()
+    val systemIsDark = isSystemInDarkTheme()
+    var isDark by remember { mutableStateOf(systemIsDark) }
 
     val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }
     var runId by remember { mutableIntStateOf(0) }
@@ -85,6 +86,22 @@ fun PerfScreen() {
                 TopAppBar(
                     title = { Text("⚡ Perf Benchmark") },
                     actions = {
+                        // Light/dark toggle — also resets the benchmark since theme affects timing
+                        IconButton(onClick = {
+                            isDark = !isDark
+                            metricsMap.clear()
+                            heapSnapshotKb = null
+                            runId++
+                        }) {
+                            Icon(
+                                imageVector =
+                                    ImageVector.vectorResource(
+                                        if (isDark) R.drawable.light_mode_24dp else R.drawable.mode_night_24dp,
+                                    ),
+                                contentDescription = if (isDark) "Switch to light mode" else "Switch to dark mode",
+                            )
+                        }
+                        // Re-run benchmark
                         IconButton(onClick = {
                             metricsMap.clear()
                             heapSnapshotKb = null

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -1,0 +1,288 @@
+package dev.hossain.highlight.sample.perf
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.sample.R
+import dev.hossain.highlight.sample.SAMPLES
+import dev.hossain.highlight.ui.HighlightThemeProvider
+import dev.hossain.highlight.ui.SyntaxHighlightedCode
+
+/** Timing and size metrics captured for a single code block after highlighting completes. */
+internal data class HighlightMetrics(
+    val language: String,
+    val highlightMs: Long,
+    val charCount: Int,
+    val lineCount: Int,
+)
+
+/**
+ * Performance benchmark screen that renders every [SAMPLES] entry in a scrollable list and
+ * measures per-block highlighting timing, code size, and overall heap usage.
+ *
+ * - Each block shows a metric card: highlight time, line count, char count.
+ * - The sticky summary header shows aggregate stats (avg/min/max time, heap snapshot).
+ * - The ↺ Re-run button resets all metrics and forces a fresh highlight pass.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PerfScreen() {
+    val context = LocalContext.current
+    val isDark = isSystemInDarkTheme()
+
+    val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }
+    var runId by remember { mutableIntStateOf(0) }
+
+    // Take a heap snapshot once all blocks have reported their timing.
+    var heapSnapshotKb by remember { mutableStateOf<Long?>(null) }
+    if (metricsMap.size == SAMPLES.size && heapSnapshotKb == null) {
+        val rt = Runtime.getRuntime()
+        heapSnapshotKb = (rt.totalMemory() - rt.freeMemory()) / 1024
+    }
+
+    HighlightThemeProvider(
+        lightHighlightTheme = HighlightTheme.tomorrow(context),
+        darkHighlightTheme = HighlightTheme.tomorrowNight(context),
+        darkTheme = isDark,
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("⚡ Perf Benchmark") },
+                    actions = {
+                        IconButton(onClick = {
+                            metricsMap.clear()
+                            heapSnapshotKb = null
+                            runId++
+                        }) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.readiness_score_24dp),
+                                contentDescription = "Re-run benchmark",
+                            )
+                        }
+                    },
+                )
+            },
+        ) { innerPadding ->
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                item(key = "summary") {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    SummaryHeader(
+                        metricsMap = metricsMap,
+                        totalSamples = SAMPLES.size,
+                        heapSnapshotKb = heapSnapshotKb,
+                    )
+                }
+
+                items(SAMPLES, key = { it.language }) { sample ->
+                    val metrics = metricsMap[sample.language]
+                    Column {
+                        Text(
+                            text = sample.language.uppercase(),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                        key(runId) {
+                            SyntaxHighlightedCode(
+                                code = sample.code,
+                                language = sample.language,
+                                modifier = Modifier.fillMaxWidth(),
+                                showLineNumbers = true,
+                                onHighlightComplete = { elapsedMs ->
+                                    metricsMap[sample.language] =
+                                        HighlightMetrics(
+                                            language = sample.language,
+                                            highlightMs = elapsedMs,
+                                            charCount = sample.code.length,
+                                            lineCount = sample.code.lines().size,
+                                        )
+                                },
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        PerfMetricCard(metrics = metrics)
+                    }
+                }
+
+                item { Spacer(modifier = Modifier.height(16.dp)) }
+            }
+        }
+    }
+}
+
+/**
+ * Sticky summary card shown at the top of the list.
+ *
+ * Displays: completed/total count, avg/min/max highlight time, and heap snapshot once all blocks
+ * have completed.
+ */
+@Composable
+private fun SummaryHeader(
+    metricsMap: Map<String, HighlightMetrics>,
+    totalSamples: Int,
+    heapSnapshotKb: Long?,
+) {
+    val completed = metricsMap.size
+    val times = metricsMap.values.map { it.highlightMs }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = "Benchmark Summary",
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f))
+            Spacer(modifier = Modifier.height(6.dp))
+
+            SummaryRow(label = "Completed", value = "$completed / $totalSamples blocks")
+
+            if (times.isNotEmpty()) {
+                SummaryRow(label = "Avg time", value = "${times.average().toLong()} ms")
+                SummaryRow(label = "Fastest", value = "${times.min()} ms")
+                SummaryRow(label = "Slowest", value = "${times.max()} ms")
+                SummaryRow(label = "Total time", value = "${times.sum()} ms")
+            } else {
+                SummaryRow(label = "Timing", value = "Waiting for highlights…")
+            }
+
+            heapSnapshotKb?.let {
+                SummaryRow(label = "Heap used", value = "$it KB  (snapshot after all blocks)")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SummaryRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+        )
+        Text(
+            text = value,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}
+
+/**
+ * Metric card shown below each code block.
+ *
+ * Displays highlight time (ms), line count, and char count. Shows a "pending" state while the
+ * highlight is in progress.
+ */
+@Composable
+private fun PerfMetricCard(metrics: HighlightMetrics?) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (metrics != null) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    },
+            ),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (metrics != null) {
+                MetricChip(icon = "⏱", value = "${metrics.highlightMs} ms", label = "highlight")
+                MetricChip(icon = "📄", value = "${metrics.lineCount}", label = "lines")
+                MetricChip(icon = "🔤", value = "${metrics.charCount}", label = "chars")
+            } else {
+                Text(
+                    text = "Highlighting…",
+                    fontSize = 11.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricChip(
+    icon: String,
+    value: String,
+    label: String,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = "$icon $value", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+        Text(
+            text = label,
+            fontSize = 10.sp,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+        )
+    }
+}

--- a/sample/src/main/res/drawable/content_copy_24dp.xml
+++ b/sample/src/main/res/drawable/content_copy_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,720q-33,0 -56.5,-23.5T280,640v-480q0,-33 23.5,-56.5T360,80h360q33,0 56.5,23.5T800,160v480q0,33 -23.5,56.5T720,720L360,720ZM360,640h360v-480L360,160v480ZM200,880q-33,0 -56.5,-23.5T120,800v-560h80v560h440v80L200,880ZM360,640v-480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/format_line_spacing_24dp.xml
+++ b/sample/src/main/res/drawable/format_line_spacing_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M240,800 L80,640l56,-56 64,62v-332l-64,62 -56,-56 160,-160 160,160 -56,56 -64,-62v332l64,-62 56,56 -160,160ZM480,760v-80h400v80L480,760ZM480,520v-80h400v80L480,520ZM480,280v-80h400v80L480,280Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/light_mode_24dp.xml
+++ b/sample/src/main/res/drawable/light_mode_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M565,565q35,-35 35,-85t-35,-85q-35,-35 -85,-35t-85,35q-35,35 -35,85t35,85q35,35 85,35t85,-35ZM338.5,621.5Q280,563 280,480t58.5,-141.5Q397,280 480,280t141.5,58.5Q680,397 680,480t-58.5,141.5Q563,680 480,680t-141.5,-58.5ZM200,520L40,520v-80h160v80ZM920,520L760,520v-80h160v80ZM440,200v-160h80v160h-80ZM440,920v-160h80v160h-80ZM256,310l-101,-97 57,-59 96,100 -52,56ZM748,806 L651,705 704,650 805,747 748,806ZM650,256 L747,155 806,212 706,308 650,256ZM154,748l101,-97 55,53 -97,101 -59,-57ZM480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/mode_night_24dp.xml
+++ b/sample/src/main/res/drawable/mode_night_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M380,800q133,0 226.5,-93.5T700,480q0,-133 -93.5,-226.5T380,160h-21q-10,0 -19,2 57,66 88.5,147.5T460,480q0,89 -31.5,170.5T340,798q9,2 19,2h21ZM380,880q-53,0 -103.5,-13.5T180,826q93,-54 146.5,-146T380,480q0,-108 -53.5,-200T180,134q46,-27 96.5,-40.5T380,80q83,0 156,31.5T663,197q54,54 85.5,127T780,480q0,83 -31.5,156T663,763q-54,54 -127,85.5T380,880ZM460,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/palette_24dp.xml
+++ b/sample/src/main/res/drawable/palette_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,880q-82,0 -155,-31.5t-127.5,-86Q143,708 111.5,635T80,480q0,-83 32.5,-156t88,-127Q256,143 330,111.5T488,80q80,0 151,27.5t124.5,76q53.5,48.5 85,115T880,442q0,115 -70,176.5T640,680h-74q-9,0 -12.5,5t-3.5,11q0,12 15,34.5t15,51.5q0,50 -27.5,74T480,880ZM480,480ZM303,503q17,-17 17,-43t-17,-43q-17,-17 -43,-17t-43,17q-17,17 -17,43t17,43q17,17 43,17t43,-17ZM423,343q17,-17 17,-43t-17,-43q-17,-17 -43,-17t-43,17q-17,17 -17,43t17,43q17,17 43,17t43,-17ZM623,343q17,-17 17,-43t-17,-43q-17,-17 -43,-17t-43,17q-17,17 -17,43t17,43q17,17 43,17t43,-17ZM743,503q17,-17 17,-43t-17,-43q-17,-17 -43,-17t-43,17q-17,17 -17,43t17,43q17,17 43,17t43,-17ZM480,800q9,0 14.5,-5t5.5,-13q0,-14 -15,-33t-15,-57q0,-42 29,-67t71,-25h70q66,0 113,-38.5T800,442q0,-121 -92.5,-201.5T488,160q-136,0 -232,93t-96,227q0,133 93.5,226.5T480,800Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/timer_24dp.xml
+++ b/sample/src/main/res/drawable/timer_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,120v-80h240v80L360,120ZM440,560h80v-240h-80v240ZM340.5,851.5Q275,823 226,774t-77.5,-114.5Q120,594 120,520t28.5,-139.5Q177,315 226,266t114.5,-77.5Q406,160 480,160q62,0 119,20t107,58l56,-56 56,56 -56,56q38,50 58,107t20,119q0,74 -28.5,139.5T734,774q-49,49 -114.5,77.5T480,880q-74,0 -139.5,-28.5ZM678,718q82,-82 82,-198t-82,-198q-82,-82 -198,-82t-198,82q-82,82 -82,198t82,198q82,82 198,82t198,-82ZM480,520Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/type_specimen_24dp.xml
+++ b/sample/src/main/res/drawable/type_specimen_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M392,580h64l32,-92h146l32,92h62L592,220h-64L392,580ZM506,436 L558,286h4l52,150L506,436ZM320,720q-33,0 -56.5,-23.5T240,640v-480q0,-33 23.5,-56.5T320,80h480q33,0 56.5,23.5T880,160v480q0,33 -23.5,56.5T800,720L320,720ZM320,640h480v-480L320,160v480ZM160,880q-33,0 -56.5,-23.5T80,800v-560h80v560h560v80L160,880ZM320,160v480,-480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/values/themes.xml
+++ b/sample/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.ComposeSample" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>


### PR DESCRIPTION
## Summary

This PR adds several improvements to the sample app and a new public API to the library.

### 🚀 Performance Benchmark Screen
- New `PerfActivity` + `PerfScreen` in `dev.hossain.highlight.sample.perf`
- Renders all language samples and captures per-block metrics:
  - Highlight time (ms), line count, char count
  - Heap snapshot after all blocks complete
- Summary header with avg/min/max/total timing
- **Re-run** button (↺) and **Dark/Light toggle** — toggling resets metrics since theme affects timing
- Defaults to dark mode with Atom One theme

### 🎨 Vector Icon Polish
- Replaced all emoji icons in `SampleScreen` TopAppBar with vector drawables:
  - `speed_24dp` → performance screen (left of theme picker)
  - `palette_24dp` → theme picker
  - `light_mode_24dp` / `mode_night_24dp` → dark/light toggle
- Replaced emoji metric chips in `PerfMetricCard` with vector icons:
  - `timer_24dp`, `format_line_spacing_24dp`, `type_specimen_24dp`

### 🌍 New Language Samples
Added 8 new languages to `SampleData.kt` (17 total):
TypeScript, Rust, Go, Swift, C++, C#, Bash, CSS — each with constructs that stress different highlighter tokens

### 📋 Custom Copy Button Icon (library API)
New `copyButtonIcon: (@Composable (tint: Color) -> Unit)?` parameter on `SyntaxHighlightedCode`:
```kotlin
SyntaxHighlightedCode(
    code = snippet,
    language = "kotlin",
    copyButtonIcon = { tint ->
        Icon(
            imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
            contentDescription = "Copy",
            tint = tint,
        )
    },
)
```
- Slot receives the theme-derived tint color automatically
- `null` (default) falls back to the existing `⧉` text — fully backwards compatible
- Demonstrated in the **Callbacks** tab of the sample app

### 🛠 Bug Fix
- Added `themes.xml` with `Theme.ComposeSample` (parent: `android:Theme.Material.Light.NoActionBar`) to suppress the system ActionBar that was appearing over the Compose `TopAppBar`

### 🎨 Sample App Defaults
- Both `SampleScreen` and `PerfScreen` now default to dark mode with Atom One theme