### PR TITLE
ci: fix dry-run validation to use dynamic artifact path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,22 +69,31 @@ jobs:
       - name: '[Dry Run] Validate artifacts'
         if: ${{ inputs.dry_run }}
         run: |
-          ARTIFACT_DIR="$HOME/.m2/repository/dev/hossain/compose-highlight/${{ inputs.tag }}"
           VERSION="${{ inputs.tag }}"
 
+          # Derive groupId and artifactId from the publication POM that Gradle just wrote,
+          # so this works regardless of which tag's build config was checked out.
+          POM_SEARCH=$(find "$HOME/.m2/repository" -name "*.pom" -path "*/${VERSION}/*" 2>/dev/null | head -1)
+          if [ -z "$POM_SEARCH" ]; then
+            echo "::error::No POM found under ~/.m2/repository for version ${VERSION}. publishToMavenLocal may have failed."
+            exit 1
+          fi
+
+          ARTIFACT_DIR=$(dirname "$POM_SEARCH")
+          ARTIFACT_ID=$(basename "$POM_SEARCH" "-${VERSION}.pom")
           echo "── Artifact directory: $ARTIFACT_DIR"
           ls -lh "$ARTIFACT_DIR"
           echo ""
 
           EXPECTED=(
-            "compose-highlight-${VERSION}.aar"
-            "compose-highlight-${VERSION}.aar.asc"
-            "compose-highlight-${VERSION}.pom"
-            "compose-highlight-${VERSION}.pom.asc"
-            "compose-highlight-${VERSION}-sources.jar"
-            "compose-highlight-${VERSION}-sources.jar.asc"
-            "compose-highlight-${VERSION}-javadoc.jar"
-            "compose-highlight-${VERSION}-javadoc.jar.asc"
+            "${ARTIFACT_ID}-${VERSION}.aar"
+            "${ARTIFACT_ID}-${VERSION}.aar.asc"
+            "${ARTIFACT_ID}-${VERSION}.pom"
+            "${ARTIFACT_ID}-${VERSION}.pom.asc"
+            "${ARTIFACT_ID}-${VERSION}-sources.jar"
+            "${ARTIFACT_ID}-${VERSION}-sources.jar.asc"
+            "${ARTIFACT_ID}-${VERSION}-javadoc.jar"
+            "${ARTIFACT_ID}-${VERSION}-javadoc.jar.asc"
           )
 
           PASS=0


### PR DESCRIPTION
## Problem

The dry-run validation step hardcoded the Maven Local path as `dev/hossain/compose-highlight/<version>/`, which breaks when running against tag `0.11.0` (created before the Maven Central publishing migration). That tag's `build.gradle.kts` uses the old JitPack coordinates (`com.github.hossain-khan:android-compose-highlight`), so artifacts are published to a completely different path — causing the `ls` to fail with "No such file or directory".

## Fix

Instead of hardcoding the path, find the POM file that `publishToMavenLocal` just wrote and derive the artifact directory and artifactId dynamically:

```bash
POM_SEARCH=$(find "~/.m2/repository" -name "*.pom" -path "*/<version>/*" | head -1)
ARTIFACT_DIR=$(dirname "$POM_SEARCH")
ARTIFACT_ID=$(basename "$POM_SEARCH" "-<version>.pom")
```

This works correctly for both:
- Old tags (e.g. `0.11.0`) → `com/github/hossain-khan/android-compose-highlight/`
- New tags (e.g. `0.12.0`+) → `dev/hossain/compose-highlight/`