### PR TITLE
chore: Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-13
+
 ### Added
 - **LeakCanary integrated into the sample app** — `com.squareup.leakcanary:leakcanary-android:2.14`
   is added as a `debugImplementation` dependency in `sample/build.gradle.kts`. LeakCanary

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the dependency in your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.13.0")
+    implementation("dev.hossain:compose-highlight:0.14.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.13.0
+VERSION_NAME=0.14.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 13
-        versionName = "0.13.0"
+        versionCode = 14
+        versionName = "0.14.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Release 0.14.0

### Changes
- ✅ Bumped VERSION_NAME to 0.14.0
- ✅ Updated CHANGELOG.md with release date 2026-05-13
- ✅ Updated sample app versionName to 0.14.0 and versionCode to 14
- ✅ Updated README.md dependency snippet

### Next Steps
After merge:
1. Create git tag: `git tag 0.14.0 && git push origin 0.14.0`
2. Trigger "Publish to Maven Central" workflow with tag `0.14.0`
3. Optional: Run with dry-run first to validate artifacts