### PR TITLE
docs: clarify benchmark-grade measurement vs sample perf screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,20 @@ For full design details see [`docs/prd-compose-syntax-highlight.md`](docs/prd-co
 
 Microbenchmarks are included in `compose-highlight/src/androidTest/` using the [AndroidX Microbenchmark library](https://developer.android.com/topic/performance/benchmarking/microbenchmark-overview). They measure the three core pipeline stages on a real device.
 
+> [!IMPORTANT]
+> The `HighlightEngineBenchmark` class (and the other benchmark classes below) are the **authoritative** source for performance measurement. Use `connectedAndroidTest` results for regression detection and performance comparisons — not the sample app's built-in performance screen, which is exploratory and demo-oriented only (see [Sample App — Performance screen](sample/README.md#performance-screen)).
+>
+> Note: benchmarks are most reliable when run on a **physical device** in a release build. Debuggable builds (the default for `connectedAndroidTest`) have JIT and coverage overhead that inflates timings — treat debug-build numbers as relative comparisons, not absolute measurements.
+
 ### Run
 
 ```bash
+# Run all microbenchmarks (requires a connected physical device or emulator)
 ./gradlew :compose-highlight:connectedAndroidTest
+
+# Run only the HighlightEngineBenchmark class
+./gradlew :compose-highlight:connectedAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.hossain.highlight.benchmark.HighlightEngineBenchmark
 ```
 
 Results are printed in logcat under the `BENCHMARK` tag.

--- a/sample/README.md
+++ b/sample/README.md
@@ -65,5 +65,14 @@ See `SampleData.kt` → `loadThemePairs()` for a working example using the bundl
 
 ## Performance screen
 
-`PerfActivity` / `PerfScreen` measures how long it takes to highlight all language samples
-back-to-back. Launch it from the top-right toolbar icon in the main screen.
+`PerfActivity` / `PerfScreen` is an **exploratory, demo-oriented** tool that visually shows how long it takes to highlight all language samples back-to-back. Launch it from the top-right toolbar icon in the main screen.
+
+> [!WARNING]
+> The in-app performance screen is **not** a substitute for benchmark-grade measurement. It runs in a debug build without the release optimizations needed for reliable numbers, and results vary with device state and background load.
+>
+> For authoritative performance measurement and regression detection, use the AndroidX microbenchmarks in `compose-highlight/src/androidTest/` — specifically the `HighlightEngineBenchmark` class:
+> ```bash
+> ./gradlew :compose-highlight:connectedAndroidTest \
+>   -Pandroid.testInstrumentationRunnerArguments.class=dev.hossain.highlight.benchmark.HighlightEngineBenchmark
+> ```
+> See the [Benchmarks section in the root README](../README.md#benchmarks) for full details.


### PR DESCRIPTION
## Summary

Closes #80

Clarifies the distinction between the sample app's in-app performance screen (exploratory/demo-oriented) and the proper AndroidX microbenchmarks (`HighlightEngineBenchmark`) that should be used for authoritative performance measurement and regression detection.

## Changes

### `README.md` — Benchmarks section
- Added an `[!IMPORTANT]` callout naming `HighlightEngineBenchmark` as the authoritative measurement class
- Called out the sample perf screen as exploratory/demo-only with a cross-link to `sample/README.md`
- Documented debug-build caveats: JIT + coverage overhead inflates timings; treat debug numbers as relative comparisons, not absolute measurements
- Expanded the run example to include a class-filtered `connectedAndroidTest` command

### `sample/README.md` — Performance screen section
- Added an `[!WARNING]` callout explaining the screen is not benchmark-grade
- Pointed directly to `HighlightEngineBenchmark` with the exact Gradle command
- Cross-linked to the root README Benchmarks section for full details

## Validation
- `./gradlew lintKotlin` ✅
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug` ✅