### PR TITLE
docs: fix KDoc code snippets across public API

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -48,37 +48,39 @@ import kotlin.coroutines.resumeWithException
  * ## Manual usage (e.g. ViewModel or background work)
  *
  * ```kotlin
- * val engine = HighlightEngine(context)
+ * val engine = HighlightEngine(context.applicationContext)
  *
- * // Optional: call initialize() to warm up the WebView before the first highlight.
- * // If skipped, the first call to highlight() will initialize it automatically.
- * engine.initialize().onFailure { /* handle WebViewInitFailed if needed */ }
+ * // Suspend calls must run inside a coroutine (e.g. viewModelScope.launch).
+ * viewModelScope.launch {
+ *     // Optional: warm up before first use to reduce first-call latency.
+ *     engine.initialize().onFailure { /* handle WebViewInitFailed if needed */ }
  *
- * val result = engine.highlight(
- *     code     = "val x = 42",
- *     language = "kotlin",
- *     theme    = HighlightTheme.atomOneDark(context),
- * )
- * result.onSuccess { highlighted ->
- *     display(highlighted.annotated)            // AnnotatedString
- *     log("spans: ${highlighted.spanCount}")    // 0 = unsupported language
- *     log("time:  ${highlighted.durationMs} ms")
+ *     val result = engine.highlight(
+ *         code     = "val x = 42",
+ *         language = "kotlin",
+ *         theme    = HighlightTheme.atomOneDark(context.applicationContext),
+ *     )
+ *     result.onSuccess { highlighted ->
+ *         display(highlighted.annotated)            // AnnotatedString
+ *         log("spans: ${highlighted.spanCount}")    // 0 = unsupported language
+ *         log("time:  ${highlighted.durationMs} ms")
+ *     }
  * }
  *
- * // Release resources when done
+ * // Release resources when done (e.g. in ViewModel.onCleared())
  * engine.destroy()
  * ```
  *
  * ## Highlight once, render in two themes
  *
  * ```kotlin
- * val themed = engine.highlightBothThemes(
+ * // Inside a coroutine (e.g. viewModelScope.launch or LaunchedEffect):
+ * engine.highlightBothThemes(
  *     code       = sourceCode,
  *     language   = "typescript",
- *     lightTheme = HighlightTheme.tomorrow(context),
- *     darkTheme  = HighlightTheme.tomorrowNight(context),
- * )
- * themed.onSuccess { result ->
+ *     lightTheme = HighlightTheme.tomorrow(context.applicationContext),
+ *     darkTheme  = HighlightTheme.tomorrowNight(context.applicationContext),
+ * ).onSuccess { result ->
  *     val display = if (isDark) result.dark else result.light
  * }
  * ```
@@ -197,7 +199,7 @@ class HighlightEngine(
      * engine.highlight(code, "kotlin", theme).onSuccess { result ->
      *     display(result.annotated)
      *     if (result.spanCount == 0) log("no tokens — language may be unsupported")
-     *     log("highlighted in \${result.durationMs} ms")
+     *     log("highlighted in ${result.durationMs} ms")
      * }
      * ```
      *
@@ -237,11 +239,12 @@ class HighlightEngine(
      * so theme switching after the call returns is instant — no extra WebView round-trip.
      *
      * ```kotlin
+     * // Inside a coroutine (e.g. viewModelScope.launch or LaunchedEffect):
      * engine.highlightBothThemes(
      *     code       = sourceCode,
      *     language   = "typescript",
-     *     lightTheme = HighlightTheme.tomorrow(context),
-     *     darkTheme  = HighlightTheme.tomorrowNight(context),
+     *     lightTheme = HighlightTheme.tomorrow(context.applicationContext),
+     *     darkTheme  = HighlightTheme.tomorrowNight(context.applicationContext),
      * ).onSuccess { result ->
      *     val display = if (isDark) result.dark else result.light
      * }
@@ -559,8 +562,8 @@ internal fun escapeForJs(str: String): String =
  * val result by rememberHighlightedCodeBothThemes(
  *     code       = code,
  *     language   = "kotlin",
- *     lightTheme = remember { HighlightTheme.tomorrow(context.applicationContext) },
- *     darkTheme  = remember { HighlightTheme.tomorrowNight(context.applicationContext) },
+ *     lightTheme = rememberTomorrowTheme(),
+ *     darkTheme  = rememberTomorrowNightTheme(),
  * )
  * val text = if (isDark) result?.dark else result?.light
  * Text(text = text ?: AnnotatedString(code))

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
@@ -90,8 +90,15 @@ fun rememberHighlightEngine(): HighlightEngine {
  * recomposition:
  *
  * ```kotlin
+ * val context = LocalContext.current
  * val theme = remember(context) { HighlightTheme.tomorrow(context.applicationContext) }
  * val highlighted by rememberHighlightedCode(code, "kotlin", theme)
+ * ```
+ *
+ * Or use the built-in convenience functions which handle this internally:
+ *
+ * ```kotlin
+ * val highlighted by rememberHighlightedCode(code, "kotlin", rememberTomorrowTheme())
  * ```
  *
  * For light/dark toggling without re-highlighting, prefer [rememberHighlightedCodeBothThemes].


### PR DESCRIPTION
## Summary

Fixes several inaccuracies in KDoc code snippets that would produce incorrect or misleading content in the Dokka-generated API docs.

## Changes

### `HighlightEngine.kt`

- **Class-level "Manual usage"**: `HighlightEngine(context)` → `HighlightEngine(context.applicationContext)`, same for `HighlightTheme.atomOneDark(context)`. Wrapped the suspend calls (`initialize()`, `highlight()`) in `viewModelScope.launch { }` with `engine.destroy()` outside the coroutine — the old snippet called suspend functions in a non-suspend context.
- **Class-level "Highlight once, render in two themes"**: `HighlightTheme.tomorrow(context)` / `tomorrowNight(context)` → `context.applicationContext`. Added a comment noting the call must be inside a coroutine.
- **`highlight()` KDoc**: Removed spurious `\$` escape — `\${result.durationMs}` was rendering as a literal backslash in Dokka output instead of string interpolation.
- **`highlightBothThemes()` KDoc**: Same `context` → `context.applicationContext` fix.
- **`ThemedHighlightResult` KDoc**: Replaced `remember { HighlightTheme.tomorrow(context.applicationContext) }` (where `context` was undeclared) with `rememberTomorrowTheme()` / `rememberTomorrowNightTheme()`.

### `RememberHelpers.kt`

- **`rememberHighlightedCode()` "Theme creation" section**: Added missing `val context = LocalContext.current` before `remember(context) { ... }`. Also added a second example showing `rememberTomorrowTheme()` as the simpler alternative.

## Verification

All pre-commit checks pass:
```
./gradlew lintKotlin                                              ✅
./gradlew :compose-highlight:assembleDebug :sample:assembleDebug  ✅
./gradlew :compose-highlight:test                                 ✅
```