### PR TITLE
release: 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.15.0] - 2026-05-14
 
 ### Changed
 - **`HighlightEngine.initialize()` now returns `Result<Unit>`** instead of throwing

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the [dependency](https://central.sonatype.com/artifact/dev.hossain/compose-h
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.14.0")
+    implementation("dev.hossain:compose-highlight:0.15.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.14.0
+VERSION_NAME=0.15.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.14.0"
+        versionCode = 15
+        versionName = "0.15.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Release 0.15.0

Bumps all version references from `0.14.0` to `0.15.0` in preparation for the Maven Central release.

### Changes
- `gradle.properties`: `VERSION_NAME` → `0.15.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.15.0] - 2026-05-14`
- `sample/build.gradle.kts`: `versionName` → `"0.15.0"`, `versionCode` → `15`
- `README.md`: dependency snippet → `0.15.0`

### What's included in this release

**Changed**
- `HighlightEngine.initialize()` now returns `Result<Unit>` instead of throwing
- `highlightBothThemes` now parses HTML once (single-pass, two builders)

**Added**
- Robolectric JVM tests for Compose UI (13 new tests, no emulator needed)

**Fixed**
- `HighlightTheme` context factories now normalize to `applicationContext` internally
- Sample app preserves top-level demo selections across recreation (`rememberSaveable`)
- `HighlightEngine.initialize()` correctly awaits WebView readiness via `isInitialized`
- `CancellationException` properly rethrown from `initialize()`

### Post-merge steps
1. Merge this PR into `main`
2. `git tag 0.15.0 && git push origin 0.15.0`
3. Run **dry-run** on GitHub Actions → Publish to Maven Central
4. If green, run the real publish