### PR TITLE
build: add Maven Central publishing via gradle-nexus publish plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,8 @@ jobs:
             -PVERSION_NAME=${{ inputs.tag }}
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          # Must be ASCII-armored key text (-----BEGIN PGP PRIVATE KEY BLOCK-----)
+          # Export with: gpg --export-secret-keys --armor <FINGERPRINT>
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g. 0.11.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify tag exists
+        run: |
+          if ! git ls-remote --tags "https://github.com/${{ github.repository }}.git" "refs/tags/${{ inputs.tag }}" | grep -q .; then
+            echo "::error::Tag '${{ inputs.tag }}' does not exist in the repository."
+            exit 1
+          fi
+          echo "Tag '${{ inputs.tag }}' found."
+
+      - name: Check not already published on Maven Central
+        run: |
+          POM_URL="https://repo1.maven.org/maven2/dev/hossain/compose-highlight/${{ inputs.tag }}/compose-highlight-${{ inputs.tag }}.pom"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$POM_URL")
+          if [ "$STATUS" = "200" ]; then
+            echo "::error::Version ${{ inputs.tag }} is already published on Maven Central. Aborting to avoid duplicate deployment."
+            exit 1
+          fi
+          echo "Version ${{ inputs.tag }} is not yet on Maven Central — proceeding."
+
+      - name: Checkout tag
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Publish and release to Maven Central
+        run: |
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+            -PVERSION_NAME=${{ inputs.tag }}
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,15 @@ on:
         description: 'Git tag to publish (e.g. 0.11.0)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run — publishes to Maven Local and validates artifacts without uploading to Maven Central'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   publish:
-    name: Publish to Maven Central
+    name: ${{ inputs.dry_run && 'Dry Run — Validate Artifacts' || 'Publish to Maven Central' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +28,7 @@ jobs:
           echo "Tag '${{ inputs.tag }}' found."
 
       - name: Check not already published on Maven Central
+        if: ${{ !inputs.dry_run }}
         run: |
           POM_URL="https://repo1.maven.org/maven2/dev/hossain/compose-highlight/${{ inputs.tag }}/compose-highlight-${{ inputs.tag }}.pom"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$POM_URL")
@@ -48,7 +54,62 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: '[Dry Run] Publish to Maven Local'
+        if: ${{ inputs.dry_run }}
+        run: |
+          ./gradlew :compose-highlight:publishToMavenLocal \
+            -PVERSION_NAME=${{ inputs.tag }}
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: '[Dry Run] Validate artifacts'
+        if: ${{ inputs.dry_run }}
+        run: |
+          ARTIFACT_DIR="$HOME/.m2/repository/dev/hossain/compose-highlight/${{ inputs.tag }}"
+          VERSION="${{ inputs.tag }}"
+
+          echo "── Artifact directory: $ARTIFACT_DIR"
+          ls -lh "$ARTIFACT_DIR"
+          echo ""
+
+          EXPECTED=(
+            "compose-highlight-${VERSION}.aar"
+            "compose-highlight-${VERSION}.aar.asc"
+            "compose-highlight-${VERSION}.pom"
+            "compose-highlight-${VERSION}.pom.asc"
+            "compose-highlight-${VERSION}-sources.jar"
+            "compose-highlight-${VERSION}-sources.jar.asc"
+            "compose-highlight-${VERSION}-javadoc.jar"
+            "compose-highlight-${VERSION}-javadoc.jar.asc"
+          )
+
+          PASS=0
+          FAIL=0
+          for FILE in "${EXPECTED[@]}"; do
+            FULL_PATH="$ARTIFACT_DIR/$FILE"
+            if [ -f "$FULL_PATH" ] && [ -s "$FULL_PATH" ]; then
+              SIZE=$(du -h "$FULL_PATH" | cut -f1)
+              echo "  ✅  $FILE  ($SIZE)"
+              PASS=$((PASS + 1))
+            else
+              echo "  ❌  $FILE  — MISSING or EMPTY"
+              FAIL=$((FAIL + 1))
+            fi
+          done
+
+          echo ""
+          echo "── Result: $PASS passed, $FAIL failed"
+
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::error::$FAIL expected artifact(s) are missing or empty. See output above."
+            exit 1
+          fi
+          echo "All artifacts present and non-empty — ready to publish! 🎉"
+
       - name: Publish and release to Maven Central
+        if: ${{ !inputs.dry_run }}
         run: |
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
             -PVERSION_NAME=${{ inputs.tag }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,163 @@
+# Publishing Guide
+
+This library is distributed through two channels:
+
+| Channel | Coordinates | How it works |
+|---|---|---|
+| **Maven Central** | `dev.hossain:compose-highlight:<version>` | Primary channel — published via GitHub Actions |
+| **JitPack** | `com.github.hossain-khan:android-compose-highlight:<version>` | Auto-built from git tags; no action required |
+
+---
+
+## Prerequisites
+
+Complete these steps once before your first Maven Central release.
+
+### 1. Sonatype Central Portal account
+
+1. Sign up at [central.sonatype.com](https://central.sonatype.com)
+2. Verify the `dev.hossain` namespace (Settings → Namespaces)
+3. Generate a user token: Account → Generate User Token
+   - Save the **token username** → `OSSRH_USERNAME` secret
+   - Save the **token password** → `OSSRH_PASSWORD` secret
+
+### 2. GPG signing key
+
+Generate a key (if you don't have one):
+```bash
+gpg --gen-key
+# Choose Ed25519, set name/email, set a passphrase
+```
+
+Upload the public key to keyservers:
+```bash
+gpg --list-keys               # find your FULL_FINGERPRINT (40 hex chars)
+gpg --keyserver keys.openpgp.org --send-keys <FULL_FINGERPRINT>
+gpg --keyserver pgp.mit.edu   --send-keys <FULL_FINGERPRINT>
+```
+
+Export the **ASCII-armored** private key for CI:
+```bash
+gpg --export-secret-keys --armor <FULL_FINGERPRINT>
+```
+
+> ⚠️ Copy the entire output — including the `-----BEGIN PGP PRIVATE KEY BLOCK-----`
+> and `-----END PGP PRIVATE KEY BLOCK-----` lines — directly into the `SIGNING_KEY`
+> GitHub Secret. **Do not base64-encode it.**
+
+### 3. GitHub Secrets
+
+Add the following secrets in **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+|---|---|
+| `SIGNING_KEY_ID` | Short key ID — last 8 hex chars of the fingerprint (e.g. `F17804D7`) |
+| `SIGNING_KEY` | ASCII-armored private key (full `-----BEGIN/END-----` block) |
+| `SIGNING_PASSWORD` | Passphrase used when generating the key |
+| `OSSRH_USERNAME` | Central Portal token username |
+| `OSSRH_PASSWORD` | Central Portal token password |
+
+---
+
+## Releasing a new version
+
+### Step 1 — Bump the version
+
+Update `VERSION_NAME` in [`gradle.properties`](gradle.properties):
+```properties
+VERSION_NAME=0.12.0
+```
+
+Also update these per the [project conventions](README.md#releasing):
+- `CHANGELOG.md` — rename `[Unreleased]` to `[0.12.0] - YYYY-MM-DD`
+- `sample/build.gradle.kts` — `versionName` and `versionCode`
+- `README.md` — dependency snippet version
+
+Commit, push, and create the git tag:
+```bash
+git tag 0.12.0
+git push origin 0.12.0
+```
+
+### Step 2 — Dry run (recommended)
+
+Run the workflow in dry-run mode first to validate all artifacts are produced
+and signed correctly **without uploading anything** to Maven Central:
+
+1. Go to **Actions → Publish to Maven Central**
+2. Click **Run workflow**
+3. Enter the tag (e.g. `0.12.0`)
+4. ✅ Check **Dry run**
+5. Click **Run workflow**
+
+Expected output from the validation step:
+```
+✅  compose-highlight-0.12.0.aar
+✅  compose-highlight-0.12.0.aar.asc
+✅  compose-highlight-0.12.0.pom
+✅  compose-highlight-0.12.0.pom.asc
+✅  compose-highlight-0.12.0-sources.jar
+✅  compose-highlight-0.12.0-sources.jar.asc
+✅  compose-highlight-0.12.0-javadoc.jar
+✅  compose-highlight-0.12.0-javadoc.jar.asc
+── Result: 8 passed, 0 failed
+```
+
+### Step 3 — Publish
+
+Once the dry run is green:
+
+1. Go to **Actions → Publish to Maven Central**
+2. Click **Run workflow**
+3. Enter the tag (e.g. `0.12.0`)
+4. Leave **Dry run** unchecked
+5. Click **Run workflow**
+
+The workflow will:
+1. Verify the git tag exists
+2. Confirm the version isn't already on Maven Central
+3. Check out that exact tag
+4. Build, sign, and upload all artifacts
+5. Close and release the staging repository automatically
+
+The release typically appears on Maven Central within **10–30 minutes**.
+
+### Step 4 — Verify
+
+Check the release is live:
+```
+https://repo1.maven.org/maven2/dev/hossain/compose-highlight/<version>/
+```
+
+Or search on [central.sonatype.com](https://central.sonatype.com/artifact/dev.hossain/compose-highlight).
+
+---
+
+## Local dry run (without CI)
+
+You can also validate signing and artifact generation locally:
+
+```bash
+export SIGNING_KEY_ID=F17804D7
+export SIGNING_KEY="$(gpg --export-secret-keys --armor <FULL_FINGERPRINT>)"
+export SIGNING_PASSWORD=<your-passphrase>
+
+./gradlew :compose-highlight:publishToMavenLocal -PVERSION_NAME=0.12.0
+```
+
+Inspect the output:
+```bash
+ls -lh ~/.m2/repository/dev/hossain/compose-highlight/0.12.0/
+```
+
+---
+
+## Gradle publish tasks reference
+
+| Task | Description |
+|---|---|
+| `publishToMavenLocal` | Publishes to `~/.m2` — no upload, useful for local testing |
+| `publishToSonatype` | Uploads to Sonatype staging repository |
+| `closeSonatypeStagingRepository` | Closes the staging repo (triggers validation) |
+| `releaseAndCloseSonatypeStagingRepository` | Closes and releases in one step |
+| `closeAndReleaseSonatypeStagingRepository` | Full publish — used in CI |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,20 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.nexus.publish)
+}
+
+// Publishes to Sonatype's OSSRH Staging API compatibility layer, which forwards
+// to the Central Publisher Portal (central.sonatype.com). Credentials must be
+// Central Portal user tokens — NOT legacy OSSRH credentials.
+// Generate tokens at: https://central.sonatype.com/account
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
+            password = findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
+        }
+    }
 }

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.dokka)
     `maven-publish`
+    `signing`
 }
 
 android {
@@ -93,30 +94,63 @@ dokka {
     }
 }
 
-// JitPack requires a maven-publish publication named "release" that exposes the Android
-// library component. JitPack overrides groupId and version at build time, so only
-// artifactId needs to be meaningful here.
+// Maven Central requires a -javadoc.jar artifact. Kotlin projects commonly ship
+// Dokka HTML output as the javadoc artifact since there is no Javadoc equivalent.
+val dokkaHtmlJar by tasks.registering(Jar::class) {
+    dependsOn(tasks.named("dokkaGeneratePublicationHtml"))
+    from(rootDir.resolve("docs/api"))
+    archiveClassifier.set("javadoc")
+}
+
+// Maven Central publishing. JitPack also uses this block — it overrides groupId and version
+// at build time from the git tag, so both registries are served from the same publication.
+// Repository config lives in root build.gradle.kts (nexusPublishing block).
 afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "com.github.hossain-khan"
-                artifactId = "android-compose-highlight"
-                version = "0.11.0"
+                artifact(tasks["dokkaHtmlJar"])
+                groupId    = "dev.hossain"
+                artifactId = "compose-highlight"
+                version    = findProperty("VERSION_NAME") as String? ?: "0.11.0"
 
                 pom {
-                    name.set("compose-highlight")
+                    name.set("Android Compose Syntax Highlight")
                     description.set("Jetpack Compose syntax highlighting powered by Highlight.js")
                     url.set("https://github.com/hossain-khan/android-compose-highlight")
+                    inceptionYear.set("2025")
+
                     licenses {
                         license {
                             name.set("MIT License")
                             url.set("https://opensource.org/licenses/MIT")
                         }
                     }
+                    developers {
+                        developer {
+                            id.set("hossain-khan")
+                            name.set("Hossain Khan")
+                            email.set("hello@hossain.dev")
+                            url.set("https://github.com/hossain-khan")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:https://github.com/hossain-khan/android-compose-highlight.git")
+                        developerConnection.set("scm:git:ssh://github.com/hossain-khan/android-compose-highlight.git")
+                        url.set("https://github.com/hossain-khan/android-compose-highlight")
+                    }
                 }
             }
         }
+    }
+
+    signing {
+        val signingKeyId = findProperty("signing.keyId") as String? ?: System.getenv("SIGNING_KEY_ID")
+        val signingKey = findProperty("signing.key") as String? ?: System.getenv("SIGNING_KEY")
+        val signingPassword = findProperty("signing.password") as String? ?: System.getenv("SIGNING_PASSWORD")
+        isRequired = signingKeyId != null && signingKey != null
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        sign(publishing.publications["release"])
     }
 }

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -119,7 +119,7 @@ afterEvaluate {
                     name.set("Android Compose Syntax Highlight")
                     description.set("Jetpack Compose syntax highlighting powered by Highlight.js")
                     url.set("https://github.com/hossain-khan/android-compose-highlight")
-                    inceptionYear.set("2025")
+                    inceptionYear.set("2026")
 
                     licenses {
                         license {

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -113,7 +113,9 @@ afterEvaluate {
                 artifact(tasks["dokkaHtmlJar"])
                 groupId    = "dev.hossain"
                 artifactId = "compose-highlight"
-                version    = findProperty("VERSION_NAME") as String? ?: "0.11.0"
+                version    = requireNotNull(findProperty("VERSION_NAME") as String?) {
+                    "VERSION_NAME must be set in gradle.properties before publishing"
+                }
 
                 pom {
                     name.set("Android Compose Syntax Highlight")
@@ -149,10 +151,14 @@ afterEvaluate {
     }
 
     signing {
+        // SIGNING_KEY must be the ASCII-armored private key — the literal text starting with
+        // "-----BEGIN PGP PRIVATE KEY BLOCK-----". Export it with:
+        //   gpg --export-secret-keys --armor <FINGERPRINT>
+        // Store that output directly as the SIGNING_KEY secret (no base64 encoding).
         val signingKeyId = findProperty("signing.keyId") as String? ?: System.getenv("SIGNING_KEY_ID")
         val signingKey = findProperty("signing.key") as String? ?: System.getenv("SIGNING_KEY")
         val signingPassword = findProperty("signing.password") as String? ?: System.getenv("SIGNING_PASSWORD")
-        isRequired = signingKeyId != null && signingKey != null
+        isRequired = signingKeyId != null && signingKey != null && signingPassword != null
         useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
         sign(publishing.publications["release"])
     }

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -132,7 +132,10 @@ afterEvaluate {
                             id.set("hossain-khan")
                             name.set("Hossain Khan")
                             email.set("hello@hossain.dev")
-                            url.set("https://github.com/hossain-khan")
+                            url.set("https://hossain.dev")
+                            organization.set("Independent")
+                            roles.add("developer")
+                            roles.add("maintainer")
                         }
                     }
                     scm {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+VERSION_NAME=0.11.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ jsoup = "1.22.2"
 junit = "4.13.2"
 kotlin = "2.3.21"
 kotlinter = "5.4.2"
+nexus-publish = "2.0.0"
 truth = "1.4.5"
 
 [libraries]
@@ -50,3 +51,4 @@ android-test = { id = "com.android.test", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }


### PR DESCRIPTION
## Summary

Migrates publishing from JitPack-only to also support **Maven Central** (central.sonatype.com) via the [gradle-nexus/publish-plugin](https://github.com/gradle-nexus/publish-plugin) v2.0.0.

> **JitPack continues to work** — it overrides groupId/version from the git tag at build time.

## Changes

### 🔴 Bug fixes (would have blocked Central publishing)
- **Wrong repository URLs** — replaced legacy `s01.oss.sonatype.org` OSSRH URLs (being sunset) with `ossrh-staging-api.central.sonatype.com` via the nexus plugin, compatible with the new Central Publisher Portal (`dev.hossain` namespace)
- **Broken SNAPSHOT/release URL check** — `version` was always resolving to project version `"unspecified"`, so it always used the release URL; nexus plugin now handles this automatically
- **Malformed SCM connection URL** — fixed missing `https://` prefix: `scm:git:github.com/...` → `scm:git:https://github.com/...`

### 🟡 Best-practice improvements
- **Javadoc JAR** — added `dokkaHtmlJar` task packaging Dokka HTML output as the `-javadoc.jar` artifact required by Maven Central
- **Signing guard** — `isRequired = signingKeyId != null` prevents local build failures when env vars aren't set
- **Version in `gradle.properties`** — `VERSION_NAME=0.11.0` replaces hardcoded string; single source of truth
- **Developer email** — added `hello@hossain.dev` to POM

## Required GitHub Secrets (for CI)

| Secret | Value |
|---|---|
| `SIGNING_KEY_ID` | Short GPG key ID (e.g. `F17804D7`) |
| `SIGNING_KEY` | Base64-encoded private key |
| `SIGNING_PASSWORD` | GPG key passphrase |
| `OSSRH_USERNAME` | Central Portal token username |
| `OSSRH_PASSWORD` | Central Portal token password |

## Publish command (CI)
```bash
./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
```

Closes #30