### PR TITLE
build: migrate to vanniktech/gradle-maven-publish-plugin for Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,11 +60,11 @@ jobs:
           ./gradlew :compose-highlight:publishToMavenLocal \
             -PVERSION_NAME=${{ inputs.tag }}
         env:
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           # Must be ASCII-armored key text (-----BEGIN PGP PRIVATE KEY BLOCK-----)
           # Export with: gpg --export-secret-keys --armor <FINGERPRINT>
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 
       - name: '[Dry Run] Validate artifacts'
         if: ${{ inputs.dry_run }}
@@ -122,11 +122,11 @@ jobs:
       - name: Publish and release to Maven Central
         if: ${{ !inputs.dry_run }}
         run: |
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+          ./gradlew publishAllPublicationsToMavenCentralRepository \
             -PVERSION_NAME=${{ inputs.tag }}
         env:
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,11 +1,6 @@
 # Publishing Guide
 
-This library is distributed through two channels:
-
-| Channel | Coordinates | How it works |
-|---|---|---|
-| **Maven Central** | `dev.hossain:compose-highlight:<version>` | Primary channel — published via GitHub Actions |
-| **JitPack** | `com.github.hossain-khan:android-compose-highlight:<version>` | Auto-built from git tags; no action required |
+This library is distributed through **Maven Central** with coordinates `dev.hossain:compose-highlight:<version>`.
 
 ---
 
@@ -56,6 +51,8 @@ Add the following secrets in **Settings → Secrets and variables → Actions**:
 | `SIGNING_PASSWORD` | Passphrase used when generating the key |
 | `OSSRH_USERNAME` | Central Portal token username |
 | `OSSRH_PASSWORD` | Central Portal token password |
+
+The workflow maps these to `ORG_GRADLE_PROJECT_*` environment variables that the vanniktech plugin reads automatically.
 
 ---
 
@@ -138,9 +135,9 @@ Or search on [central.sonatype.com](https://central.sonatype.com/artifact/dev.ho
 You can also validate signing and artifact generation locally:
 
 ```bash
-export SIGNING_KEY_ID=<YOUR_KEY_ID>
-export SIGNING_KEY="$(gpg --export-secret-keys --armor <FULL_FINGERPRINT>)"
-export SIGNING_PASSWORD=<your-passphrase>
+export ORG_GRADLE_PROJECT_signingInMemoryKeyId=<YOUR_KEY_ID>
+export ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --export-secret-keys --armor <FULL_FINGERPRINT>)"
+export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=<your-passphrase>
 
 ./gradlew :compose-highlight:publishToMavenLocal -PVERSION_NAME=0.12.0
 ```
@@ -157,7 +154,5 @@ ls -lh ~/.m2/repository/dev/hossain/compose-highlight/0.12.0/
 | Task | Description |
 |---|---|
 | `publishToMavenLocal` | Publishes to `~/.m2` — no upload, useful for local testing |
-| `publishToSonatype` | Uploads to Sonatype staging repository |
-| `closeSonatypeStagingRepository` | Closes the staging repo (triggers validation) |
+| `publishAllPublicationsToMavenCentralRepository` | Uploads and releases to Maven Central (used in CI) |
 | `releaseSonatypeStagingRepository` | Releases (publishes) a closed staging repo |
-| `closeAndReleaseSonatypeStagingRepository` | Full publish — used in CI |

--- a/README.md
+++ b/README.md
@@ -49,27 +49,15 @@ https://github.com/user-attachments/assets/10617b72-9b7c-413b-92b5-a939a34ad6af
 
 ## Setup
 
-[![](https://jitpack.io/v/hossain-khan/android-compose-highlight.svg)](https://jitpack.io/#hossain-khan/android-compose-highlight)
-
-Add JitPack to your root `settings.gradle.kts`:
-
-```kotlin
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
-}
-```
-
-Then add the dependency in your module's `build.gradle.kts`:
+Add the dependency in your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.hossain-khan:android-compose-highlight:0.12.0")
+    implementation("dev.hossain:compose-highlight:0.12.0")
 }
 ```
+
+`mavenCentral()` is included in the default Android project template, so no extra repository setup is needed.
 
 The library requires `minSdk = 24`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,20 +5,5 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka) apply false
-    alias(libs.plugins.nexus.publish)
-}
-
-// Publishes to Sonatype's OSSRH Staging API compatibility layer, which forwards
-// to the Central Publisher Portal (central.sonatype.com). Credentials must be
-// Central Portal user tokens — NOT legacy OSSRH credentials.
-// Generate tokens at: https://central.sonatype.com/account
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-            username = findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
-            password = findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
-        }
-    }
+    alias(libs.plugins.maven.publish) apply false
 }

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -3,8 +3,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.dokka)
-    `maven-publish`
-    `signing`
+    alias(libs.plugins.maven.publish)
 }
 
 android {
@@ -38,13 +37,6 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-
-    // Expose the release variant as a Maven component for JitPack / maven-publish.
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
         }
     }
 }
@@ -94,72 +86,51 @@ dokka {
     }
 }
 
-// Maven Central requires a -javadoc.jar artifact. Kotlin projects commonly ship
-// Dokka HTML output as the javadoc artifact since there is no Javadoc equivalent.
-val dokkaHtmlJar by tasks.registering(Jar::class) {
-    dependsOn(tasks.named("dokkaGeneratePublicationHtml"))
-    from(rootDir.resolve("docs/api"))
-    archiveClassifier.set("javadoc")
-}
+// Maven Central publishing via vanniktech/gradle-maven-publish-plugin.
+// Credentials are read from ORG_GRADLE_PROJECT_* environment variables (set in CI).
+// Signing credentials: ORG_GRADLE_PROJECT_signingInMemoryKeyId,
+//   ORG_GRADLE_PROJECT_signingInMemoryKey (ASCII-armored, full -----BEGIN block-----),
+//   ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
+// Maven Central credentials: ORG_GRADLE_PROJECT_mavenCentralUsername,
+//   ORG_GRADLE_PROJECT_mavenCentralPassword (Central Portal user token)
+mavenPublishing {
+    signAllPublications()
 
-// Maven Central publishing. JitPack also uses this block — it overrides groupId and version
-// at build time from the git tag, so both registries are served from the same publication.
-// Repository config lives in root build.gradle.kts (nexusPublishing block).
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                artifact(tasks["dokkaHtmlJar"])
-                groupId    = "dev.hossain"
-                artifactId = "compose-highlight"
-                version    = requireNotNull(findProperty("VERSION_NAME") as String?) {
-                    "VERSION_NAME must be set in gradle.properties before publishing"
-                }
+    coordinates(
+        groupId    = "dev.hossain",
+        artifactId = "compose-highlight",
+        version    = requireNotNull(findProperty("VERSION_NAME") as String?) {
+            "VERSION_NAME must be set in gradle.properties before publishing"
+        },
+    )
 
-                pom {
-                    name.set("Android Compose Syntax Highlight")
-                    description.set("Jetpack Compose syntax highlighting powered by Highlight.js")
-                    url.set("https://github.com/hossain-khan/android-compose-highlight")
-                    inceptionYear.set("2026")
+    pom {
+        name.set("Android Compose Syntax Highlight")
+        description.set("Jetpack Compose syntax highlighting powered by Highlight.js")
+        url.set("https://github.com/hossain-khan/android-compose-highlight")
+        inceptionYear.set("2026")
 
-                    licenses {
-                        license {
-                            name.set("MIT License")
-                            url.set("https://opensource.org/licenses/MIT")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("hossain-khan")
-                            name.set("Hossain Khan")
-                            email.set("hello@hossain.dev")
-                            url.set("https://hossain.dev")
-                            organization.set("Independent")
-                            roles.add("developer")
-                            roles.add("maintainer")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:https://github.com/hossain-khan/android-compose-highlight.git")
-                        developerConnection.set("scm:git:ssh://github.com/hossain-khan/android-compose-highlight.git")
-                        url.set("https://github.com/hossain-khan/android-compose-highlight")
-                    }
-                }
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
-    }
-
-    signing {
-        // SIGNING_KEY must be the ASCII-armored private key — the literal text starting with
-        // "-----BEGIN PGP PRIVATE KEY BLOCK-----". Export it with:
-        //   gpg --export-secret-keys --armor <FINGERPRINT>
-        // Store that output directly as the SIGNING_KEY secret (no base64 encoding).
-        val signingKeyId = findProperty("signing.keyId") as String? ?: System.getenv("SIGNING_KEY_ID")
-        val signingKey = findProperty("signing.key") as String? ?: System.getenv("SIGNING_KEY")
-        val signingPassword = findProperty("signing.password") as String? ?: System.getenv("SIGNING_PASSWORD")
-        isRequired = signingKeyId != null && signingKey != null && signingPassword != null
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-        sign(publishing.publications["release"])
+        developers {
+            developer {
+                id.set("hossain-khan")
+                name.set("Hossain Khan")
+                email.set("hello@hossain.dev")
+                url.set("https://hossain.dev")
+                organization.set("Independent")
+                roles.add("developer")
+                roles.add("maintainer")
+            }
+        }
+        scm {
+            connection.set("scm:git:https://github.com/hossain-khan/android-compose-highlight.git")
+            developerConnection.set("scm:git:ssh://github.com/hossain-khan/android-compose-highlight.git")
+            url.set("https://github.com/hossain-khan/android-compose-highlight")
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,8 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 VERSION_NAME=0.12.0
+# vanniktech/gradle-maven-publish-plugin configuration
+# SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
+# mavenCentralAutomaticPublishing: auto-release after upload without manual close step
+SONATYPE_HOST=CENTRAL_PORTAL
+mavenCentralAutomaticPublishing=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ jsoup = "1.22.2"
 junit = "4.13.2"
 kotlin = "2.3.21"
 kotlinter = "5.4.2"
-nexus-publish = "2.0.0"
+vanniktech-publish = "0.36.0"
 truth = "1.4.5"
 
 [libraries]
@@ -51,4 +51,4 @@ android-test = { id = "com.android.test", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
-nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-publish" }


### PR DESCRIPTION
## Problem
The previous setup used `gradle-nexus/publish-plugin` which relies on legacy OSSRH staging profiles. New Central Portal accounts don't have staging profiles, causing:
```
Failed to find staging profile for package group:
```

## Solution
Migrate to [`com.vanniktech:gradle-maven-publish-plugin` 0.36.0](https://github.com/vanniktech/gradle-maven-publish-plugin) which natively supports the new Sonatype Central Portal API via bundle upload.

## Changes
- `libs.versions.toml`: `nexus-publish` → `vanniktech-publish 0.36.0`
- Root `build.gradle.kts`: remove `nexusPublishing` block, add vanniktech plugin
- `compose-highlight/build.gradle.kts`: replace `maven-publish`/`signing` plugins and `afterEvaluate` block with clean `mavenPublishing {}` DSL (same POM metadata)
- `gradle.properties`: add `SONATYPE_HOST=CENTRAL_PORTAL` and `mavenCentralAutomaticPublishing=true`
- `publish.yml`: update env vars to `ORG_GRADLE_PROJECT_*` naming; update publish command to `publishAllPublicationsToMavenCentralRepository`
- `README.md`: replace JitPack setup with Maven Central (no extra repo config needed)
- `PUBLISHING.md`: remove JitPack, update credential env var names and Gradle task reference

## Verified
- ✅ `formatKotlin` passes
- ✅ `:compose-highlight:assembleDebug` passes
- ✅ `:sample:assembleDebug` passes
- ✅ `:compose-highlight:test` passes