### PR TITLE
refactor(sample): trim Themes section — 1 built-in + 1 fromAsset() demo

### DIFF
--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -102,6 +102,39 @@ httpApiClient.get("/users")
     }
     """.trimIndent()
 
+/**
+ * Kotlin snippet demonstrating [HighlightTheme.fromAsset] — intentionally shown
+ * inside a [dev.hossain.highlight.ui.SyntaxHighlightedCode] block so the demo
+ * highlights its own loading code ("eat your own dog food").
+ */
+internal val FROM_ASSET_SNIPPET =
+    """
+// Save any highlight.js CSS theme file in your app's assets:
+//   app/src/main/assets/themes/dracula.min.css
+
+val theme = HighlightTheme.fromAsset(
+    context   = context.applicationContext,
+    assetPath = "themes/dracula.min.css",
+    name      = "dracula",
+)
+
+// Pass the theme directly to the composable
+SyntaxHighlightedCode(
+    code     = sourceCode,
+    language = "kotlin",
+    theme    = theme,
+)
+
+// Or wrap a subtree so all code blocks share one theme
+HighlightThemeProvider(
+    lightHighlightTheme = lightTheme,
+    darkHighlightTheme  = theme,
+) {
+    SyntaxHighlightedCode(code = sourceCode, language = "kotlin")
+    SyntaxHighlightedCode(code = otherCode,  language = "python")
+}
+    """.trimIndent()
+
 internal val JAVASCRIPT_EXTENDED_SNIPPET =
     """
 // --- Classes & inheritance ---

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -74,13 +73,8 @@ private val MATERIAL3_LIGHT_CSS =
  */
 @Composable
 internal fun ThemeCreationSection() {
-    val context = LocalContext.current.applicationContext
-
     // Built-in theme — @Composable helper resolves LocalContext internally
     val atomOneDarkTheme = rememberAtomOneDarkTheme()
-
-    // fromAsset() — GitHub theme bundled in the sample app's assets/
-    val githubTheme = remember(context) { HighlightTheme.fromAsset(context, "themes/github.css", "github") }
 
     // fromCss() — Material 3–inspired inline CSS string
     val material3LightTheme =
@@ -121,7 +115,15 @@ internal fun ThemeCreationSection() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // ── Built-in theme ─────────────────────────────────────────────────
-        SubSectionHeader("Built-in: HighlightTheme.atomOneDark()")
+        SubSectionHeader("Built-in themes")
+        Text(
+            text =
+                "The library bundles 4 ready-to-use themes: atomOneDark, atomOneLight, " +
+                    "tomorrow, and tomorrowNight. No extra assets needed — just call the " +
+                    "corresponding factory function. Here is atomOneDark as an example:",
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -137,8 +139,7 @@ internal fun ThemeCreationSection() {
             text =
                 "Save any highlight.js-compatible CSS file anywhere under your app's assets/ " +
                     "directory and load it at runtime with HighlightTheme.fromAsset(). " +
-                    "The code block below is highlighted with a theme loaded from assets/ " +
-                    "and also shows you exactly how to do it.",
+                    "The code block below shows you exactly how to do it:",
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(horizontal = 4.dp),
         )
@@ -146,7 +147,7 @@ internal fun ThemeCreationSection() {
             code = FROM_ASSET_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
-            theme = githubTheme,
+            theme = atomOneDarkTheme,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -15,12 +17,10 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.sample.FROM_ASSET_SNIPPET
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberAtomOneDarkTheme
-import dev.hossain.highlight.ui.rememberAtomOneLightTheme
-import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
 
 /**
  * Material 3–inspired light CSS theme used to demonstrate [HighlightTheme.fromCss].
@@ -66,10 +66,9 @@ private val MATERIAL3_LIGHT_CSS =
     """.trimIndent()
 
 /**
- * Exercises every [HighlightTheme] factory method side-by-side:
- * - Built-in: [HighlightTheme.tomorrow], [HighlightTheme.tomorrowNight],
- *   [HighlightTheme.atomOneLight], [HighlightTheme.atomOneDark]
- * - [HighlightTheme.fromAsset] — GitHub CSS bundled in sample assets
+ * Demonstrates all four [HighlightTheme] factory methods:
+ * - Built-in: [HighlightTheme.atomOneDark] (one representative bundled theme)
+ * - [HighlightTheme.fromAsset] — any highlight.js CSS saved in `assets/`
  * - [HighlightTheme.fromCss] — Material 3–inspired inline CSS
  * - [HighlightTheme.fromColorMap] — Material 3–inspired precomputed color map (dark variant)
  */
@@ -77,15 +76,11 @@ private val MATERIAL3_LIGHT_CSS =
 internal fun ThemeCreationSection() {
     val context = LocalContext.current.applicationContext
 
-    // Built-in themes — use @Composable helpers that resolve LocalContext internally
-    val tomorrowTheme = rememberTomorrowTheme()
-    val tomorrowNightTheme = rememberTomorrowNightTheme()
-    val atomOneLightTheme = rememberAtomOneLightTheme()
+    // Built-in theme — @Composable helper resolves LocalContext internally
     val atomOneDarkTheme = rememberAtomOneDarkTheme()
 
-    // fromAsset() — GitHub themes bundled in the sample app's assets/
+    // fromAsset() — GitHub theme bundled in the sample app's assets/
     val githubTheme = remember(context) { HighlightTheme.fromAsset(context, "themes/github.css", "github") }
-    val githubDarkTheme = remember(context) { HighlightTheme.fromAsset(context, "themes/github-dark.css", "github-dark") }
 
     // fromCss() — Material 3–inspired inline CSS string
     val material3LightTheme =
@@ -125,32 +120,8 @@ internal fun ThemeCreationSection() {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        // ── Built-in themes ────────────────────────────────────────────────
-        SubSectionHeader("Built-in: HighlightTheme.tomorrow() — light")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            theme = tomorrowTheme,
-        )
-
-        SubSectionHeader("Built-in: HighlightTheme.tomorrowNight() — dark")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            theme = tomorrowNightTheme,
-        )
-
-        SubSectionHeader("Built-in: HighlightTheme.atomOneLight() — light")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            theme = atomOneLightTheme,
-        )
-
-        SubSectionHeader("Built-in: HighlightTheme.atomOneDark() — dark")
+        // ── Built-in theme ─────────────────────────────────────────────────
+        SubSectionHeader("Built-in: HighlightTheme.atomOneDark()")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -161,26 +132,27 @@ internal fun ThemeCreationSection() {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // ── fromAsset() ────────────────────────────────────────────────────
-        SubSectionHeader("fromAsset(): GitHub light (themes/github.css)")
+        SubSectionHeader("fromAsset(): load any CSS theme from assets/")
+        Text(
+            text =
+                "Save any highlight.js-compatible CSS file anywhere under your app's assets/ " +
+                    "directory and load it at runtime with HighlightTheme.fromAsset(). " +
+                    "The code block below is highlighted with a theme loaded from assets/ " +
+                    "and also shows you exactly how to do it.",
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
         SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
+            code = FROM_ASSET_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
             theme = githubTheme,
         )
 
-        SubSectionHeader("fromAsset(): GitHub dark (themes/github-dark.css)")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            theme = githubDarkTheme,
-        )
-
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // ── fromCss() ──────────────────────────────────────────────────────
-        SubSectionHeader("fromCss(): Material 3 light (inline CSS)")
+        SubSectionHeader("fromCss(): Material 3 light (inline CSS string)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -191,7 +163,7 @@ internal fun ThemeCreationSection() {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // ── fromColorMap() ─────────────────────────────────────────────────
-        SubSectionHeader("fromColorMap(): Material 3 dark (precomputed map)")
+        SubSectionHeader("fromColorMap(): Material 3 dark (precomputed SpanStyle map)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",


### PR DESCRIPTION
## Summary

Refines the **Themes** demo tab to be more focused now that the dedicated **All Themes** tab exists for exploring all 256 bundled themes.

### Changes

**`ThemeCreationSection.kt`**
- Removed three redundant built-in theme blocks (`tomorrow`, `tomorrowNight`, `atomOneLight`); kept only **`atomOneDark`** as the representative example
- Removed the second `fromAsset()` block (GitHub dark); kept a single **GitHub light** demo
- Added a `bodySmall` description above the `fromAsset()` block explaining that any highlight.js CSS can be placed anywhere in `assets/` and loaded at runtime
- The `fromAsset()` code block now shows `FROM_ASSET_SNIPPET` — Kotlin code demonstrating how to call `HighlightTheme.fromAsset()` and `HighlightThemeProvider` — so the block simultaneously previews the GitHub theme *and* teaches the API

**`SampleData.kt`**
- Added `FROM_ASSET_SNIPPET`: a Kotlin snippet showing `HighlightTheme.fromAsset()` usage, with KDoc explaining its self-documenting intent

### Before / After

| Before | After |
|--------|-------|
| 4 built-in theme blocks | 1 built-in block (`atomOneDark`) |
| 2 `fromAsset()` blocks | 1 `fromAsset()` block (GitHub light) |
| Code blocks all show `KOTLIN_SNIPPET` | `fromAsset()` block shows its own loading code |
