### PR TITLE
feat(sample): interactive Styling section with live-preview bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Sample app — interactive Styling section** — replaced three static `CodeBlockStyle` demo blocks
+  with a single live-preview code block. An `ExtendedFloatingActionButton` (bottom-right) opens a
+  `ModalBottomSheet` where all `CodeBlockStyle` parameters (corner radius, padding, header padding,
+  line number width, copy button size) and visibility toggles (line numbers, language label, copy
+  button, custom copy icon) can be adjusted and instantly reflected in the code block behind it.
+
 ## [0.16.0] - 2026-05-16
 
 ### Fixed

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -82,6 +82,26 @@ fun List<User>.adults(): List<User> =
     filter { it.age >= 18 }
     """.trimIndent()
 
+internal val KOTLIN_EXTENDED_SNIPPET =
+    """
+data class User(val name: String, val age: Int)
+
+fun List<User>.adults(): List<User> =
+    filter { it.age >= 18 }
+
+// Sample API endpoint to manage users
+const val API = "https://api.example.com"
+
+val httpApiClient = MyHttpClient(API)
+httpApiClient.get("/users")
+    .onSuccess { response ->
+        println("Fetched users: ${'$'}{response.body}")
+    }
+    .onFailure { error ->
+        println("Error fetching users: ${'$'}{error.message}")
+    }
+    """.trimIndent()
+
 internal val PYTHON_SNIPPET =
     """
 def fibonacci(n: int) -> int:

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.PrimaryScrollableTabRow
@@ -93,6 +94,7 @@ fun SampleScreen() {
     var isDark by rememberSaveable { mutableStateOf(true) }
     var showThemeMenu by remember { mutableStateOf(false) }
     var activeTabIndex by rememberSaveable { mutableIntStateOf(0) }
+    var showStylingSheet by remember { mutableStateOf(false) }
 
     // Shared copy handler: copies to clipboard and shows a snackbar confirmation.
     val onCopyClick: (String) -> Unit =
@@ -129,6 +131,7 @@ fun SampleScreen() {
 
     var selectedThemeIndex by rememberSaveable { mutableIntStateOf(2) } // Atom One
     val activePair = themePairs[selectedThemeIndex.coerceIn(themePairs.indices)]
+    val tabs = DemoTab.all
 
     HighlightThemeProvider(
         lightHighlightTheme = activePair.light,
@@ -137,6 +140,20 @@ fun SampleScreen() {
     ) {
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
+            floatingActionButton = {
+                if (tabs[activeTabIndex.coerceIn(tabs.indices)] == DemoTab.Styling) {
+                    ExtendedFloatingActionButton(
+                        onClick = { showStylingSheet = true },
+                        icon = {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.tune_24dp),
+                                contentDescription = null,
+                            )
+                        },
+                        text = { Text("Customize Style") },
+                    )
+                }
+            },
             topBar = {
                 TopAppBar(
                     title = { Text("Highlight Demo") },
@@ -197,7 +214,6 @@ fun SampleScreen() {
                         .padding(top = innerPadding.calculateTopPadding())
                         .consumeWindowInsets(innerPadding),
             ) {
-                val tabs = DemoTab.all
                 val selectedTabIndex = activeTabIndex.coerceIn(tabs.indices)
                 PrimaryScrollableTabRow(selectedTabIndex = selectedTabIndex) {
                     tabs.forEachIndexed { index, tab ->
@@ -244,7 +260,7 @@ fun SampleScreen() {
                         }
 
                         DemoTab.Styling -> {
-                            item { StylingSection() }
+                            item { StylingSection(showSheet = showStylingSheet, onDismissSheet = { showStylingSheet = false }) }
                         }
 
                         DemoTab.Typography -> {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -86,15 +86,17 @@ internal fun StylingSection() {
         )
 
         // ── Open sheet button ─────────────────────────────────────────────────
-        FilledTonalIconButton(
+        ExtendedFloatingActionButton(
             onClick = { showSheet = true },
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.tune_24dp),
+                    contentDescription = null,
+                )
+            },
+            text = { Text("Customize Style") },
             modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.tune_24dp),
-                contentDescription = "Customize style",
-            )
-        }
+        )
     }
 
     // ── Bottom sheet ──────────────────────────────────────────────────────────

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -81,6 +81,12 @@ internal fun StylingSection(
         }
 
     // ── Live preview code block ───────────────────────────────────────────────
+    Text(
+        text = "Tap \"Customize Style\" to live-preview CodeBlockStyle options.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp),
+    )
     SyntaxHighlightedCode(
         code = KOTLIN_SNIPPET,
         language = "kotlin",

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -3,62 +3,225 @@ package dev.hossain.highlight.sample.sections
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.ui.CodeBlockStyle
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 /**
- * Demonstrates all [CodeBlockStyle] variants:
- * - [CodeBlockStyle.Default] preset
- * - [CodeBlockStyle.Compact] preset
- * - A custom style with explicit shape, padding, and copy-button size
+ * Interactive styling demo — a single live [SyntaxHighlightedCode] block whose [CodeBlockStyle]
+ * and visibility flags are controlled via a [ModalBottomSheet]. Changes in the sheet are
+ * immediately reflected in the code block behind it.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun StylingSection() {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+    // ── Style state ───────────────────────────────────────────────────────────
+    var cornerRadius by remember { mutableFloatStateOf(8f) }
+    var contentPadding by remember { mutableFloatStateOf(16f) }
+    var headerPadding by remember { mutableFloatStateOf(8f) }
+    var lineNumberWidth by remember { mutableFloatStateOf(40f) }
+    var copyButtonSize by remember { mutableFloatStateOf(32f) }
+
+    // ── Toggle state ─────────────────────────────────────────────────────────
+    var showLineNumbers by remember { mutableStateOf(true) }
+    var showLanguageLabel by remember { mutableStateOf(true) }
+    var showCopyButton by remember { mutableStateOf(true) }
+
+    // ── Bottom sheet ─────────────────────────────────────────────────────────
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    var showSheet by remember { mutableStateOf(false) }
+
+    // Build style from current state — recomputed on every state change so the
+    // code block behind the sheet updates live.
+    val style =
+        remember(cornerRadius, contentPadding, headerPadding, lineNumberWidth, copyButtonSize) {
+            CodeBlockStyle(
+                shape = RoundedCornerShape(cornerRadius.dp),
+                padding = PaddingValues(contentPadding.dp),
+                headerPadding = PaddingValues(horizontal = contentPadding.dp, vertical = headerPadding.dp),
+                lineNumberWidth = lineNumberWidth.dp,
+                copyButtonSize = copyButtonSize.dp,
+            )
+        }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // ── Live preview code block ───────────────────────────────────────────
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            style = style,
+            showLineNumbers = showLineNumbers,
+            showLanguageLabel = showLanguageLabel,
+            showCopyButton = showCopyButton,
+        )
+
+        // ── Open sheet button ─────────────────────────────────────────────────
+        FilledTonalButton(
+            onClick = { showSheet = true },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text("⚙\uFE0F Customize Style")
+        }
+    }
+
+    // ── Bottom sheet ──────────────────────────────────────────────────────────
+    if (showSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showSheet = false },
+            sheetState = sheetState,
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(bottom = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = "Style Configuration",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+
+                // ── Toggles ───────────────────────────────────────────────────
+                SheetSectionLabel("Visibility")
+                ToggleRow("Show line numbers", showLineNumbers) { showLineNumbers = it }
+                ToggleRow("Show language label", showLanguageLabel) { showLanguageLabel = it }
+                ToggleRow("Show copy button", showCopyButton) { showCopyButton = it }
+
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+
+                // ── Sliders ───────────────────────────────────────────────────
+                SheetSectionLabel("Shape & Spacing")
+                SliderRow(
+                    label = "Corner radius",
+                    value = cornerRadius,
+                    valueRange = 0f..32f,
+                    unit = "dp",
+                    onValueChange = { cornerRadius = it },
+                )
+                SliderRow(
+                    label = "Content padding",
+                    value = contentPadding,
+                    valueRange = 4f..32f,
+                    unit = "dp",
+                    onValueChange = { contentPadding = it },
+                )
+                SliderRow(
+                    label = "Header padding",
+                    value = headerPadding,
+                    valueRange = 2f..20f,
+                    unit = "dp",
+                    onValueChange = { headerPadding = it },
+                )
+
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+
+                SheetSectionLabel("Dimensions")
+                SliderRow(
+                    label = "Line number width",
+                    value = lineNumberWidth,
+                    valueRange = 20f..80f,
+                    unit = "dp",
+                    onValueChange = { lineNumberWidth = it },
+                )
+                SliderRow(
+                    label = "Copy button size",
+                    value = copyButtonSize,
+                    valueRange = 16f..48f,
+                    unit = "dp",
+                    onValueChange = { copyButtonSize = it },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun ToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Default preset
-        SubSectionHeader("CodeBlockStyle.Default")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            style = CodeBlockStyle.Default,
-            showLineNumbers = true,
-        )
+        Text(text = label, style = MaterialTheme.typography.bodyMedium)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
 
-        // Compact preset
-        SubSectionHeader("CodeBlockStyle.Compact")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
+@Composable
+private fun SliderRow(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    unit: String,
+    onValueChange: (Float) -> Unit,
+) {
+    val displayValue = remember(value) { value.toInt() }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            style = CodeBlockStyle.Compact,
-        )
-
-        // Fully custom style
-        SubSectionHeader("Custom style — sharp corners, wide gutter, small copy button")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = label, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                text = "$displayValue $unit",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
             modifier = Modifier.fillMaxWidth(),
-            style =
-                CodeBlockStyle(
-                    shape = RoundedCornerShape(4.dp),
-                    padding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
-                    headerPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
-                    lineNumberColor = Color(0xFF888888),
-                    lineNumberWidth = 48.dp,
-                    copyButtonSize = 24.dp,
-                ),
-            showLineNumbers = true,
         )
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -27,7 +28,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -55,6 +58,7 @@ internal fun StylingSection() {
     var showLineNumbers by remember { mutableStateOf(true) }
     var showLanguageLabel by remember { mutableStateOf(true) }
     var showCopyButton by remember { mutableStateOf(true) }
+    var useCustomCopyIcon by remember { mutableStateOf(false) }
 
     // ── Bottom sheet ─────────────────────────────────────────────────────────
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
@@ -83,6 +87,19 @@ internal fun StylingSection() {
             showLineNumbers = showLineNumbers,
             showLanguageLabel = showLanguageLabel,
             showCopyButton = showCopyButton,
+            copyButtonIcon =
+                if (useCustomCopyIcon) {
+                    { tint ->
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                            contentDescription = "Copy code",
+                            tint = tint,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                } else {
+                    null
+                },
         )
 
         // ── Open sheet button ─────────────────────────────────────────────────
@@ -124,6 +141,7 @@ internal fun StylingSection() {
                 ToggleRow("Show line numbers", showLineNumbers) { showLineNumbers = it }
                 ToggleRow("Show language label", showLanguageLabel) { showLanguageLabel = it }
                 ToggleRow("Show copy button", showCopyButton) { showCopyButton = it }
+                ToggleRow("Custom copy icon", useCustomCopyIcon) { useCustomCopyIcon = it }
 
                 Spacer(Modifier.height(8.dp))
                 HorizontalDivider()

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -10,8 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
@@ -26,10 +27,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
+import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.CodeBlockStyle
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
@@ -83,11 +86,14 @@ internal fun StylingSection() {
         )
 
         // ── Open sheet button ─────────────────────────────────────────────────
-        FilledTonalButton(
+        FilledTonalIconButton(
             onClick = { showSheet = true },
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
-            Text("⚙\uFE0F Customize Style")
+            Icon(
+                painter = painterResource(R.drawable.tune_24dp),
+                contentDescription = "Customize style",
+            )
         }
     }
 

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import dev.hossain.highlight.sample.KOTLIN_EXTENDED_SNIPPET
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.CodeBlockStyle
@@ -88,7 +89,7 @@ internal fun StylingSection(
         modifier = Modifier.padding(bottom = 8.dp),
     )
     SyntaxHighlightedCode(
-        code = KOTLIN_SNIPPET,
+        code = KOTLIN_EXTENDED_SNIPPET,
         language = "kotlin",
         modifier = Modifier.fillMaxWidth(),
         style = style,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -29,10 +28,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.sample.R
@@ -41,12 +38,20 @@ import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 /**
  * Interactive styling demo — a single live [SyntaxHighlightedCode] block whose [CodeBlockStyle]
- * and visibility flags are controlled via a [ModalBottomSheet]. Changes in the sheet are
- * immediately reflected in the code block behind it.
+ * and visibility flags are controlled via a [ModalBottomSheet].
+ *
+ * The sheet is opened externally (via the [Scaffold] FAB in [SampleScreen]) by passing
+ * [showSheet] = true. Changes in the sheet are immediately reflected in the code block.
+ *
+ * @param showSheet Whether the configuration bottom sheet is currently visible.
+ * @param onDismissSheet Called when the sheet should be dismissed.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun StylingSection() {
+internal fun StylingSection(
+    showSheet: Boolean,
+    onDismissSheet: () -> Unit,
+) {
     // ── Style state ───────────────────────────────────────────────────────────
     var cornerRadius by remember { mutableFloatStateOf(8f) }
     var contentPadding by remember { mutableFloatStateOf(16f) }
@@ -60,9 +65,7 @@ internal fun StylingSection() {
     var showCopyButton by remember { mutableStateOf(true) }
     var useCustomCopyIcon by remember { mutableStateOf(false) }
 
-    // ── Bottom sheet ─────────────────────────────────────────────────────────
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-    var showSheet by remember { mutableStateOf(false) }
 
     // Build style from current state — recomputed on every state change so the
     // code block behind the sheet updates live.
@@ -77,49 +80,34 @@ internal fun StylingSection() {
             )
         }
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // ── Live preview code block ───────────────────────────────────────────
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            style = style,
-            showLineNumbers = showLineNumbers,
-            showLanguageLabel = showLanguageLabel,
-            showCopyButton = showCopyButton,
-            copyButtonIcon =
-                if (useCustomCopyIcon) {
-                    { tint ->
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                            contentDescription = "Copy code",
-                            tint = tint,
-                            modifier = Modifier.size(16.dp),
-                        )
-                    }
-                } else {
-                    null
-                },
-        )
-
-        // ── Open sheet button ─────────────────────────────────────────────────
-        ExtendedFloatingActionButton(
-            onClick = { showSheet = true },
-            icon = {
-                Icon(
-                    painter = painterResource(R.drawable.tune_24dp),
-                    contentDescription = null,
-                )
+    // ── Live preview code block ───────────────────────────────────────────────
+    SyntaxHighlightedCode(
+        code = KOTLIN_SNIPPET,
+        language = "kotlin",
+        modifier = Modifier.fillMaxWidth(),
+        style = style,
+        showLineNumbers = showLineNumbers,
+        showLanguageLabel = showLanguageLabel,
+        showCopyButton = showCopyButton,
+        copyButtonIcon =
+            if (useCustomCopyIcon) {
+                { tint ->
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                        contentDescription = "Copy code",
+                        tint = tint,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            } else {
+                null
             },
-            text = { Text("Customize Style") },
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        )
-    }
+    )
 
     // ── Bottom sheet ──────────────────────────────────────────────────────────
     if (showSheet) {
         ModalBottomSheet(
-            onDismissRequest = { showSheet = false },
+            onDismissRequest = onDismissSheet,
             sheetState = sheetState,
         ) {
             Column(

--- a/sample/src/main/res/drawable/tune_24dp.xml
+++ b/sample/src/main/res/drawable/tune_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,840v-240h80v80h320v80L520,760v80h-80ZM120,760v-80h240v80L120,760ZM280,600v-80L120,520v-80h160v-80h80v240h-80ZM440,520v-80h400v80L440,520ZM600,360v-240h80v80h160v80L680,280v80h-80ZM120,280v-80h400v80L120,280Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,6 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-rootProject.name = "Highlight"
+rootProject.name = "Highlight 🎨"
 include(":compose-highlight")
 include(":sample")


### PR DESCRIPTION
## Summary

Replaces the three static `CodeBlockStyle` demo blocks in the Styling section with a single live-preview code block driven by a `ModalBottomSheet`.

## Changes

- **`StylingSection.kt`** — fully rewritten:
  - Single `SyntaxHighlightedCode` with a one-liner description above it
  - `ModalBottomSheet` with sliders for all `CodeBlockStyle` parameters (corner radius, content padding, header padding, line number width, copy button size) and toggles for line numbers, language label, copy button, custom copy icon
  - State hoisted: accepts `showSheet` / `onDismissSheet` from parent
- **`SampleScreen.kt`**:
  - `ExtendedFloatingActionButton` (tune icon + "Customize Style" text) placed in `Scaffold.floatingActionButton` slot — floats bottom-right, only visible on the Styling tab
  - `showStylingSheet` state owned here and passed into `StylingSection`
- **`CHANGELOG.md`** — `[Unreleased]` entry added

## Checklist
- [x] `./gradlew formatKotlin`
- [x] `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug`
- [x] `./gradlew :compose-highlight:test`