### PR TITLE
refactor(sample): move code samples to asset files

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -1,0 +1,69 @@
+# Sample App
+
+A standalone Android app that exercises every feature of the `compose-highlight` library.
+It is **not** published — it exists solely to demonstrate usage and serve as a manual test bed.
+
+## Structure
+
+```
+sample/
+├── src/main/
+│   ├── assets/
+│   │   ├── samples/          # Code snippets shown in the Languages tab (one file per language)
+│   │   └── themes/           # Custom Highlight.js CSS themes (github.css, github-dark.css)
+│   │                         # Demonstrates HighlightTheme.fromAsset()
+│   └── kotlin/…/sample/
+│       ├── MainActivity.kt         # Entry point; wraps SampleScreen in HighlightThemeProvider
+│       ├── SampleScreen.kt         # Top-level screen: tab bar + per-tab content routing
+│       ├── DemoTab.kt              # Sealed class for the 8 demo tabs (type-safe routing)
+│       ├── SampleData.kt           # loadCodeSamples(), loadThemePairs(), KOTLIN_SNIPPET, PYTHON_SNIPPET
+│       ├── sections/               # One file per tab — each exports a single @Composable
+│       │   ├── SectionComponents.kt    # Shared SectionHeader / SubSectionHeader
+│       │   ├── StylingSection.kt
+│       │   ├── TypographySection.kt
+│       │   ├── TogglesSection.kt
+│       │   ├── CallbacksSection.kt
+│       │   ├── ThemeCreationSection.kt
+│       │   ├── AdvancedEngineSection.kt
+│       │   └── EngineInfoSection.kt
+│       └── perf/                   # Separate performance-benchmark screen
+│           ├── PerfActivity.kt
+│           └── PerfScreen.kt
+```
+
+## Demo tabs
+
+| Tab | What it shows |
+|-----|---------------|
+| **Languages** | Highlights every file from `assets/samples/` — one code block per language |
+| **Styling** | `CodeBlockStyle` variants and custom background/border parameters |
+| **Typography** | `CodeBlockStyle.textStyle` — font size, weight, line height |
+| **Toggles** | All boolean flags: line numbers, language label, copy button |
+| **Callbacks** | `onHighlightComplete` and `onCopyClick` in action |
+| **Themes** | Every `HighlightTheme` factory method demonstrated side-by-side |
+| **Advanced** | `rememberHighlightedCodeBothThemes` for instant light/dark switching |
+| **Engine** | `HighlightEngine.highlightJsVersion` and `supportedLanguages` |
+
+## Adding a language sample
+
+Drop a file into `assets/samples/` with:
+- A two-digit numeric prefix for ordering, e.g. `18_example.rb`
+- A real file extension so your IDE applies syntax highlighting
+
+`loadCodeSamples()` in `SampleData.kt` picks it up automatically at runtime — no Kotlin changes needed.
+The file extension is mapped to a Highlight.js language identifier by `extensionToLanguage()`.
+
+## Adding a custom theme
+
+Put a Highlight.js CSS file in `assets/themes/` and load it with:
+
+```kotlin
+HighlightTheme.fromAsset(context, "themes/my-theme.css")
+```
+
+See `SampleData.kt` → `loadThemePairs()` for a working example using the bundled GitHub themes.
+
+## Performance screen
+
+`PerfActivity` / `PerfScreen` measures how long it takes to highlight all language samples
+back-to-back. Launch it from the top-right toolbar icon in the main screen.

--- a/sample/src/main/assets/samples/01_fibonacci.py
+++ b/sample/src/main/assets/samples/01_fibonacci.py
@@ -1,0 +1,12 @@
+def fibonacci(n: int) -> int:
+    # Returns the nth Fibonacci number
+    if n <= 1:
+        return n
+    a, b = 0, 1
+    for _ in range(n - 1):
+        a, b = b, a + b
+    return b
+
+# Edge case: special chars  \t \n ' "
+result = fibonacci(10)
+print(f"Result: {result}")

--- a/sample/src/main/assets/samples/02_user.kt
+++ b/sample/src/main/assets/samples/02_user.kt
@@ -1,0 +1,13 @@
+data class User(val name: String, val age: Int)
+
+fun List<User>.filter(minAge: Int): List<User> =
+    filter { it.age >= minAge }
+
+// Unicode: héllo wörld 🌍
+val users = listOf(
+    User("Alice", 30),
+    User("Bob", 25),
+)
+
+val adults = users.filter(18)
+println(adults)

--- a/sample/src/main/assets/samples/03_server.js
+++ b/sample/src/main/assets/samples/03_server.js
@@ -1,0 +1,10 @@
+async function fetchUser(id) {
+    const response = await fetch(`/api/users/${'$'}{id}`);
+    if (!response.ok) {
+        throw new Error(`HTTP error: ${'$'}{response.status}`);
+    }
+    return response.json();
+}
+
+// Backslash path: C:\Users\test
+const path = 'C:\\Users\\test\\file.txt';

--- a/sample/src/main/assets/samples/03_server.js
+++ b/sample/src/main/assets/samples/03_server.js
@@ -1,7 +1,7 @@
 async function fetchUser(id) {
-    const response = await fetch(`/api/users/${'$'}{id}`);
+    const response = await fetch(`/api/users/${id}`);
     if (!response.ok) {
-        throw new Error(`HTTP error: ${'$'}{response.status}`);
+        throw new Error(`HTTP error: ${response.status}`);
     }
     return response.json();
 }

--- a/sample/src/main/assets/samples/04_Calculator.java
+++ b/sample/src/main/assets/samples/04_Calculator.java
@@ -1,0 +1,12 @@
+public class BinarySearch {
+    public static int search(int[] arr, int target) {
+        int left = 0, right = arr.length - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (arr[mid] == target) return mid;
+            if (arr[mid] < target) left = mid + 1;
+            else right = mid - 1;
+        }
+        return -1;
+    }
+}

--- a/sample/src/main/assets/samples/05_query.sql
+++ b/sample/src/main/assets/samples/05_query.sql
@@ -1,0 +1,12 @@
+SELECT
+    u.id,
+    u.name,
+    COUNT(o.id) AS order_count,
+    SUM(o.total) AS revenue
+FROM users u
+LEFT JOIN orders o ON o.user_id = u.id
+WHERE u.created_at >= '2024-01-01'
+GROUP BY u.id, u.name
+HAVING order_count > 0
+ORDER BY revenue DESC
+LIMIT 10;

--- a/sample/src/main/assets/samples/06_config.json
+++ b/sample/src/main/assets/samples/06_config.json
@@ -1,0 +1,39 @@
+{
+    "string": "Hello, World!",
+    "emptyString": "",
+    "unicodeString": "héllo 🌍 日本語",
+    "escapedString": "line1\nline2\ttabbed \"quoted\" and backslash \\",
+    "integer": 42,
+    "negativeInteger": -7,
+    "float": 3.14159,
+    "negativeFloat": -0.001,
+    "scientificNotation": 1.5e10,
+    "largeNumber": 9007199254740991,
+    "booleanTrue": true,
+    "booleanFalse": false,
+    "nullValue": null,
+    "emptyArray": [],
+    "stringArray": ["android", "compose", "kotlin"],
+    "numberArray": [1, 2, 3, 4, 5],
+    "mixedArray": [1, "two", true, null, 3.0],
+    "nestedArray": [[1, 2], [3, 4], [5, 6]],
+    "emptyObject": {},
+    "nestedObject": {
+        "id": 101,
+        "name": "compose-highlight",
+        "version": "0.3.0",
+        "stable": true,
+        "deprecated": null,
+        "tags": ["library", "ui", "syntax"],
+        "metadata": {
+            "author": "hossain-khan",
+            "license": "Apache-2.0",
+            "stars": 42
+        }
+    },
+    "arrayOfObjects": [
+        { "lang": "kotlin", "highlight": true },
+        { "lang": "python", "highlight": true },
+        { "lang": "cobol", "highlight": false }
+    ]
+}

--- a/sample/src/main/assets/samples/07_layout.xml
+++ b/sample/src/main/assets/samples/07_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Compose Highlight</string>
+    <style name="Theme.App" parent="Theme.Material3.DayNight">
+        <item name="colorPrimary">@color/purple_500</item>
+    </style>
+</resources>

--- a/sample/src/main/assets/samples/08_WeatherApp.kt
+++ b/sample/src/main/assets/samples/08_WeatherApp.kt
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.sample.weather
+
+import com.jakewharton.picnic.TextAlignment
+import com.jakewharton.picnic.table
+import dev.zacsweers.metro.Inject
+import kotlin.time.Instant
+import kotlinx.coroutines.coroutineScope
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+
+@Inject
+class WeatherApp(private val repository: WeatherRepository) {
+  suspend operator fun invoke(query: String, log: (String, isError: Boolean) -> Unit) {
+    byLocation(query)
+      .onSuccess { weather ->
+        val location = weather.location
+        val message = buildString {
+          appendLine("Weather for ${'$'}{location.name}, ${'$'}{location.region ?: location.country}:")
+
+          val current = weather.current
+          appendLine("\nCurrent conditions:")
+          appendLine("Temperature: ${'$'}{current.temperature}°C")
+          appendLine("Humidity: ${'$'}{current.humidity}%")
+          appendLine("Wind Speed: ${'$'}{current.windSpeed} km/h")
+          appendLine("Description: ${'$'}{current.description}")
+
+          appendLine("\nHourly forecast:")
+
+          val hourlyTable = formatHourlyForecast(weather.hourlyForecast)
+          appendLine(hourlyTable)
+        }
+        log(message, false)
+      }
+      .onFailure { error -> log("Error fetching weather: ${'$'}{error.message}", true) }
+  }
+
+  private suspend fun byLocation(query: String): Result<WeatherInfo> = coroutineScope {
+    try {
+      val locations = repository.searchLocation(query).getOrThrow()
+      if (locations.isEmpty()) {
+        Result.failure(NoSuchElementException("Location not found: ${'$'}query"))
+      } else {
+        val location = locations.first()
+        val weather = repository.getWeather(location.latitude, location.longitude).getOrThrow()
+
+        Result.success(
+          WeatherInfo(
+            location =
+              LocationInfo(
+                name = location.name,
+                region = location.region,
+                country = location.country,
+              ),
+            current =
+              CurrentWeatherInfo(
+                temperature = weather.current.temperature,
+                humidity = weather.current.humidity,
+                windSpeed = weather.current.windSpeed,
+                description = getWeatherDescription(weather.current.weatherCode),
+              ),
+            hourlyForecast =
+              weather.hourly.time.zip(
+                weather.hourly.temperatures.zip(weather.hourly.weatherCodes)
+              ) { time, (temp, code) ->
+                HourlyForecastInfo(
+                  time = LocalDateTime.parse(time).toInstant(TimeZone.UTC),
+                  temperature = temp,
+                  description = getWeatherDescription(code),
+                )
+              },
+          )
+        )
+      }
+    } catch (e: Exception) {
+      Result.failure(e)
+    }
+  }
+
+  private fun getWeatherDescription(code: Int): String =
+    when (code) {
+      0 -> "Clear sky"
+      1, 2, 3 -> "Partly cloudy"
+      45, 48 -> "Foggy"
+      51, 53, 55 -> "Drizzle"
+      61, 63, 65 -> "Rain"
+      71, 73, 75 -> "Snow"
+      77 -> "Snow grains"
+      80, 81, 82 -> "Rain showers"
+      85, 86 -> "Snow showers"
+      95 -> "Thunderstorm"
+      96, 99 -> "Thunderstorm with hail"
+      else -> "Unknown"
+    }
+
+  private fun formatHourlyForecast(forecast: List<HourlyForecastInfo>): String {
+    return table {
+        cellStyle {
+          border = true
+          alignment = TextAlignment.MiddleCenter
+        }
+
+        header {
+          row {
+            cell("Time") { alignment = TextAlignment.MiddleCenter }
+            cell("Temperature")
+            cell("Conditions") { alignment = TextAlignment.MiddleCenter }
+          }
+        }
+
+        forecast.take(24).forEach { hour ->
+          val localTime = hour.time.toLocalDateTime(TimeZone.currentSystemDefault())
+          val timeStr =
+            "${'$'}{localTime.hour.toString().padStart(2, '0')}:${'$'}{
+          localTime.minute.toString().padStart(2, '0')
+        }"
+
+          row {
+            cell(timeStr)
+            cell("${'$'}{hour.temperature}°C")
+            cell(hour.description)
+          }
+        }
+      }
+      .toString()
+  }
+}
+
+data class WeatherInfo(
+  val location: LocationInfo,
+  val current: CurrentWeatherInfo,
+  val hourlyForecast: List<HourlyForecastInfo>,
+)
+
+data class LocationInfo(val name: String, val region: String?, val country: String)
+
+data class CurrentWeatherInfo(
+  val temperature: Double,
+  val humidity: Double,
+  val windSpeed: Double,
+  val description: String,
+)
+
+data class HourlyForecastInfo(val time: Instant, val temperature: Double, val description: String)

--- a/sample/src/main/assets/samples/08_WeatherApp.kt
+++ b/sample/src/main/assets/samples/08_WeatherApp.kt
@@ -19,14 +19,14 @@ class WeatherApp(private val repository: WeatherRepository) {
       .onSuccess { weather ->
         val location = weather.location
         val message = buildString {
-          appendLine("Weather for ${'$'}{location.name}, ${'$'}{location.region ?: location.country}:")
+          appendLine("Weather for ${location.name}, ${location.region ?: location.country}:")
 
           val current = weather.current
           appendLine("\nCurrent conditions:")
-          appendLine("Temperature: ${'$'}{current.temperature}°C")
-          appendLine("Humidity: ${'$'}{current.humidity}%")
-          appendLine("Wind Speed: ${'$'}{current.windSpeed} km/h")
-          appendLine("Description: ${'$'}{current.description}")
+          appendLine("Temperature: ${current.temperature}°C")
+          appendLine("Humidity: ${current.humidity}%")
+          appendLine("Wind Speed: ${current.windSpeed} km/h")
+          appendLine("Description: ${current.description}")
 
           appendLine("\nHourly forecast:")
 
@@ -35,14 +35,14 @@ class WeatherApp(private val repository: WeatherRepository) {
         }
         log(message, false)
       }
-      .onFailure { error -> log("Error fetching weather: ${'$'}{error.message}", true) }
+      .onFailure { error -> log("Error fetching weather: ${error.message}", true) }
   }
 
   private suspend fun byLocation(query: String): Result<WeatherInfo> = coroutineScope {
     try {
       val locations = repository.searchLocation(query).getOrThrow()
       if (locations.isEmpty()) {
-        Result.failure(NoSuchElementException("Location not found: ${'$'}query"))
+        Result.failure(NoSuchElementException("Location not found: $query"))
       } else {
         val location = locations.first()
         val weather = repository.getWeather(location.latitude, location.longitude).getOrThrow()
@@ -114,13 +114,13 @@ class WeatherApp(private val repository: WeatherRepository) {
         forecast.take(24).forEach { hour ->
           val localTime = hour.time.toLocalDateTime(TimeZone.currentSystemDefault())
           val timeStr =
-            "${'$'}{localTime.hour.toString().padStart(2, '0')}:${'$'}{
+            "${localTime.hour.toString().padStart(2, '0')}:${
           localTime.minute.toString().padStart(2, '0')
         }"
 
           row {
             cell(timeStr)
-            cell("${'$'}{hour.temperature}°C")
+            cell("${hour.temperature}°C")
             cell(hour.description)
           }
         }

--- a/sample/src/main/assets/samples/09_ApiService.ts
+++ b/sample/src/main/assets/samples/09_ApiService.ts
@@ -1,0 +1,29 @@
+interface Repository<T extends { id: number }> {
+  findById(id: number): Promise<T | null>;
+  save(entity: Omit<T, 'id'>): Promise<T>;
+  delete(id: number): Promise<void>;
+}
+
+type ApiResponse<T> = {
+  data: T;
+  status: number;
+  message?: string;
+};
+
+async function fetchWithRetry<T>(
+  url: string,
+  retries = 3,
+): Promise<ApiResponse<T>> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${'$'}{res.status}: ${'$'}{res.statusText}`);
+      const data: T = await res.json();
+      return { data, status: res.status };
+    } catch (err) {
+      if (attempt === retries - 1) throw err;
+      await new Promise(r => setTimeout(r, 2 ** attempt * 100));
+    }
+  }
+  throw new Error('unreachable');
+}

--- a/sample/src/main/assets/samples/09_ApiService.ts
+++ b/sample/src/main/assets/samples/09_ApiService.ts
@@ -17,7 +17,7 @@ async function fetchWithRetry<T>(
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
       const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${'$'}{res.status}: ${'$'}{res.statusText}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       const data: T = await res.json();
       return { data, status: res.status };
     } catch (err) {

--- a/sample/src/main/assets/samples/10_memory.rs
+++ b/sample/src/main/assets/samples/10_memory.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct LruCache<V> {
+    store: HashMap<String, V>,
+    capacity: usize,
+}
+
+impl<V> LruCache<V> {
+    pub fn new(capacity: usize) -> Self {
+        Self { store: HashMap::with_capacity(capacity), capacity }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&V> {
+        self.store.get(key)
+    }
+
+    /// Inserts a value; returns the old value if the key existed.
+    pub fn insert(&mut self, key: String, value: V) -> Result<Option<V>, &'static str> {
+        if self.store.len() >= self.capacity && !self.store.contains_key(&key) {
+            return Err("cache full — eviction not implemented");
+        }
+        Ok(self.store.insert(key, value))
+    }
+}
+
+fn main() {
+    let mut cache: LruCache<i32> = LruCache::new(4);
+    cache.insert("answer".to_owned(), 42).unwrap();
+    match cache.get("answer") {
+        Some(v) => println!("Found: {v}"),
+        None    => println!("Cache miss"),
+    }
+}

--- a/sample/src/main/assets/samples/11_goroutine.go
+++ b/sample/src/main/assets/samples/11_goroutine.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "sync"
+    "time"
+)
+
+type Result struct {
+    URL      string
+    Duration time.Duration
+    Err      error
+}
+
+func fetchAll(ctx context.Context, urls []string) []Result {
+    var mu sync.Mutex
+    results := make([]Result, 0, len(urls))
+    var wg sync.WaitGroup
+
+    for _, url := range urls {
+        wg.Add(1)
+        go func(u string) {
+            defer wg.Done()
+            start := time.Now()
+            select {
+            case <-ctx.Done():
+                mu.Lock()
+                results = append(results, Result{URL: u, Err: ctx.Err()})
+                mu.Unlock()
+            case <-time.After(50 * time.Millisecond):
+                mu.Lock()
+                results = append(results, Result{URL: u, Duration: time.Since(start)})
+                mu.Unlock()
+            }
+        }(url)
+    }
+    wg.Wait()
+    return results
+}
+
+func main() {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    urls := []string{"https://example.com", "https://golang.org", "https://pkg.go.dev"}
+    for _, r := range fetchAll(ctx, urls) {
+        if r.Err != nil {
+            fmt.Printf("ERR  %s: %v\n", r.URL, r.Err)
+        } else {
+            fmt.Printf("OK   %s  (%v)\n", r.URL, r.Duration)
+        }
+    }
+}

--- a/sample/src/main/assets/samples/12_ContentView.swift
+++ b/sample/src/main/assets/samples/12_ContentView.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol Fetchable {
+    associatedtype Resource: Decodable
+    var baseURL: URL { get }
+    func fetch(id: Int) async throws -> Resource
+}
+
+struct User: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let email: String?
+}
+
+enum NetworkError: LocalizedError {
+    case badStatus(Int)
+    case decodingFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .badStatus(let code): return "Server returned HTTP \(code)"
+        case .decodingFailed(let e): return "Decode error: \(e.localizedDescription)"
+        }
+    }
+}
+
+struct UserService: Fetchable {
+    typealias Resource = User
+    let baseURL = URL(string: "https://api.example.com")!
+
+    func fetch(id: Int) async throws -> User {
+        let url = baseURL.appendingPathComponent("users/\(id)")
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            throw NetworkError.badStatus((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        do {
+            return try JSONDecoder().decode(User.self, from: data)
+        } catch {
+            throw NetworkError.decodingFailed(error)
+        }
+    }
+}

--- a/sample/src/main/assets/samples/13_matrix.cpp
+++ b/sample/src/main/assets/samples/13_matrix.cpp
@@ -1,0 +1,39 @@
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+template <typename T>
+class Stack {
+public:
+    void push(T value) { data_.push_back(std::move(value)); }
+
+    T pop() {
+        if (data_.empty()) throw std::underflow_error("Stack is empty");
+        T top = std::move(data_.back());
+        data_.pop_back();
+        return top;
+    }
+
+    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
+
+private:
+    std::vector<T> data_;
+};
+
+int main() {
+    auto s = std::make_unique<Stack<int>>();
+    for (int i : {3, 1, 4, 1, 5, 9, 2, 6}) s->push(i);
+
+    std::cout << "Size: " << s->size() << "\nPopping: ";
+    while (!s->empty()) std::cout << s->pop() << ' ';
+    std::cout << '\n';
+
+    // Lambda + algorithm example
+    std::vector<int> nums = {5, 3, 8, 1, 9, 2};
+    std::sort(nums.begin(), nums.end(), [](int a, int b) { return a > b; });
+    for (auto n : nums) std::cout << n << ' ';
+    return 0;
+}

--- a/sample/src/main/assets/samples/14_LinqDemo.cs
+++ b/sample/src/main/assets/samples/14_LinqDemo.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public record Product(int Id, string Name, decimal Price, int Stock);
+
+public class ProductService(IEnumerable<Product> catalog)
+{
+    public IEnumerable<Product> Search(string query, decimal? maxPrice = null) =>
+        catalog
+            .Where(p => p.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Where(p => maxPrice is null || p.Price <= maxPrice)
+            .OrderBy(p => p.Price);
+
+    public async Task<Product?> FindCheapestAsync(string query)
+    {
+        await Task.Delay(10); // simulate DB round-trip
+        return Search(query).FirstOrDefault();
+    }
+}
+
+var catalog = new List<Product>
+{
+    new(1, "Kotlin Book",    29.99m, 100),
+    new(2, "Rust in Action", 34.99m,  50),
+    new(3, "Go Programming", 24.99m,  75),
+};
+
+var svc = new ProductService(catalog);
+var hit = await svc.FindCheapestAsync("kotlin");
+Console.WriteLine(hit is { } p
+    ? ${'$'}"Found: {p.Name} at ${'$'}{p.Price:C}"
+    : "Not found");

--- a/sample/src/main/assets/samples/14_LinqDemo.cs
+++ b/sample/src/main/assets/samples/14_LinqDemo.cs
@@ -30,5 +30,5 @@ var catalog = new List<Product>
 var svc = new ProductService(catalog);
 var hit = await svc.FindCheapestAsync("kotlin");
 Console.WriteLine(hit is { } p
-    ? ${'$'}"Found: {p.Name} at ${'$'}{p.Price:C}"
+    ? $"Found: {p.Name} at ${p.Price:C}"
     : "Not found");

--- a/sample/src/main/assets/samples/15_deploy.sh
+++ b/sample/src/main/assets/samples/15_deploy.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="${'$'}(cd "${'$'}(dirname "${'$'}{BASH_SOURCE[0]}")" && pwd)"
-BUILD_DIR="${'$'}{SCRIPT_DIR}/build"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
 
-log()  { printf '[%s] %s\n' "${'$'}(date +%T)" "${'$'}*"; }
-fail() { log "ERROR: ${'$'}*" >&2; exit 1; }
+log()  { printf '[%s] %s\n' "$(date +%T)" "$*"; }
+fail() { log "ERROR: $*" >&2; exit 1; }
 
 setup() {
-    mkdir -p "${'$'}BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
     [[ -f "gradle.properties" ]] || fail "Not a Gradle project"
-    log "Setup done → ${'$'}BUILD_DIR"
+    log "Setup done → $BUILD_DIR"
 }
 
 run_tests() {
-    local filter="${'$'}{1:-}"
-    if [[ -n "${'$'}filter" ]]; then
-        ./gradlew test --tests "${'$'}filter"
+    local filter="${1:-}"
+    if [[ -n "$filter" ]]; then
+        ./gradlew test --tests "$filter"
     else
         ./gradlew test
     fi
@@ -24,18 +24,18 @@ run_tests() {
 }
 
 publish() {
-    local version="${'$'}{1:?version required (e.g. 1.2.3)}"
-    [[ "${'$'}version" =~ ^[0-9]+\.[0-9]+\.[0-9]+${'$'} ]] \
-        || fail "Invalid semver: ${'$'}version"
-    ./gradlew publishToMavenLocal -Pversion="${'$'}version"
-    git tag "${'$'}version" && git push origin "${'$'}version"
-    log "Published ${'$'}version"
+    local version="${1:?version required (e.g. 1.2.3)}"
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || fail "Invalid semver: $version"
+    ./gradlew publishToMavenLocal -Pversion="$version"
+    git tag "$version" && git push origin "$version"
+    log "Published $version"
 }
 
-case "${'$'}{1:-help}" in
+case "${1:-help}" in
     setup)   setup ;;
-    test)    run_tests "${'$'}{2:-}" ;;
-    publish) publish "${'$'}{2:-}" ;;
-    clean)   rm -rf "${'$'}BUILD_DIR" && log "Cleaned." ;;
-    *)       echo "Usage: ${'$'}0 {setup|test|publish <ver>|clean}" ;;
+    test)    run_tests "${2:-}" ;;
+    publish) publish "${2:-}" ;;
+    clean)   rm -rf "$BUILD_DIR" && log "Cleaned." ;;
+    *)       echo "Usage: $0 {setup|test|publish <ver>|clean}" ;;
 esac

--- a/sample/src/main/assets/samples/15_deploy.sh
+++ b/sample/src/main/assets/samples/15_deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="${'$'}(cd "${'$'}(dirname "${'$'}{BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${'$'}{SCRIPT_DIR}/build"
+
+log()  { printf '[%s] %s\n' "${'$'}(date +%T)" "${'$'}*"; }
+fail() { log "ERROR: ${'$'}*" >&2; exit 1; }
+
+setup() {
+    mkdir -p "${'$'}BUILD_DIR"
+    [[ -f "gradle.properties" ]] || fail "Not a Gradle project"
+    log "Setup done → ${'$'}BUILD_DIR"
+}
+
+run_tests() {
+    local filter="${'$'}{1:-}"
+    if [[ -n "${'$'}filter" ]]; then
+        ./gradlew test --tests "${'$'}filter"
+    else
+        ./gradlew test
+    fi
+    log "Tests complete ✓"
+}
+
+publish() {
+    local version="${'$'}{1:?version required (e.g. 1.2.3)}"
+    [[ "${'$'}version" =~ ^[0-9]+\.[0-9]+\.[0-9]+${'$'} ]] \
+        || fail "Invalid semver: ${'$'}version"
+    ./gradlew publishToMavenLocal -Pversion="${'$'}version"
+    git tag "${'$'}version" && git push origin "${'$'}version"
+    log "Published ${'$'}version"
+}
+
+case "${'$'}{1:-help}" in
+    setup)   setup ;;
+    test)    run_tests "${'$'}{2:-}" ;;
+    publish) publish "${'$'}{2:-}" ;;
+    clean)   rm -rf "${'$'}BUILD_DIR" && log "Cleaned." ;;
+    *)       echo "Usage: ${'$'}0 {setup|test|publish <ver>|clean}" ;;
+esac

--- a/sample/src/main/assets/samples/16_styles.css
+++ b/sample/src/main/assets/samples/16_styles.css
@@ -1,0 +1,46 @@
+:root {
+    --color-primary:  #6200ea;
+    --color-surface:  #ffffff;
+    --color-on-surface: #1c1b1f;
+    --radius-md: 8px;
+    --transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-primary:    #bb86fc;
+        --color-surface:    #121212;
+        --color-on-surface: #e6e1e5;
+    }
+}
+
+.card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    color: var(--color-on-surface);
+    padding: 1.5rem;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0);   }
+}
+
+.card--animated {
+    animation: fadeIn 0.35s var(--transition) both;
+}
+
+.card__title {
+    color: var(--color-primary);
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    margin: 0 0 0.5rem;
+}

--- a/sample/src/main/assets/samples/17_plaintext.txt
+++ b/sample/src/main/assets/samples/17_plaintext.txt
@@ -1,0 +1,2 @@
+This is plaintext.
+Nothing to highlight.

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
@@ -28,6 +28,6 @@ internal sealed class DemoTab(
     data object Engine : DemoTab("Engine")
 
     companion object {
-        val all = listOf(Languages, Styling, Typography, Toggles, Callbacks, Themes, Advanced, Engine)
+        val all by lazy { listOf(Languages, Styling, Typography, Toggles, Callbacks, Themes, Advanced, Engine) }
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -1,13 +1,79 @@
 package dev.hossain.highlight.sample
 
+import android.content.Context
 import dev.hossain.highlight.engine.HighlightTheme
 
-/** A single syntax-highlighting demo sample with its highlight.js [language] identifier and [code] string. */
+/**
+ * A single syntax-highlighting demo sample.
+ *
+ * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`).
+ * @param displayLabel Human-readable label shown in the UI (e.g. `"WeatherApp.kt"`).
+ * @param code The source code to highlight.
+ */
 internal data class CodeSample(
     val language: String,
+    val displayLabel: String,
     val code: String,
 )
 
+/**
+ * Loads all demo code samples from `assets/samples/`.
+ *
+ * Files are named with a numeric prefix for ordering (e.g. `01_fibonacci.py`).
+ * The prefix is stripped for the display label. The file extension is mapped to
+ * a Highlight.js language identifier via [extensionToLanguage].
+ *
+ * Adding a new sample only requires dropping a file into `assets/samples/` —
+ * no Kotlin changes needed.
+ */
+internal fun loadCodeSamples(context: Context): List<CodeSample> =
+    context.assets
+        .list("samples")
+        .orEmpty()
+        .sorted()
+        .mapNotNull { filename ->
+            runCatching {
+                val code =
+                    context.assets
+                        .open("samples/$filename")
+                        .bufferedReader()
+                        .readText()
+                val ext = filename.substringAfterLast(".", missingDelimiterValue = "")
+                val language = extensionToLanguage(ext)
+                val displayLabel = filename.substringAfter("_")
+                CodeSample(language = language, displayLabel = displayLabel, code = code)
+            }.getOrNull()
+        }
+
+private fun extensionToLanguage(ext: String): String =
+    when (ext) {
+        "py" -> "python"
+        "kt" -> "kotlin"
+        "js" -> "javascript"
+        "java" -> "java"
+        "sql" -> "sql"
+        "json" -> "json"
+        "xml" -> "xml"
+        "ts" -> "typescript"
+        "rs" -> "rust"
+        "go" -> "go"
+        "swift" -> "swift"
+        "cpp" -> "cpp"
+        "cs" -> "csharp"
+        "sh" -> "bash"
+        "css" -> "css"
+        "txt" -> "plaintext"
+        else -> ext
+    }
+
+/** A named pair of light/dark [HighlightTheme]s for the theme picker. */
+internal data class ThemePair(
+    val name: String,
+    val light: HighlightTheme,
+    val dark: HighlightTheme,
+)
+
+// Short snippets used in demo sections (not loaded from assets — intentionally inline).
 internal val KOTLIN_SNIPPET =
     """
 data class User(val name: String, val age: Int)
@@ -26,700 +92,3 @@ def fibonacci(n: int) -> int:
         a, b = b, a + b
     return b
     """.trimIndent()
-
-/**
- * Collection of code samples used to showcase syntax highlighting across multiple languages.
- *
- * Each [CodeSample] pairs a highlight.js language identifier with the corresponding source code
- * string, passed directly to [dev.hossain.highlight.ui.SyntaxHighlightedCode].
- *
- * The list intentionally covers a range of use-cases:
- * - Short, focused snippets (Python, Kotlin, JavaScript, Java, SQL, JSON, XML)
- * - Systems / low-level languages (Rust, C++, Go) showcasing templates, lifetimes, goroutines
- * - Typed languages (TypeScript, Swift, C#) showcasing generics, protocols, LINQ, async/await
- * - Shell script (Bash) showcasing variables, functions, case statements
- * - Stylesheet (CSS) showcasing selectors, variables, media queries, keyframes
- * - A large, real-world Kotlin file (WeatherApp) to stress-test rendering performance
- * - An empty string edge case to verify graceful fallback
- */
-internal val CODE_SAMPLES =
-    listOf(
-        CodeSample(
-            language = "python",
-            code =
-                """
-def fibonacci(n: int) -> int:
-    # Returns the nth Fibonacci number
-    if n <= 1:
-        return n
-    a, b = 0, 1
-    for _ in range(n - 1):
-        a, b = b, a + b
-    return b
-
-# Edge case: special chars  \t \n ' "
-result = fibonacci(10)
-print(f"Result: {result}")
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "kotlin",
-            code =
-                """
-data class User(val name: String, val age: Int)
-
-fun List<User>.filter(minAge: Int): List<User> =
-    filter { it.age >= minAge }
-
-// Unicode: héllo wörld 🌍
-val users = listOf(
-    User("Alice", 30),
-    User("Bob", 25),
-)
-
-val adults = users.filter(18)
-println(adults)
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "javascript",
-            code =
-                """
-async function fetchUser(id) {
-    const response = await fetch(`/api/users/${'$'}{id}`);
-    if (!response.ok) {
-        throw new Error(`HTTP error: ${'$'}{response.status}`);
-    }
-    return response.json();
-}
-
-// Backslash path: C:\Users\test
-const path = 'C:\\Users\\test\\file.txt';
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "java",
-            code =
-                """
-public class BinarySearch {
-    public static int search(int[] arr, int target) {
-        int left = 0, right = arr.length - 1;
-        while (left <= right) {
-            int mid = left + (right - left) / 2;
-            if (arr[mid] == target) return mid;
-            if (arr[mid] < target) left = mid + 1;
-            else right = mid - 1;
-        }
-        return -1;
-    }
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "sql",
-            code =
-                """
-SELECT
-    u.id,
-    u.name,
-    COUNT(o.id) AS order_count,
-    SUM(o.total) AS revenue
-FROM users u
-LEFT JOIN orders o ON o.user_id = u.id
-WHERE u.created_at >= '2024-01-01'
-GROUP BY u.id, u.name
-HAVING order_count > 0
-ORDER BY revenue DESC
-LIMIT 10;
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "json",
-            code =
-                """
-{
-    "string": "Hello, World!",
-    "emptyString": "",
-    "unicodeString": "héllo 🌍 日本語",
-    "escapedString": "line1\nline2\ttabbed \"quoted\" and backslash \\",
-    "integer": 42,
-    "negativeInteger": -7,
-    "float": 3.14159,
-    "negativeFloat": -0.001,
-    "scientificNotation": 1.5e10,
-    "largeNumber": 9007199254740991,
-    "booleanTrue": true,
-    "booleanFalse": false,
-    "nullValue": null,
-    "emptyArray": [],
-    "stringArray": ["android", "compose", "kotlin"],
-    "numberArray": [1, 2, 3, 4, 5],
-    "mixedArray": [1, "two", true, null, 3.0],
-    "nestedArray": [[1, 2], [3, 4], [5, 6]],
-    "emptyObject": {},
-    "nestedObject": {
-        "id": 101,
-        "name": "compose-highlight",
-        "version": "0.3.0",
-        "stable": true,
-        "deprecated": null,
-        "tags": ["library", "ui", "syntax"],
-        "metadata": {
-            "author": "hossain-khan",
-            "license": "Apache-2.0",
-            "stars": 42
-        }
-    },
-    "arrayOfObjects": [
-        { "lang": "kotlin", "highlight": true },
-        { "lang": "python", "highlight": true },
-        { "lang": "cobol", "highlight": false }
-    ]
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "xml",
-            code =
-                """
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_name">Compose Highlight</string>
-    <style name="Theme.App" parent="Theme.Material3.DayNight">
-        <item name="colorPrimary">@color/purple_500</item>
-    </style>
-</resources>
-                """.trimIndent(),
-        ),
-        // Large real-world Kotlin file — WeatherApp from ZacSweers/metro samples.
-        // Source: https://github.com/ZacSweers/metro/blob/main/samples/weather-app/src/commonMain/kotlin/dev/zacsweers/metro/sample/weather/WeatherApp.kt
-        CodeSample(
-            language = "kotlin (large — WeatherApp)",
-            code =
-                """
-// Copyright (C) 2025 Zac Sweers
-// SPDX-License-Identifier: Apache-2.0
-package dev.zacsweers.metro.sample.weather
-
-import com.jakewharton.picnic.TextAlignment
-import com.jakewharton.picnic.table
-import dev.zacsweers.metro.Inject
-import kotlin.time.Instant
-import kotlinx.coroutines.coroutineScope
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
-
-@Inject
-class WeatherApp(private val repository: WeatherRepository) {
-  suspend operator fun invoke(query: String, log: (String, isError: Boolean) -> Unit) {
-    byLocation(query)
-      .onSuccess { weather ->
-        val location = weather.location
-        val message = buildString {
-          appendLine("Weather for ${'$'}{location.name}, ${'$'}{location.region ?: location.country}:")
-
-          val current = weather.current
-          appendLine("\nCurrent conditions:")
-          appendLine("Temperature: ${'$'}{current.temperature}°C")
-          appendLine("Humidity: ${'$'}{current.humidity}%")
-          appendLine("Wind Speed: ${'$'}{current.windSpeed} km/h")
-          appendLine("Description: ${'$'}{current.description}")
-
-          appendLine("\nHourly forecast:")
-
-          val hourlyTable = formatHourlyForecast(weather.hourlyForecast)
-          appendLine(hourlyTable)
-        }
-        log(message, false)
-      }
-      .onFailure { error -> log("Error fetching weather: ${'$'}{error.message}", true) }
-  }
-
-  private suspend fun byLocation(query: String): Result<WeatherInfo> = coroutineScope {
-    try {
-      val locations = repository.searchLocation(query).getOrThrow()
-      if (locations.isEmpty()) {
-        Result.failure(NoSuchElementException("Location not found: ${'$'}query"))
-      } else {
-        val location = locations.first()
-        val weather = repository.getWeather(location.latitude, location.longitude).getOrThrow()
-
-        Result.success(
-          WeatherInfo(
-            location =
-              LocationInfo(
-                name = location.name,
-                region = location.region,
-                country = location.country,
-              ),
-            current =
-              CurrentWeatherInfo(
-                temperature = weather.current.temperature,
-                humidity = weather.current.humidity,
-                windSpeed = weather.current.windSpeed,
-                description = getWeatherDescription(weather.current.weatherCode),
-              ),
-            hourlyForecast =
-              weather.hourly.time.zip(
-                weather.hourly.temperatures.zip(weather.hourly.weatherCodes)
-              ) { time, (temp, code) ->
-                HourlyForecastInfo(
-                  time = LocalDateTime.parse(time).toInstant(TimeZone.UTC),
-                  temperature = temp,
-                  description = getWeatherDescription(code),
-                )
-              },
-          )
-        )
-      }
-    } catch (e: Exception) {
-      Result.failure(e)
-    }
-  }
-
-  private fun getWeatherDescription(code: Int): String =
-    when (code) {
-      0 -> "Clear sky"
-      1, 2, 3 -> "Partly cloudy"
-      45, 48 -> "Foggy"
-      51, 53, 55 -> "Drizzle"
-      61, 63, 65 -> "Rain"
-      71, 73, 75 -> "Snow"
-      77 -> "Snow grains"
-      80, 81, 82 -> "Rain showers"
-      85, 86 -> "Snow showers"
-      95 -> "Thunderstorm"
-      96, 99 -> "Thunderstorm with hail"
-      else -> "Unknown"
-    }
-
-  private fun formatHourlyForecast(forecast: List<HourlyForecastInfo>): String {
-    return table {
-        cellStyle {
-          border = true
-          alignment = TextAlignment.MiddleCenter
-        }
-
-        header {
-          row {
-            cell("Time") { alignment = TextAlignment.MiddleCenter }
-            cell("Temperature")
-            cell("Conditions") { alignment = TextAlignment.MiddleCenter }
-          }
-        }
-
-        forecast.take(24).forEach { hour ->
-          val localTime = hour.time.toLocalDateTime(TimeZone.currentSystemDefault())
-          val timeStr =
-            "${'$'}{localTime.hour.toString().padStart(2, '0')}:${'$'}{
-          localTime.minute.toString().padStart(2, '0')
-        }"
-
-          row {
-            cell(timeStr)
-            cell("${'$'}{hour.temperature}°C")
-            cell(hour.description)
-          }
-        }
-      }
-      .toString()
-  }
-}
-
-data class WeatherInfo(
-  val location: LocationInfo,
-  val current: CurrentWeatherInfo,
-  val hourlyForecast: List<HourlyForecastInfo>,
-)
-
-data class LocationInfo(val name: String, val region: String?, val country: String)
-
-data class CurrentWeatherInfo(
-  val temperature: Double,
-  val humidity: Double,
-  val windSpeed: Double,
-  val description: String,
-)
-
-data class HourlyForecastInfo(val time: Instant, val temperature: Double, val description: String)
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "typescript",
-            code =
-                """
-interface Repository<T extends { id: number }> {
-  findById(id: number): Promise<T | null>;
-  save(entity: Omit<T, 'id'>): Promise<T>;
-  delete(id: number): Promise<void>;
-}
-
-type ApiResponse<T> = {
-  data: T;
-  status: number;
-  message?: string;
-};
-
-async function fetchWithRetry<T>(
-  url: string,
-  retries = 3,
-): Promise<ApiResponse<T>> {
-  for (let attempt = 0; attempt < retries; attempt++) {
-    try {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${'$'}{res.status}: ${'$'}{res.statusText}`);
-      const data: T = await res.json();
-      return { data, status: res.status };
-    } catch (err) {
-      if (attempt === retries - 1) throw err;
-      await new Promise(r => setTimeout(r, 2 ** attempt * 100));
-    }
-  }
-  throw new Error('unreachable');
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "rust",
-            code =
-                """
-use std::collections::HashMap;
-
-#[derive(Debug, Clone)]
-pub struct LruCache<V> {
-    store: HashMap<String, V>,
-    capacity: usize,
-}
-
-impl<V> LruCache<V> {
-    pub fn new(capacity: usize) -> Self {
-        Self { store: HashMap::with_capacity(capacity), capacity }
-    }
-
-    pub fn get(&self, key: &str) -> Option<&V> {
-        self.store.get(key)
-    }
-
-    /// Inserts a value; returns the old value if the key existed.
-    pub fn insert(&mut self, key: String, value: V) -> Result<Option<V>, &'static str> {
-        if self.store.len() >= self.capacity && !self.store.contains_key(&key) {
-            return Err("cache full — eviction not implemented");
-        }
-        Ok(self.store.insert(key, value))
-    }
-}
-
-fn main() {
-    let mut cache: LruCache<i32> = LruCache::new(4);
-    cache.insert("answer".to_owned(), 42).unwrap();
-    match cache.get("answer") {
-        Some(v) => println!("Found: {v}"),
-        None    => println!("Cache miss"),
-    }
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "go",
-            code =
-                """
-package main
-
-import (
-    "context"
-    "fmt"
-    "sync"
-    "time"
-)
-
-type Result struct {
-    URL      string
-    Duration time.Duration
-    Err      error
-}
-
-func fetchAll(ctx context.Context, urls []string) []Result {
-    var mu sync.Mutex
-    results := make([]Result, 0, len(urls))
-    var wg sync.WaitGroup
-
-    for _, url := range urls {
-        wg.Add(1)
-        go func(u string) {
-            defer wg.Done()
-            start := time.Now()
-            select {
-            case <-ctx.Done():
-                mu.Lock()
-                results = append(results, Result{URL: u, Err: ctx.Err()})
-                mu.Unlock()
-            case <-time.After(50 * time.Millisecond):
-                mu.Lock()
-                results = append(results, Result{URL: u, Duration: time.Since(start)})
-                mu.Unlock()
-            }
-        }(url)
-    }
-    wg.Wait()
-    return results
-}
-
-func main() {
-    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-    defer cancel()
-    urls := []string{"https://example.com", "https://golang.org", "https://pkg.go.dev"}
-    for _, r := range fetchAll(ctx, urls) {
-        if r.Err != nil {
-            fmt.Printf("ERR  %s: %v\n", r.URL, r.Err)
-        } else {
-            fmt.Printf("OK   %s  (%v)\n", r.URL, r.Duration)
-        }
-    }
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "swift",
-            code =
-                """
-import Foundation
-
-protocol Fetchable {
-    associatedtype Resource: Decodable
-    var baseURL: URL { get }
-    func fetch(id: Int) async throws -> Resource
-}
-
-struct User: Decodable, Identifiable {
-    let id: Int
-    let name: String
-    let email: String?
-}
-
-enum NetworkError: LocalizedError {
-    case badStatus(Int)
-    case decodingFailed(Error)
-
-    var errorDescription: String? {
-        switch self {
-        case .badStatus(let code): return "Server returned HTTP \(code)"
-        case .decodingFailed(let e): return "Decode error: \(e.localizedDescription)"
-        }
-    }
-}
-
-struct UserService: Fetchable {
-    typealias Resource = User
-    let baseURL = URL(string: "https://api.example.com")!
-
-    func fetch(id: Int) async throws -> User {
-        let url = baseURL.appendingPathComponent("users/\(id)")
-        let (data, response) = try await URLSession.shared.data(from: url)
-        guard let http = response as? HTTPURLResponse,
-              (200..<300).contains(http.statusCode) else {
-            throw NetworkError.badStatus((response as? HTTPURLResponse)?.statusCode ?? -1)
-        }
-        do {
-            return try JSONDecoder().decode(User.self, from: data)
-        } catch {
-            throw NetworkError.decodingFailed(error)
-        }
-    }
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "cpp",
-            code =
-                """
-#include <algorithm>
-#include <iostream>
-#include <memory>
-#include <stdexcept>
-#include <vector>
-
-template <typename T>
-class Stack {
-public:
-    void push(T value) { data_.push_back(std::move(value)); }
-
-    T pop() {
-        if (data_.empty()) throw std::underflow_error("Stack is empty");
-        T top = std::move(data_.back());
-        data_.pop_back();
-        return top;
-    }
-
-    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
-    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
-
-private:
-    std::vector<T> data_;
-};
-
-int main() {
-    auto s = std::make_unique<Stack<int>>();
-    for (int i : {3, 1, 4, 1, 5, 9, 2, 6}) s->push(i);
-
-    std::cout << "Size: " << s->size() << "\nPopping: ";
-    while (!s->empty()) std::cout << s->pop() << ' ';
-    std::cout << '\n';
-
-    // Lambda + algorithm example
-    std::vector<int> nums = {5, 3, 8, 1, 9, 2};
-    std::sort(nums.begin(), nums.end(), [](int a, int b) { return a > b; });
-    for (auto n : nums) std::cout << n << ' ';
-    return 0;
-}
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "csharp",
-            code =
-                """
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-public record Product(int Id, string Name, decimal Price, int Stock);
-
-public class ProductService(IEnumerable<Product> catalog)
-{
-    public IEnumerable<Product> Search(string query, decimal? maxPrice = null) =>
-        catalog
-            .Where(p => p.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
-            .Where(p => maxPrice is null || p.Price <= maxPrice)
-            .OrderBy(p => p.Price);
-
-    public async Task<Product?> FindCheapestAsync(string query)
-    {
-        await Task.Delay(10); // simulate DB round-trip
-        return Search(query).FirstOrDefault();
-    }
-}
-
-var catalog = new List<Product>
-{
-    new(1, "Kotlin Book",    29.99m, 100),
-    new(2, "Rust in Action", 34.99m,  50),
-    new(3, "Go Programming", 24.99m,  75),
-};
-
-var svc = new ProductService(catalog);
-var hit = await svc.FindCheapestAsync("kotlin");
-Console.WriteLine(hit is { } p
-    ? ${'$'}"Found: {p.Name} at ${'$'}{p.Price:C}"
-    : "Not found");
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "bash",
-            code =
-                """
-#!/usr/bin/env bash
-set -euo pipefail
-
-SCRIPT_DIR="${'$'}(cd "${'$'}(dirname "${'$'}{BASH_SOURCE[0]}")" && pwd)"
-BUILD_DIR="${'$'}{SCRIPT_DIR}/build"
-
-log()  { printf '[%s] %s\n' "${'$'}(date +%T)" "${'$'}*"; }
-fail() { log "ERROR: ${'$'}*" >&2; exit 1; }
-
-setup() {
-    mkdir -p "${'$'}BUILD_DIR"
-    [[ -f "gradle.properties" ]] || fail "Not a Gradle project"
-    log "Setup done → ${'$'}BUILD_DIR"
-}
-
-run_tests() {
-    local filter="${'$'}{1:-}"
-    if [[ -n "${'$'}filter" ]]; then
-        ./gradlew test --tests "${'$'}filter"
-    else
-        ./gradlew test
-    fi
-    log "Tests complete ✓"
-}
-
-publish() {
-    local version="${'$'}{1:?version required (e.g. 1.2.3)}"
-    [[ "${'$'}version" =~ ^[0-9]+\.[0-9]+\.[0-9]+${'$'} ]] \
-        || fail "Invalid semver: ${'$'}version"
-    ./gradlew publishToMavenLocal -Pversion="${'$'}version"
-    git tag "${'$'}version" && git push origin "${'$'}version"
-    log "Published ${'$'}version"
-}
-
-case "${'$'}{1:-help}" in
-    setup)   setup ;;
-    test)    run_tests "${'$'}{2:-}" ;;
-    publish) publish "${'$'}{2:-}" ;;
-    clean)   rm -rf "${'$'}BUILD_DIR" && log "Cleaned." ;;
-    *)       echo "Usage: ${'$'}0 {setup|test|publish <ver>|clean}" ;;
-esac
-                """.trimIndent(),
-        ),
-        CodeSample(
-            language = "css",
-            code =
-                """
-:root {
-    --color-primary:  #6200ea;
-    --color-surface:  #ffffff;
-    --color-on-surface: #1c1b1f;
-    --radius-md: 8px;
-    --transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --color-primary:    #bb86fc;
-        --color-surface:    #121212;
-        --color-on-surface: #e6e1e5;
-    }
-}
-
-.card {
-    background: var(--color-surface);
-    border-radius: var(--radius-md);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-    color: var(--color-on-surface);
-    padding: 1.5rem;
-    transition: transform var(--transition), box-shadow var(--transition);
-}
-
-.card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(6px); }
-    to   { opacity: 1; transform: translateY(0);   }
-}
-
-.card--animated {
-    animation: fadeIn 0.35s var(--transition) both;
-}
-
-.card__title {
-    color: var(--color-primary);
-    font-size: clamp(1rem, 2.5vw, 1.5rem);
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    margin: 0 0 0.5rem;
-}
-                """.trimIndent(),
-        ),
-        CodeSample(language = "plaintext", code = "This is plaintext.\nNothing to highlight."),
-    )
-
-/** A named pair of light/dark [HighlightTheme]s for the theme picker. */
-internal data class ThemePair(
-    val name: String,
-    val light: HighlightTheme,
-    val dark: HighlightTheme,
-)

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -37,7 +37,7 @@ internal fun loadCodeSamples(context: Context): List<CodeSample> =
                     context.assets
                         .open("samples/$filename")
                         .bufferedReader()
-                        .readText()
+                        .use { it.readText() }
                 val ext = filename.substringAfterLast(".", missingDelimiterValue = "")
                 val language = extensionToLanguage(ext)
                 val displayLabel = filename.substringAfter("_")

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun SampleScreen() {
     val context = LocalContext.current
+    val codeSamples = remember(context) { loadCodeSamples(context) }
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -210,9 +211,9 @@ fun SampleScreen() {
                 ) {
                     when (activeTab) {
                         DemoTab.Languages -> {
-                            CODE_SAMPLES.forEach { sample ->
-                                item(key = sample.language) {
-                                    SectionHeader(sample.language)
+                            codeSamples.forEach { sample ->
+                                item(key = sample.displayLabel) {
+                                    SectionHeader(sample.displayLabel)
                                     SyntaxHighlightedCode(
                                         code = sample.code,
                                         language = sample.language,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -50,7 +51,9 @@ import dev.hossain.highlight.sample.sections.TogglesSection
 import dev.hossain.highlight.sample.sections.TypographySection
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Main demo screen that renders a scrollable list of syntax-highlighted code snippets.
@@ -79,7 +82,9 @@ import kotlinx.coroutines.launch
 @Composable
 fun SampleScreen() {
     val context = LocalContext.current
-    val codeSamples = remember(context) { loadCodeSamples(context) }
+    val codeSamples by produceState(initialValue = emptyList<CodeSample>(), context) {
+        value = withContext(Dispatchers.IO) { loadCodeSamples(context) }
+    }
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -40,10 +41,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.sample.CodeSample
 import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.sample.loadCodeSamples
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /** Timing and size metrics captured for a single code block after highlighting completes. */
 internal data class HighlightMetrics(
@@ -65,7 +69,9 @@ internal data class HighlightMetrics(
 @Composable
 fun PerfScreen() {
     val context = LocalContext.current
-    val codeSamples = remember(context) { loadCodeSamples(context) }
+    val codeSamples by produceState(initialValue = emptyList<CodeSample>(), context) {
+        value = withContext(Dispatchers.IO) { loadCodeSamples(context) }
+    }
     var isDark by remember { mutableStateOf(true) }
 
     val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -40,8 +40,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightTheme
-import dev.hossain.highlight.sample.CODE_SAMPLES
 import dev.hossain.highlight.sample.R
+import dev.hossain.highlight.sample.loadCodeSamples
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
@@ -54,7 +54,7 @@ internal data class HighlightMetrics(
 )
 
 /**
- * Performance benchmark screen that renders every [CODE_SAMPLES] entry in a scrollable list and
+ * Performance benchmark screen that renders every loaded code sample in a scrollable list and
  * measures per-block highlighting timing, code size, and overall heap usage.
  *
  * - Each block shows a metric card: highlight time, line count, char count.
@@ -65,6 +65,7 @@ internal data class HighlightMetrics(
 @Composable
 fun PerfScreen() {
     val context = LocalContext.current
+    val codeSamples = remember(context) { loadCodeSamples(context) }
     var isDark by remember { mutableStateOf(true) }
 
     val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }
@@ -72,7 +73,7 @@ fun PerfScreen() {
 
     // Take a heap snapshot once all blocks have reported their timing.
     var heapSnapshotKb by remember { mutableStateOf<Long?>(null) }
-    if (metricsMap.size == CODE_SAMPLES.size && heapSnapshotKb == null) {
+    if (metricsMap.size == codeSamples.size && heapSnapshotKb == null) {
         val rt = Runtime.getRuntime()
         heapSnapshotKb = (rt.totalMemory() - rt.freeMemory()) / 1024
     }
@@ -143,16 +144,16 @@ fun PerfScreen() {
                     Spacer(modifier = Modifier.height(4.dp))
                     SummaryHeader(
                         metricsMap = metricsMap,
-                        totalSamples = CODE_SAMPLES.size,
+                        totalSamples = codeSamples.size,
                         heapSnapshotKb = heapSnapshotKb,
                     )
                 }
 
-                items(CODE_SAMPLES, key = { it.language }) { sample ->
-                    val metrics = metricsMap[sample.language]
+                items(codeSamples, key = { it.displayLabel }) { sample ->
+                    val metrics = metricsMap[sample.displayLabel]
                     Column {
                         Text(
-                            text = sample.language.uppercase(),
+                            text = sample.displayLabel,
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.padding(bottom = 4.dp),
@@ -164,7 +165,7 @@ fun PerfScreen() {
                                 modifier = Modifier.fillMaxWidth(),
                                 showLineNumbers = true,
                                 onHighlightComplete = { result ->
-                                    metricsMap[sample.language] =
+                                    metricsMap[sample.displayLabel] =
                                         HighlightMetrics(
                                             language = sample.language,
                                             highlightMs = result.durationMs,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -113,6 +115,7 @@ internal fun EngineInfoSection() {
                         Modifier
                             .fillMaxWidth()
                             .height(400.dp)
+                            .verticalScroll(rememberScrollState())
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {


### PR DESCRIPTION
## Summary

Replaces 700+ lines of hardcoded Kotlin string literals in `SampleData.kt` with individual asset files under `sample/src/main/assets/samples/`.

## Why

- **IDE syntax highlighting** — each file has a real extension (`.py`, `.kt`, `.rs`, etc.) so editors apply proper highlighting when you open or edit them
- **Easier to maintain** — code is in its natural file format, not escaped inside a Kotlin raw string
- **Extensible** — adding a new language sample only requires dropping a file in the folder; no Kotlin changes needed

## Changes

| File | Change |
|------|--------|
| `assets/samples/01_fibonacci.py` … `17_plaintext.txt` | New — 17 sample files with real extensions |
| `SampleData.kt` | Removed ~700 lines of raw strings; added `loadCodeSamples(Context)`, `extensionToLanguage()`, and `displayLabel` field on `CodeSample` |
| `SampleScreen.kt` | Load samples at runtime via `remember(context) { loadCodeSamples(context) }` |
| `PerfScreen.kt` | Same runtime loading pattern |

## Bug fixed

`"kotlin (large — WeatherApp)"` was previously passed directly to hljs as the language identifier, which it doesn't recognise — resulting in zero syntax-highlighted spans for that file. Now `displayLabel = "WeatherApp.kt"` and `language = "kotlin"` are separate fields.

## Verification

- ✅ `./gradlew formatKotlin`
- ✅ `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug`
- ✅ `./gradlew :compose-highlight:test`