### PR TITLE
fix: rethrow CancellationException and surface Timeout in HighlightEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`CancellationException` is no longer swallowed in `HighlightEngine`** — `highlightToHtml`,
+  `supportedLanguages`, and `highlightJsVersion` previously caught all `Exception` types,
+  silently converting parent coroutine cancellations into `Result.failure(JsExecutionFailed(...))`.
+  They now rethrow `CancellationException` to respect structured concurrency.
+- **`HighlightException.Timeout` is now actually thrown on timeout** — the same broad
+  `catch (e: Exception)` was swallowing `TimeoutCancellationException` (from `withTimeout`),
+  making `HighlightException.Timeout` dead code. Timeout is now correctly caught and converted
+  to `Result.failure(HighlightException.Timeout())` in all three methods.
+
 ### Performance
 - **`SyntaxHighlightedCode` is now `restartable skippable`** — Derived colors and `TextStyle`
   values (`backgroundColor`, `textColor`, `lineNumberColor`, `themedCodeStyle`,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -168,7 +168,7 @@ class HighlightEngine(
         code: String,
         language: String,
     ): Result<HtmlHighlightResult> =
-        try {
+        withEngineErrorHandling {
             manager.initialize()
             val webView = manager.getReadyWebView()
 
@@ -183,14 +183,6 @@ class HighlightEngine(
                     )
                 }
             }
-        } catch (e: TimeoutCancellationException) {
-            Result.failure(HighlightException.Timeout())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: HighlightException) {
-            Result.failure(e)
-        } catch (e: Exception) {
-            Result.failure(HighlightException.JsExecutionFailed(e))
         }
 
     /**
@@ -317,53 +309,49 @@ class HighlightEngine(
      */
     suspend fun supportedLanguages(): Result<List<String>> {
         cachedLanguages?.let { return Result.success(it) }
-        return try {
+        return withEngineErrorHandling {
             manager.initialize()
             val webView = manager.getReadyWebView()
             mutex.withLock {
                 // Double-checked: another coroutine may have populated the cache while we waited.
-                cachedLanguages?.let { return Result.success(it) }
-                withTimeout(HighlightException.TIMEOUT_SECONDS * 1000L) {
-                    withContext(Dispatchers.Main) {
-                        suspendCancellableCoroutine { continuation ->
-                            webView.evaluateJavascript("listLanguages()") { rawResult ->
-                                if (!continuation.isActive) return@evaluateJavascript
-                                if (rawResult == null || rawResult == "null") {
-                                    continuation.resumeWithException(
-                                        HighlightException.JsExecutionFailed(
-                                            RuntimeException("listLanguages() returned null"),
-                                        ),
-                                    )
-                                    return@evaluateJavascript
-                                }
-                                // evaluateJavascript serializes a JS array to a JSON array string,
-                                // e.g. ["kotlin","java",...] — parse with JSONArray.
-                                try {
-                                    val jsonArray = org.json.JSONArray(rawResult)
-                                    val languages =
-                                        (0 until jsonArray.length())
-                                            .map { jsonArray.getString(it) }
-                                            .sorted()
-                                    cachedLanguages = languages
-                                    continuation.resume(Result.success(languages))
-                                } catch (e: Exception) {
-                                    continuation.resumeWithException(
-                                        HighlightException.JsExecutionFailed(e),
-                                    )
+                val cached = cachedLanguages
+                if (cached != null) {
+                    Result.success(cached)
+                } else {
+                    withTimeout(HighlightException.TIMEOUT_SECONDS * 1000L) {
+                        withContext(Dispatchers.Main) {
+                            suspendCancellableCoroutine { continuation ->
+                                webView.evaluateJavascript("listLanguages()") { rawResult ->
+                                    if (!continuation.isActive) return@evaluateJavascript
+                                    if (rawResult == null || rawResult == "null") {
+                                        continuation.resumeWithException(
+                                            HighlightException.JsExecutionFailed(
+                                                RuntimeException("listLanguages() returned null"),
+                                            ),
+                                        )
+                                        return@evaluateJavascript
+                                    }
+                                    // evaluateJavascript serializes a JS array to a JSON array string,
+                                    // e.g. ["kotlin","java",...] — parse with JSONArray.
+                                    try {
+                                        val jsonArray = org.json.JSONArray(rawResult)
+                                        val languages =
+                                            (0 until jsonArray.length())
+                                                .map { jsonArray.getString(it) }
+                                                .sorted()
+                                        cachedLanguages = languages
+                                        continuation.resume(Result.success(languages))
+                                    } catch (e: Exception) {
+                                        continuation.resumeWithException(
+                                            HighlightException.JsExecutionFailed(e),
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        } catch (e: TimeoutCancellationException) {
-            Result.failure(HighlightException.Timeout())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: HighlightException) {
-            Result.failure(e)
-        } catch (e: Exception) {
-            Result.failure(HighlightException.JsExecutionFailed(e))
         }
     }
 
@@ -386,42 +374,38 @@ class HighlightEngine(
      */
     suspend fun highlightJsVersion(): Result<String> {
         cachedVersion?.let { return Result.success(it) }
-        return try {
+        return withEngineErrorHandling {
             manager.initialize()
             val webView = manager.getReadyWebView()
             mutex.withLock {
                 // Double-checked: another coroutine may have populated the cache while we waited.
-                cachedVersion?.let { return Result.success(it) }
-                withTimeout(HighlightException.TIMEOUT_SECONDS * 1000L) {
-                    withContext(Dispatchers.Main) {
-                        suspendCancellableCoroutine { continuation ->
-                            webView.evaluateJavascript("hljsVersion()") { rawResult ->
-                                if (!continuation.isActive) return@evaluateJavascript
-                                if (rawResult == null || rawResult == "null") {
-                                    continuation.resumeWithException(
-                                        HighlightException.JsExecutionFailed(
-                                            RuntimeException("hljsVersion() returned null"),
-                                        ),
-                                    )
-                                    return@evaluateJavascript
+                val cached = cachedVersion
+                if (cached != null) {
+                    Result.success(cached)
+                } else {
+                    withTimeout(HighlightException.TIMEOUT_SECONDS * 1000L) {
+                        withContext(Dispatchers.Main) {
+                            suspendCancellableCoroutine { continuation ->
+                                webView.evaluateJavascript("hljsVersion()") { rawResult ->
+                                    if (!continuation.isActive) return@evaluateJavascript
+                                    if (rawResult == null || rawResult == "null") {
+                                        continuation.resumeWithException(
+                                            HighlightException.JsExecutionFailed(
+                                                RuntimeException("hljsVersion() returned null"),
+                                            ),
+                                        )
+                                        return@evaluateJavascript
+                                    }
+                                    // evaluateJavascript returns a JSON-encoded string — strip quotes.
+                                    val version = unescapeJsString(rawResult)
+                                    cachedVersion = version
+                                    continuation.resume(Result.success(version))
                                 }
-                                // evaluateJavascript returns a JSON-encoded string — strip quotes.
-                                val version = unescapeJsString(rawResult)
-                                cachedVersion = version
-                                continuation.resume(Result.success(version))
                             }
                         }
                     }
                 }
             }
-        } catch (e: TimeoutCancellationException) {
-            Result.failure(HighlightException.Timeout())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: HighlightException) {
-            Result.failure(e)
-        } catch (e: Exception) {
-            Result.failure(HighlightException.JsExecutionFailed(e))
         }
     }
 
@@ -459,6 +443,32 @@ class HighlightEngine(
         }
     }
 }
+
+/**
+ * Executes [block] and maps common exceptions to [Result] failure types, while correctly
+ * propagating [CancellationException] for structured concurrency.
+ *
+ * - [TimeoutCancellationException] (from internal `withTimeout`) → [HighlightException.Timeout]
+ * - [CancellationException] (parent scope cancellation) → rethrown
+ * - [HighlightException] → preserved as [Result.failure]
+ * - Any other [Exception] → wrapped in [HighlightException.JsExecutionFailed]
+ *
+ * This helper eliminates the repeated catch chain in [HighlightEngine.highlightToHtml],
+ * [HighlightEngine.supportedLanguages], and [HighlightEngine.highlightJsVersion], and enables
+ * direct unit testing of the exception-mapping logic without a real WebView.
+ */
+internal suspend fun <T> withEngineErrorHandling(block: suspend () -> Result<T>): Result<T> =
+    try {
+        block()
+    } catch (e: TimeoutCancellationException) {
+        Result.failure(HighlightException.Timeout())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HighlightException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(HighlightException.JsExecutionFailed(e))
+    }
 
 /**
  * Unescapes a JSON-encoded string returned by [WebView.evaluateJavascript].

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -5,6 +5,7 @@ import android.webkit.WebView
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -160,7 +161,8 @@ class HighlightEngine(
      * @param code The source code to highlight.
      * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`).
      * @return [Result] wrapping an [HtmlHighlightResult] (html + timing), or [Result.failure]
-     *   with a [HighlightException] on error.
+     *   with a [HighlightException] on error. Returns [HighlightException.Timeout] if the
+     *   JavaScript call does not complete within the timeout window.
      */
     suspend fun highlightToHtml(
         code: String,
@@ -181,6 +183,10 @@ class HighlightEngine(
                     )
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            Result.failure(HighlightException.Timeout())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: HighlightException) {
             Result.failure(e)
         } catch (e: Exception) {
@@ -350,6 +356,10 @@ class HighlightEngine(
                     }
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            Result.failure(HighlightException.Timeout())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: HighlightException) {
             Result.failure(e)
         } catch (e: Exception) {
@@ -404,6 +414,10 @@ class HighlightEngine(
                     }
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            Result.failure(HighlightException.Timeout())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: HighlightException) {
             Result.failure(e)
         } catch (e: Exception) {

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightEngineErrorHandlingTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightEngineErrorHandlingTest.kt
@@ -1,0 +1,172 @@
+package dev.hossain.highlight.engine
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+
+/**
+ * Unit tests for [withEngineErrorHandling] — the shared exception-mapping helper used by
+ * [HighlightEngine.highlightToHtml], [HighlightEngine.supportedLanguages], and
+ * [HighlightEngine.highlightJsVersion].
+ *
+ * These tests run on the JVM (no WebView or device required) by exercising the helper directly
+ * with controlled exception inputs. They verify that:
+ * - [TimeoutCancellationException] is mapped to [HighlightException.Timeout] (not [HighlightException.JsExecutionFailed])
+ * - [CancellationException] is rethrown to respect structured concurrency (not silently swallowed)
+ * - [HighlightException] subtypes are preserved as-is
+ * - Arbitrary [Exception]s are wrapped in [HighlightException.JsExecutionFailed]
+ * - Successful blocks return [Result.success]
+ */
+class HighlightEngineErrorHandlingTest {
+    // ── TimeoutCancellationException → Timeout ────────────────────────────────
+
+    @Test
+    fun `TimeoutCancellationException is mapped to HighlightException Timeout`() =
+        runTest {
+            // Generate a real TimeoutCancellationException via withTimeout so it carries the
+            // correct coroutine context expected by the Kotlin coroutines runtime.
+            var tce: TimeoutCancellationException? = null
+            try {
+                withTimeout(1L) { delay(10_000L) }
+            } catch (e: TimeoutCancellationException) {
+                tce = e
+            }
+            requireNotNull(tce) { "Expected TimeoutCancellationException to be thrown" }
+
+            val result = withEngineErrorHandling<Unit> { throw tce }
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(HighlightException.Timeout::class.java)
+        }
+
+    @Test
+    fun `Timeout result is not a JsExecutionFailed wrapping a TimeoutCancellationException`() =
+        runTest {
+            var tce: TimeoutCancellationException? = null
+            try {
+                withTimeout(1L) { delay(10_000L) }
+            } catch (e: TimeoutCancellationException) {
+                tce = e
+            }
+            requireNotNull(tce)
+
+            val result = withEngineErrorHandling<Unit> { throw tce }
+
+            assertThat(result.exceptionOrNull()).isNotInstanceOf(HighlightException.JsExecutionFailed::class.java)
+        }
+
+    // ── CancellationException → rethrown ──────────────────────────────────────
+
+    @Test
+    fun `CancellationException is rethrown, not converted to Result failure`() {
+        // withEngineErrorHandling must rethrow CancellationException to respect structured
+        // concurrency. We verify by catching it outside and confirming result was never set.
+        var result: Result<Unit>? = null
+        try {
+            kotlinx.coroutines.runBlocking {
+                result = withEngineErrorHandling { throw CancellationException("parent cancelled") }
+            }
+        } catch (e: CancellationException) {
+            // Expected: the exception propagated out instead of being swallowed as Result.failure
+        }
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `CancellationException cause is not lost when rethrown`() {
+        val cause = CancellationException("test cancellation")
+        var caught: CancellationException? = null
+        try {
+            kotlinx.coroutines.runBlocking {
+                withEngineErrorHandling<Unit> { throw cause }
+            }
+        } catch (e: CancellationException) {
+            caught = e
+        }
+
+        assertThat(caught).isSameInstanceAs(cause)
+    }
+
+    // ── HighlightException → preserved ───────────────────────────────────────
+
+    @Test
+    fun `HighlightException JsExecutionFailed is preserved as Result failure`() =
+        runTest {
+            val ex = HighlightException.JsExecutionFailed(RuntimeException("js error"))
+
+            val result = withEngineErrorHandling<Unit> { throw ex }
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isSameInstanceAs(ex)
+        }
+
+    @Test
+    fun `HighlightException WebViewInitFailed is preserved as Result failure`() =
+        runTest {
+            val ex = HighlightException.WebViewInitFailed(RuntimeException("init failure"))
+
+            val result = withEngineErrorHandling<Unit> { throw ex }
+
+            assertThat(result.exceptionOrNull()).isSameInstanceAs(ex)
+        }
+
+    @Test
+    fun `HighlightException HtmlParseFailed is preserved as Result failure`() =
+        runTest {
+            val ex = HighlightException.HtmlParseFailed(RuntimeException("parse error"))
+
+            val result = withEngineErrorHandling<Unit> { throw ex }
+
+            assertThat(result.exceptionOrNull()).isSameInstanceAs(ex)
+        }
+
+    // ── generic Exception → JsExecutionFailed ─────────────────────────────────
+
+    @Test
+    fun `generic Exception is wrapped in JsExecutionFailed`() =
+        runTest {
+            val cause = RuntimeException("unexpected failure")
+
+            val result = withEngineErrorHandling<Unit> { throw cause }
+
+            assertThat(result.isFailure).isTrue()
+            val ex = result.exceptionOrNull()
+            assertThat(ex).isInstanceOf(HighlightException.JsExecutionFailed::class.java)
+            assertThat(ex?.cause).isSameInstanceAs(cause)
+        }
+
+    @Test
+    fun `IllegalStateException is wrapped in JsExecutionFailed`() =
+        runTest {
+            val result = withEngineErrorHandling<Unit> { throw IllegalStateException("bad state") }
+
+            assertThat(result.exceptionOrNull()).isInstanceOf(HighlightException.JsExecutionFailed::class.java)
+        }
+
+    // ── success path ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `successful block returns Result success with the value`() =
+        runTest {
+            val result = withEngineErrorHandling { Result.success(42) }
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrNull()).isEqualTo(42)
+        }
+
+    @Test
+    fun `successful block returning Result failure preserves the failure`() =
+        runTest {
+            val ex = HighlightException.ThemeNotFound("themes/missing.css")
+
+            val result = withEngineErrorHandling<Unit> { Result.failure(ex) }
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isSameInstanceAs(ex)
+        }
+}


### PR DESCRIPTION
## Summary

Identified via `kotlin-coroutines-structured-concurrency` skill assessment.

### Bug 1: `CancellationException` swallowed

`highlightToHtml`, `supportedLanguages`, and `highlightJsVersion` had a broad `catch (e: Exception)` that silently converted parent coroutine cancellations into `Result.failure(JsExecutionFailed(...))`. This violated structured concurrency — when a `LaunchedEffect` is cancelled (e.g. user navigates away), the engine call should propagate cancellation rather than silently returning a failure result.

### Bug 2: `HighlightException.Timeout` was dead code

The same broad `catch (e: Exception)` also caught `TimeoutCancellationException` thrown by `withTimeout`, wrapping it as `JsExecutionFailed(TimeoutCancellationException(...))`. This meant `HighlightException.Timeout` was never actually thrown — callers matching on it would never see it.

### Fix

Add explicit catch blocks in the correct order before `catch (e: Exception)`:

```kotlin
} catch (e: TimeoutCancellationException) {
    Result.failure(HighlightException.Timeout())
} catch (e: CancellationException) {
    throw e  // propagate structured cancellation
} catch (e: HighlightException) {
    Result.failure(e)
} catch (e: Exception) {
    Result.failure(HighlightException.JsExecutionFailed(e))
}
```

Note: `initialize()` was already correct — it explicitly rethrew `CancellationException`.

### Other skills assessed (no issues found)
- **`kotlin-flow-state-event-modeling`**: `StateFlow<Boolean>` in `WebViewManager` correctly models init state, no sentinel values or `stateIn` misuse.
- **`kotlin-types-value-class`**: All result types are multi-field data classes — no single-field wrappers that should be value classes.