### PR TITLE
fix(engine): ThemeParser incorrectly applies ::selection background as theme background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`ThemeParser` — pseudo-element/pseudo-class selector leak** — selectors containing `::` or `:`
+  (e.g. `.hljs::selection`, `.hljs:hover`) were being stripped of the pseudo-part and incorrectly
+  stored as the `.hljs` base entry. This caused the selection-highlight background color
+  (e.g. `#516d7b` in `base16/atelier-lakeside`) to overwrite the real theme background (`#161b1d`),
+  making code blocks appear with the wrong background color. All `::selection`, `:hover`, etc. rules
+  are now skipped during parsing.
+
 ### Changed
 - **Sample app — "All Themes" tab** — new tab that bundles all 256 highlight.js 11.11.1 theme CSS
   files as sample app assets. A searchable dropdown lets users pick any theme and instantly

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -81,6 +81,13 @@ object ThemeParser {
             // overwriting the standalone `.hljs-keyword` entry with a context-specific style.
             selectorsPart.split(",").forEach { individualSelector ->
                 val trimmed = individualSelector.trim()
+
+                // Skip pseudo-element and pseudo-class selectors (::selection, :hover, etc.).
+                // Without this check, a rule like `.hljs::selection { background: #aabbcc }`
+                // strips the pseudo-element and incorrectly overwrites `result["hljs"]`
+                // with the selection-highlight color instead of the real background color.
+                if (trimmed.contains("::") || trimmed.contains(Regex(""":(?!:)[a-z]"""))) return@forEach
+
                 val matches = selectorPattern.findAll(trimmed).toList()
 
                 // Skip context-specific descendant selectors entirely.

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -1,5 +1,6 @@
 package dev.hossain.highlight.engine
 
+import androidx.compose.ui.graphics.Color
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
@@ -57,11 +58,44 @@ class ThemeParserAssetTest {
         assertThat(result).isEmpty()
     }
 
+    // ── Regression tests: ::selection must not overwrite the real .hljs background ──────────────
+    // Both tomorrow.css and tomorrow-night.css contain a `.hljs::selection { background-color: X }`
+    // rule. Before the fix, ThemeParser would strip the pseudo-element and store the selection color
+    // under the "hljs" key, overwriting the correct theme background.
+
     @Test
-    fun `parseAsset tomorrow theme has background color`() {
+    fun `parseAsset tomorrow theme background is white not selection gray`() {
+        // tomorrow.css: .hljs { background: #fff }  ← correct
+        //               .hljs::selection { background-color: #d6d6d6 }  ← must NOT win
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow.css")
         val hljsStyle = result["hljs"]
         assertThat(hljsStyle).isNotNull()
-        assertThat(hljsStyle!!.background).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFffffff))
+    }
+
+    @Test
+    fun `parseAsset tomorrow-night theme background is dark not selection gray`() {
+        // tomorrow-night.css: .hljs { background: #2d2d2d }  ← correct
+        //                     .hljs::selection { background-color: #515151 }  ← must NOT win
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow-night.css")
+        val hljsStyle = result["hljs"]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF2d2d2d))
+    }
+
+    @Test
+    fun `parseAsset atom-one-dark theme background is correct dark color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-dark.css")
+        val hljsStyle = result["hljs"]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF282c34))
+    }
+
+    @Test
+    fun `parseAsset atom-one-light theme background is correct light color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-light.css")
+        val hljsStyle = result["hljs"]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFfafafa))
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -201,4 +201,24 @@ class ThemeParserTest {
         // The descendant selector should not create an entry for hljs-keyword
         assertThat(result["hljs-keyword"]).isNull()
     }
+
+    @Test
+    fun `parse does not overwrite hljs background with pseudo-element selection color`() {
+        // Regression: .hljs::selection has a different background (selection highlight) that
+        // must NOT overwrite the real .hljs background derived from the base rule.
+        val css =
+            ".hljs { color: #7ea2b4; background: #161b1d } " +
+                ".hljs ::selection, .hljs::selection { background-color: #516d7b; color: #7ea2b4 }"
+        val result = ThemeParser.parse(css)
+        // The real background color must be preserved
+        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF161b1d))
+    }
+
+    @Test
+    fun `parse skips pseudo-class selectors`() {
+        // :focus, :hover etc. should not pollute the color map
+        val css = ".hljs { background: #1e1e1e } .hljs:hover { background: #ff0000 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF1e1e1e))
+    }
 }


### PR DESCRIPTION
## Bug

When loading themes like `base16/atelier-lakeside` from the All Themes tab, the code block background shows the wrong color (teal `#516d7b` instead of the correct near-black `#161b1d`).

## Root cause

`ThemeParser` matches each CSS selector against `\.hljs[-\w]*...` to find hljs class names. For a rule like:

```css
.hljs ::selection, .hljs::selection { background-color: #516d7b; color: #7ea2b4 }
```

The pseudo-part (`::selection`) doesn't match the hljs pattern, so the selector is reduced to `.hljs` and stored as the `"hljs"` key — **overwriting** the correct background already parsed from the earlier `.hljs { background: #161b1d }` rule.

## Fix

Skip any individual selector that contains `::` (pseudo-element) or `:` followed by a letter (pseudo-class). These rules — `::selection`, `::placeholder`, `:hover`, `:focus`, etc. — define browser interaction states that have no equivalent in Android's text rendering and must never pollute the base color map.

## Tests added

- `parse does not overwrite hljs background with pseudo-element selection color` — the original regression
- `parse skips pseudo-class selectors` — covers `:hover` and similar

## Impact

Affects all themes that include a `::selection` rule (most of the 256 bundled themes have this). The fix is in the library's `ThemeParser`, so it benefits all callers of `HighlightTheme.fromAsset()` and `HighlightTheme.fromCss()`.
