### PR TITLE
Update target SDK from 37 to 36

### DIFF
--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "dev.hossain.highlight"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "dev.hossain.highlight.sample"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
-        targetSdk = 37
+        targetSdk = 36
         versionCode = 7
         versionName = "0.7.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Android 17 (API 37) is currently in late beta (Beta 4) with stable release expected in June 2026. Using API 36 ensures immediate compatibility with stable Android 12+ versions while maintaining minSdk 24 compatibility.

All checks passing:
- ✅ Linting (ktlint)
- ✅ Unit tests (41 tests)
- ✅ Build (library + sample)