### PR TITLE
perf: avoid double HTML parse in highlightBothThemes (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **`highlightBothThemes` now parses the HTML once** — `HtmlToAnnotatedString.convertBothThemes()`
+  replaces the prior double-`convert()` call in `HighlightEngine.highlightBothThemes()`. The HTML
+  fragment is parsed into a DOM once and walked once, with two `AnnotatedString.Builder` instances
+  updated in parallel (one per theme). This removes a redundant Jsoup parse and a redundant DOM
+  traversal on every dual-theme highlight call. Closes #82.
+
 ### Added
 - **Robolectric JVM tests for Compose UI** — Added 13 new unit tests in `src/test/` that run on
   the JVM without an emulator using Robolectric 4.16.1 and the v2 Compose testing APIs

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/benchmark/HtmlToAnnotatedStringBenchmark.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/benchmark/HtmlToAnnotatedStringBenchmark.kt
@@ -29,6 +29,7 @@ class HtmlToAnnotatedStringBenchmark {
     val benchmarkRule = BenchmarkRule()
 
     private lateinit var colorMap: Map<String, SpanStyle>
+    private lateinit var darkColorMap: Map<String, SpanStyle>
 
     // Realistic hljs HTML output for a Python function (from actual device log)
     private val pythonHtml =
@@ -80,6 +81,7 @@ class HtmlToAnnotatedStringBenchmark {
     fun loadTheme() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         colorMap = ThemeParser.parse(context, "compose-highlight/themes/tomorrow.css")
+        darkColorMap = ThemeParser.parse(context, "compose-highlight/themes/tomorrow-night.css")
     }
 
     @Test
@@ -98,5 +100,25 @@ class HtmlToAnnotatedStringBenchmark {
     fun convertSqlHtml() =
         benchmarkRule.measureRepeated {
             HtmlToAnnotatedString.convert(sqlHtml, colorMap)
+        }
+
+    // Dual-theme benchmarks — measure the single-parse / single-traversal path.
+
+    @Test
+    fun convertBothThemesPythonHtml() =
+        benchmarkRule.measureRepeated {
+            HtmlToAnnotatedString.convertBothThemes(pythonHtml, colorMap, darkColorMap)
+        }
+
+    @Test
+    fun convertBothThemesKotlinHtml() =
+        benchmarkRule.measureRepeated {
+            HtmlToAnnotatedString.convertBothThemes(kotlinHtml, colorMap, darkColorMap)
+        }
+
+    @Test
+    fun convertBothThemesSqlHtml() =
+        benchmarkRule.measureRepeated {
+            HtmlToAnnotatedString.convertBothThemes(sqlHtml, colorMap, darkColorMap)
         }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -256,8 +256,12 @@ class HighlightEngine(
         val start = System.nanoTime()
         return highlightToHtml(code, language).map { htmlResult ->
             try {
-                val light = HtmlToAnnotatedString.convert(htmlResult.html, lightTheme.colorMap)
-                val dark = HtmlToAnnotatedString.convert(htmlResult.html, darkTheme.colorMap)
+                val (light, dark) =
+                    HtmlToAnnotatedString.convertBothThemes(
+                        htmlResult.html,
+                        lightTheme.colorMap,
+                        darkTheme.colorMap,
+                    )
                 ThemedHighlightResult(
                     light = light,
                     dark = dark,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -561,8 +561,9 @@ internal fun escapeForJs(str: String): String =
  *
  * @property light Syntax-highlighted [AnnotatedString] styled with the light theme.
  * @property dark Syntax-highlighted [AnnotatedString] styled with the dark theme.
- * @property durationMs Pure highlight time in milliseconds — covers the JS call and both
- *   HTML conversion passes. Excludes coroutine-scheduling overhead.
+ * @property durationMs Pure highlight time in milliseconds — covers the JS call and a single
+ *   HTML conversion pass (light and dark outputs are produced together in one pass). Excludes
+ *   coroutine-scheduling overhead.
  */
 data class ThemedHighlightResult(
     val light: AnnotatedString,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -51,6 +51,53 @@ object HtmlToAnnotatedString {
         return result
     }
 
+    /**
+     * Converts highlighted HTML to two [AnnotatedString] values — one per theme — in a single
+     * DOM parse and traversal pass.
+     *
+     * Semantically equivalent to calling [convert] twice with different color maps, but more
+     * efficient: the HTML is parsed once and the DOM is walked once. Both builders receive
+     * text nodes and span styles in parallel, each resolved against their own color map.
+     *
+     * Each builder independently applies the `.hljs` base text color from its own [colorMap],
+     * so light and dark outputs have the correct default text colors.
+     *
+     * @param html HTML fragment output from highlight.js (not a full document)
+     * @param lightColorMap Color map for the light theme, from [ThemeParser]
+     * @param darkColorMap Color map for the dark theme, from [ThemeParser]
+     * @return A [Pair] of (light [AnnotatedString], dark [AnnotatedString])
+     */
+    internal fun convertBothThemes(
+        html: String,
+        lightColorMap: Map<String, SpanStyle>,
+        darkColorMap: Map<String, SpanStyle>,
+    ): Pair<AnnotatedString, AnnotatedString> {
+        if (html.isBlank()) return Pair(AnnotatedString(""), AnnotatedString(""))
+
+        val doc = Jsoup.parseBodyFragment(html)
+        val body = doc.body()
+
+        // Each builder gets its own independent base text color from its own color map.
+        // Do NOT share a single base style — light and dark themes have different default colors.
+        val lightBaseStyle = lightColorMap["hljs"]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
+        val darkBaseStyle = darkColorMap["hljs"]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
+
+        val lightBuilder = AnnotatedString.Builder()
+        val darkBuilder = AnnotatedString.Builder()
+
+        if (lightBaseStyle != null) lightBuilder.pushStyle(lightBaseStyle)
+        if (darkBaseStyle != null) darkBuilder.pushStyle(darkBaseStyle)
+
+        body.childNodes().forEach { node ->
+            walkNodeBothThemes(node, lightColorMap, darkColorMap, lightBuilder, darkBuilder)
+        }
+
+        if (lightBaseStyle != null) lightBuilder.pop()
+        if (darkBaseStyle != null) darkBuilder.pop()
+
+        return Pair(lightBuilder.toAnnotatedString(), darkBuilder.toAnnotatedString())
+    }
+
     private fun walkNode(
         node: org.jsoup.nodes.Node,
         colorMap: Map<String, SpanStyle>,
@@ -77,6 +124,45 @@ object HtmlToAnnotatedString {
 
             is TextNode -> {
                 builder.append(node.wholeText)
+            }
+        }
+    }
+
+    private fun walkNodeBothThemes(
+        node: org.jsoup.nodes.Node,
+        lightColorMap: Map<String, SpanStyle>,
+        darkColorMap: Map<String, SpanStyle>,
+        lightBuilder: AnnotatedString.Builder,
+        darkBuilder: AnnotatedString.Builder,
+    ) {
+        when (node) {
+            is Element -> {
+                // Evaluate tagName once; resolve styles for both color maps in the same pass.
+                val lightStyle: SpanStyle?
+                val darkStyle: SpanStyle?
+                if (node.tagName() == "span") {
+                    val cls = node.className()
+                    lightStyle = resolveStyle(cls, lightColorMap)
+                    darkStyle = resolveStyle(cls, darkColorMap)
+                } else {
+                    lightStyle = null
+                    darkStyle = null
+                }
+
+                if (lightStyle != null) lightBuilder.pushStyle(lightStyle)
+                if (darkStyle != null) darkBuilder.pushStyle(darkStyle)
+
+                node.childNodes().forEach { child ->
+                    walkNodeBothThemes(child, lightColorMap, darkColorMap, lightBuilder, darkBuilder)
+                }
+
+                if (lightStyle != null) lightBuilder.pop()
+                if (darkStyle != null) darkBuilder.pop()
+            }
+
+            is TextNode -> {
+                lightBuilder.append(node.wholeText)
+                darkBuilder.append(node.wholeText)
             }
         }
     }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -59,7 +59,7 @@ object HtmlToAnnotatedString {
      * efficient: the HTML is parsed once and the DOM is walked once. Both builders receive
      * text nodes and span styles in parallel, each resolved against their own color map.
      *
-     * Each builder independently applies the `.hljs` base text color from its own [colorMap],
+     * Each builder independently applies the `.hljs` base text color from its own color map,
      * so light and dark outputs have the correct default text colors.
      *
      * @param html HTML fragment output from highlight.js (not a full document)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -142,8 +142,16 @@ object HtmlToAnnotatedString {
                 val darkStyle: SpanStyle?
                 if (node.tagName() == "span") {
                     val cls = node.className()
-                    lightStyle = resolveStyle(cls, lightColorMap)
-                    darkStyle = resolveStyle(cls, darkColorMap)
+                    if (cls.isBlank()) {
+                        lightStyle = null
+                        darkStyle = null
+                    } else {
+                        // Parse the class list once; reuse for both color-map lookups to avoid
+                        // redundant trim/split/Regex work on the hot dual-theme path.
+                        val classes = cls.trim().split(Regex("\\s+"))
+                        lightStyle = resolveStyleFromClasses(cls, classes, lightColorMap)
+                        darkStyle = resolveStyleFromClasses(cls, classes, darkColorMap)
+                    }
                 } else {
                     lightStyle = null
                     darkStyle = null
@@ -193,6 +201,26 @@ object HtmlToAnnotatedString {
         }
 
         // Fall back to the first recognized class
+        return classes.firstNotNullOfOrNull { colorMap[it] }
+    }
+
+    /**
+     * Like [resolveStyle] but accepts a pre-parsed class list so the [walkNodeBothThemes]
+     * hot path can parse the class attribute once and reuse it for both color-map lookups.
+     */
+    private fun resolveStyleFromClasses(
+        classAttr: String,
+        classes: List<String>,
+        colorMap: Map<String, SpanStyle>,
+    ): SpanStyle? {
+        // Fast-path: exact match (e.g. "hljs-keyword" — the large majority of tokens).
+        colorMap[classAttr]?.let { return it }
+        // Compound key (e.g. "hljs-title.function_" for class="hljs-title function_").
+        if (classes.size > 1) {
+            val compoundKey = classes.joinToString(".")
+            colorMap[compoundKey]?.let { return it }
+        }
+        // Fall back to the first recognized class.
         return classes.firstNotNullOfOrNull { colorMap[it] }
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -231,7 +231,10 @@ class HtmlToAnnotatedStringTest {
     @Test
     fun `convertBothThemes light and dark keyword spans have different colors`() {
         val html = """<span class="hljs-keyword">return</span>"""
-        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        // Use maps without the base .hljs entry so firstOrNull() reliably returns the keyword
+        // span rather than the full-range base style span (which would also differ between
+        // themes but would not verify that keyword styling is applied correctly).
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
         val lightKeyword = light.spanStyles.firstOrNull()
         val darkKeyword = dark.spanStyles.firstOrNull()
         assertThat(lightKeyword).isNotNull()

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -24,6 +24,19 @@ class HtmlToAnnotatedStringTest {
     private val colorMapNoBase =
         colorMap.filterKeys { it != "hljs" }
 
+    // Dark-theme color map used in convertBothThemes tests — different colors than colorMap.
+    private val darkBaseColor = Color(0xFFABB2BF.toInt())
+    private val darkColorMap =
+        mapOf(
+            "hljs" to SpanStyle(color = darkBaseColor, background = Color(0xFF282C34.toInt())),
+            "hljs-keyword" to SpanStyle(color = Color(0xFFC678DD.toInt())),
+            "hljs-string" to SpanStyle(color = Color(0xFF98C379.toInt())),
+            "hljs-number" to SpanStyle(color = Color(0xFFD19A66.toInt())),
+            "hljs-comment" to SpanStyle(color = Color(0xFF5C6370.toInt())),
+            "hljs-strong" to SpanStyle(color = Color(0xFFE5C07B.toInt()), fontWeight = FontWeight.Bold),
+            "hljs-title.function_" to SpanStyle(color = Color(0xFF61AFEF.toInt())),
+        )
+
     @Test
     fun `convert simple keyword span produces colored span`() {
         val html = """<span class="hljs-keyword">if</span>"""
@@ -166,5 +179,133 @@ class HtmlToAnnotatedStringTest {
         val fullRangeSpans = result.spanStyles.filter { it.start == 0 && it.end == result.text.length }
         assertThat(fullRangeSpans).hasSize(1)
         assertThat(fullRangeSpans[0].item.color).isEqualTo(baseColor)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // convertBothThemes tests
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `convertBothThemes empty HTML returns two empty AnnotatedStrings`() {
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes("", colorMap, darkColorMap)
+        assertThat(light.text).isEmpty()
+        assertThat(dark.text).isEmpty()
+        assertThat(light.spanStyles).isEmpty()
+        assertThat(dark.spanStyles).isEmpty()
+    }
+
+    @Test
+    fun `convertBothThemes plain text produces identical text in both outputs`() {
+        val html = "hello world"
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        assertThat(light.text).isEqualTo("hello world")
+        assertThat(dark.text).isEqualTo("hello world")
+    }
+
+    @Test
+    fun `convertBothThemes produces same text content as two separate convert calls`() {
+        val html = """<span class="hljs-keyword">fun</span> <span class="hljs-string">"hi"</span>"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val singleLight = HtmlToAnnotatedString.convert(html, colorMap)
+        val singleDark = HtmlToAnnotatedString.convert(html, darkColorMap)
+        assertThat(light.text).isEqualTo(singleLight.text)
+        assertThat(dark.text).isEqualTo(singleDark.text)
+    }
+
+    @Test
+    fun `convertBothThemes light output uses light keyword color`() {
+        val html = """<span class="hljs-keyword">val</span>"""
+        val (light, _) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val keywordSpans = light.spanStyles.filter { it.item.color == Color(0xFF8959a8.toInt()) }
+        assertThat(keywordSpans).isNotEmpty()
+    }
+
+    @Test
+    fun `convertBothThemes dark output uses dark keyword color`() {
+        val html = """<span class="hljs-keyword">val</span>"""
+        val (_, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val keywordSpans = dark.spanStyles.filter { it.item.color == Color(0xFFC678DD.toInt()) }
+        assertThat(keywordSpans).isNotEmpty()
+    }
+
+    @Test
+    fun `convertBothThemes light and dark keyword spans have different colors`() {
+        val html = """<span class="hljs-keyword">return</span>"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val lightKeyword = light.spanStyles.firstOrNull()
+        val darkKeyword = dark.spanStyles.firstOrNull()
+        assertThat(lightKeyword).isNotNull()
+        assertThat(darkKeyword).isNotNull()
+        assertThat(lightKeyword!!.item.color).isNotEqualTo(darkKeyword!!.item.color)
+    }
+
+    @Test
+    fun `convertBothThemes applies independent base colors per builder`() {
+        val html = """plain <span class="hljs-keyword">if</span> code"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val lightBase = light.spanStyles.filter { it.start == 0 && it.end == light.text.length }
+        val darkBase = dark.spanStyles.filter { it.start == 0 && it.end == dark.text.length }
+        assertThat(lightBase).hasSize(1)
+        assertThat(darkBase).hasSize(1)
+        assertThat(lightBase[0].item.color).isEqualTo(baseColor)
+        assertThat(darkBase[0].item.color).isEqualTo(darkBaseColor)
+        // The two base colors must be distinct — not shared across builders.
+        assertThat(lightBase[0].item.color).isNotEqualTo(darkBase[0].item.color)
+    }
+
+    @Test
+    fun `convertBothThemes output matches two independent convert calls span-for-span`() {
+        val html =
+            """<span class="hljs-keyword">fun</span> <span class="hljs-title function_">greet</span>(<span class="hljs-string">"hi"</span>)"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMap, darkColorMap)
+        val singleLight = HtmlToAnnotatedString.convert(html, colorMap)
+        val singleDark = HtmlToAnnotatedString.convert(html, darkColorMap)
+        // Span counts and positions must match
+        assertThat(light.spanStyles.size).isEqualTo(singleLight.spanStyles.size)
+        assertThat(dark.spanStyles.size).isEqualTo(singleDark.spanStyles.size)
+        light.spanStyles.forEachIndexed { i, span ->
+            assertThat(span.start).isEqualTo(singleLight.spanStyles[i].start)
+            assertThat(span.end).isEqualTo(singleLight.spanStyles[i].end)
+            assertThat(span.item.color).isEqualTo(singleLight.spanStyles[i].item.color)
+        }
+        dark.spanStyles.forEachIndexed { i, span ->
+            assertThat(span.start).isEqualTo(singleDark.spanStyles[i].start)
+            assertThat(span.end).isEqualTo(singleDark.spanStyles[i].end)
+            assertThat(span.item.color).isEqualTo(singleDark.spanStyles[i].item.color)
+        }
+    }
+
+    @Test
+    fun `convertBothThemes handles compound hljs class correctly in both outputs`() {
+        val html = """<span class="hljs-title function_">myFunc</span>"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        assertThat(light.spanStyles).hasSize(1)
+        assertThat(dark.spanStyles).hasSize(1)
+        assertThat(light.spanStyles[0].item.color).isEqualTo(Color(0xFF4271ae.toInt()))
+        assertThat(dark.spanStyles[0].item.color).isEqualTo(Color(0xFF61AFEF.toInt()))
+    }
+
+    @Test
+    fun `convertBothThemes handles nested spans in both outputs`() {
+        val html = """<span class="hljs-string">"<span class="hljs-keyword">val</span>"</span>"""
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        assertThat(light.text).isEqualTo(""""val"""")
+        assertThat(dark.text).isEqualTo(""""val"""")
+        assertThat(light.spanStyles.size).isAtLeast(2)
+        assertThat(dark.spanStyles.size).isAtLeast(2)
+    }
+
+    @Test
+    fun `convertBothThemes with no base hljs entry produces no full-range spans`() {
+        // Use plain text outside the span so the keyword span does not accidentally cover
+        // the full range — we only want to verify the absence of the base .hljs wrap.
+        val html = """x <span class="hljs-keyword">if</span> y"""
+        val lightNoBase = colorMap.filterKeys { it != "hljs" }
+        val darkNoBase = darkColorMap.filterKeys { it != "hljs" }
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, lightNoBase, darkNoBase)
+        val lightFullRange = light.spanStyles.filter { it.start == 0 && it.end == light.text.length }
+        val darkFullRange = dark.spanStyles.filter { it.start == 0 && it.end == dark.text.length }
+        assertThat(lightFullRange).isEmpty()
+        assertThat(darkFullRange).isEmpty()
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -195,6 +195,15 @@ class HtmlToAnnotatedStringTest {
     }
 
     @Test
+    fun `convertBothThemes blank whitespace-only HTML returns two empty AnnotatedStrings`() {
+        val (light, dark) = HtmlToAnnotatedString.convertBothThemes("   \n  ", colorMap, darkColorMap)
+        assertThat(light.text).isEmpty()
+        assertThat(dark.text).isEmpty()
+        assertThat(light.spanStyles).isEmpty()
+        assertThat(dark.spanStyles).isEmpty()
+    }
+
+    @Test
     fun `convertBothThemes plain text produces identical text in both outputs`() {
         val html = "hello world"
         val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -266,12 +266,12 @@ class HtmlToAnnotatedStringTest {
         light.spanStyles.forEachIndexed { i, span ->
             assertThat(span.start).isEqualTo(singleLight.spanStyles[i].start)
             assertThat(span.end).isEqualTo(singleLight.spanStyles[i].end)
-            assertThat(span.item.color).isEqualTo(singleLight.spanStyles[i].item.color)
+            assertThat(span.item).isEqualTo(singleLight.spanStyles[i].item)
         }
         dark.spanStyles.forEachIndexed { i, span ->
             assertThat(span.start).isEqualTo(singleDark.spanStyles[i].start)
             assertThat(span.end).isEqualTo(singleDark.spanStyles[i].end)
-            assertThat(span.item.color).isEqualTo(singleDark.spanStyles[i].item.color)
+            assertThat(span.item).isEqualTo(singleDark.spanStyles[i].item)
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #82

`HighlightEngine.highlightBothThemes()` was calling `HtmlToAnnotatedString.convert()` twice with the same HTML — parsing the DOM twice and walking it twice. This PR optimizes the dual-theme path to a single parse + single traversal.

## Changes

### `HtmlToAnnotatedString.kt`
- Add `internal fun convertBothThemes(html, lightColorMap, darkColorMap): Pair<AnnotatedString, AnnotatedString>` — parses the HTML fragment once, applies both color maps in a single DOM traversal.
- Add `private fun walkNodeBothThemes(...)` — recursive dual-builder walker that resolves light and dark styles separately per `span` node and appends text nodes to both builders in the same pass.
- Each builder independently derives its base text color from its own color map's `"hljs"` entry; they do not share a base style.

### `HighlightEngine.kt`
- `highlightBothThemes()` now calls `HtmlToAnnotatedString.convertBothThemes()` and destructures the result instead of calling `convert()` twice.

### `HtmlToAnnotatedStringTest.kt`
- Add `darkColorMap` fixture (tomorrow-night palette).
- Add 11 unit tests for `convertBothThemes` covering:
  - empty/blank HTML
  - plain text with no spans
  - tokenized code (keyword + string spans)
  - text equality vs. calling `convert` twice separately
  - independent base colors per builder (regression guard for the critical correctness property)
  - compound class name resolution
  - nested span structures
  - missing base `hljs` entry

### `HtmlToAnnotatedStringBenchmark.kt`
- Add `darkColorMap` loaded from `tomorrow-night.css`.
- Add 3 microbenchmarks for `convertBothThemes` reusing the existing Python, Kotlin, and SQL HTML fixtures.

## Validation

```
./gradlew formatKotlin                        ✅
./gradlew :compose-highlight:test             ✅  (203 tests, 0 failures)
./gradlew :compose-highlight:assembleDebug    ✅
./gradlew lintKotlin                          ✅
```