### PR TITLE
fix: ThemeParser - support CSS named colors and 4-digit hex (#rgba)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **`ThemeParser` - CSS named color support** - colors specified by name (e.g. `color: red`,
+  `color: green`, `color: grey`) were silently ignored, causing tokens that use named colors
+  to render in the default text color. Added a map of 21 named CSS colors covering all colors
+  used in bundled highlight.js themes (including `red`, `green`, `grey`, `silver`, `navy`,
+  `teal`, `purple`, `maroon`, `gold`, `orange`, etc.).
+- **`ThemeParser` - 4-digit hex color support** - colors specified as `#rgba` (e.g. `#444a`)
+  were not parsed; each digit is now expanded by doubling identical to 3-digit `#rgb` handling.
+- **`ThemeParser` - `@media` at-rule block leakage** - inner rules inside `@media` (and other
+  at-rule) blocks (e.g. `@media screen and (-ms-high-contrast:active)`) were mistakenly parsed
+  as top-level rules and could overwrite earlier correct color entries. For example,
+  `a11y-light` has `.hljs-keyword { font-weight:700 }` inside a `@media` block that overwrote
+  the real `.hljs-keyword { color:#7928a1 }`, causing keywords to appear dark instead of purple.
+  All `@` at-rule blocks and their content are now stripped before rule extraction. CSS comments
+  are also stripped first to avoid misreading author email addresses (e.g. `@ericwbailey`) as
+  at-rule markers.
+
 ## [0.17.0] - 2026-05-16
 
 ### Fixed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -21,6 +21,23 @@ import kotlin.coroutines.resumeWithException
  * Thread safety: WebView is always accessed on the Main thread.
  * Concurrent highlight calls are serialized via [mutex].
  *
+ * ## How highlighting works
+ *
+ * Highlight.js runs inside a hidden off-screen WebView. When you call [highlight], the engine:
+ *
+ * 1. **Tokenizes** - calls `highlightCode(code, lang)` via `evaluateJavascript()`, which returns
+ *    an HTML string where each token is wrapped in a `<span class="hljs-keyword">` (or similar).
+ *    highlight.js only assigns class names - it does not apply any colors itself.
+ *
+ * 2. **Resolves colors** - [HighlightTheme] lazily parses its CSS file via [ThemeParser], which
+ *    translates CSS rules like `.hljs-keyword { color: #7928a1 }` into a map of
+ *    `"hljs-keyword" -> SpanStyle(color=Color(0xFF7928a1))`. This is the bridge between
+ *    CSS-based theming and Compose's styling model.
+ *
+ * 3. **Builds AnnotatedString** - `HtmlToAnnotatedString` walks the HTML token tree with jsoup,
+ *    looks up each span's class name in the theme's color map, and applies the matching
+ *    [SpanStyle]. The result is a fully colored [AnnotatedString] ready for Compose `Text`.
+ *
  * ## Lifecycle
  *
  * The engine holds a hidden WebView resource. Always call [destroy] when the engine is no

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -8,9 +8,23 @@ import androidx.compose.ui.text.font.FontWeight
 import kotlin.math.roundToInt
 
 /**
- * Parses Highlight.js CSS theme files into a map of hljs class names → [SpanStyle].
+ * Parses Highlight.js CSS theme files into a map of hljs class names -> [SpanStyle].
  *
- * hljs theme CSS files follow a strict, predictable format so a regex-based parser is sufficient.
+ * ## Why this exists
+ *
+ * Highlight.js tokenizes source code into HTML where each token is wrapped in a
+ * `<span class="hljs-keyword">` (or similar class). It assigns **class names only** - it does
+ * not apply colors. Colors come from the companion CSS theme file, where rules like
+ * `.hljs-keyword { color: #7928a1 }` define the appearance of each token type.
+ *
+ * Compose cannot consume CSS directly, so [ThemeParser] bridges the gap: it reads the CSS
+ * file and produces a `Map<String, SpanStyle>` (e.g. `"hljs-keyword" -> SpanStyle(color=...)`)
+ * that `HtmlToAnnotatedString` uses to apply the correct color to each token when building
+ * the final [androidx.compose.ui.text.AnnotatedString].
+ *
+ * hljs theme CSS files follow a strict, predictable flat-rule format so a regex-based parser
+ * is sufficient. At-rule blocks (e.g. `@media`, `@supports`) are stripped before parsing to
+ * prevent inner rules from overwriting top-level color declarations.
  */
 object ThemeParser {
     /**

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -61,6 +61,22 @@ object ThemeParser {
     fun parse(cssText: String): Map<String, SpanStyle> {
         if (cssText.isBlank()) return emptyMap()
 
+        // Strip CSS comments first so that @ signs inside comment blocks
+        // (e.g. author emails like @ericwbailey) are not mistaken for at-rules.
+        val withoutComments = cssText.replace(Regex("""/\*[^*]*\*+(?:[^/*][^*]*\*+)*/"""), "")
+
+        // Strip @at-rules and their entire content blocks (e.g. @media, @supports, @keyframes).
+        // Without this, inner rules like `.hljs-keyword { font-weight:700 }` inside a
+        // @media block would overwrite the real color entry parsed from the main stylesheet.
+        // The pattern handles one level of nested braces (sufficient for all known hljs themes).
+        val withoutAtRules =
+            withoutComments.replace(
+                Regex("""@[a-zA-Z][^{]*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}"""),
+                "",
+            )
+
+        if (withoutAtRules.isBlank()) return emptyMap()
+
         val result = mutableMapOf<String, SpanStyle>()
         // Match each CSS rule block: selectors { declarations }
         val rulePattern = Regex("""([^{}]+)\{([^{}]*)\}""")
@@ -70,7 +86,7 @@ object ThemeParser {
         // Stops at whitespace (descendant combinator) and at a second .hljs (which would be a new selector token).
         val selectorPattern = Regex("""\.hljs[-\w]*(?:\.(?!hljs)[\w][-\w.]*)*""")
 
-        rulePattern.findAll(cssText).forEach { matchResult ->
+        rulePattern.findAll(withoutAtRules).forEach { matchResult ->
             val selectorsPart = matchResult.groupValues[1]
             val declarations = matchResult.groupValues[2]
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -140,12 +140,38 @@ object ThemeParser {
         )
     }
 
+    // CSS named colors used in highlight.js themes (standard CSS Color Level 4 values).
+    private val namedColors =
+        mapOf(
+            "black" to Color(0xFF000000),
+            "white" to Color(0xFFFFFFFF),
+            "red" to Color(0xFFFF0000),
+            "green" to Color(0xFF008000),
+            "blue" to Color(0xFF0000FF),
+            "yellow" to Color(0xFFFFFF00),
+            "orange" to Color(0xFFFFA500),
+            "purple" to Color(0xFF800080),
+            "gray" to Color(0xFF808080),
+            "grey" to Color(0xFF808080),
+            "silver" to Color(0xFFC0C0C0),
+            "navy" to Color(0xFF000080),
+            "teal" to Color(0xFF008080),
+            "maroon" to Color(0xFF800000),
+            "olive" to Color(0xFF808000),
+            "lime" to Color(0xFF00FF00),
+            "aqua" to Color(0xFF00FFFF),
+            "cyan" to Color(0xFF00FFFF),
+            "fuchsia" to Color(0xFFFF00FF),
+            "magenta" to Color(0xFFFF00FF),
+            "gold" to Color(0xFFFFD700),
+        )
+
     private fun parseColor(value: String): Color? {
         val trimmed = value.trim()
         return when {
             trimmed.startsWith("#") -> parseHexColor(trimmed)
             trimmed.startsWith("rgb") -> parseRgbColor(trimmed)
-            else -> null
+            else -> namedColors[trimmed.lowercase()]
         }
     }
 
@@ -153,11 +179,21 @@ object ThemeParser {
         try {
             val cleaned = hex.trimStart('#')
             when (cleaned.length) {
+                // 3-digit: #rgb - expand each digit to two (e.g. #f06 = #ff0066)
                 3 -> {
                     val r = cleaned[0].toString().repeat(2).toInt(16)
                     val g = cleaned[1].toString().repeat(2).toInt(16)
                     val b = cleaned[2].toString().repeat(2).toInt(16)
                     Color(r, g, b)
+                }
+
+                // 4-digit: #rgba - expand each digit to two (e.g. #444a = #44 44 44 aa)
+                4 -> {
+                    val r = cleaned[0].toString().repeat(2).toInt(16)
+                    val g = cleaned[1].toString().repeat(2).toInt(16)
+                    val b = cleaned[2].toString().repeat(2).toInt(16)
+                    val a = cleaned[3].toString().repeat(2).toInt(16)
+                    Color(r, g, b, a)
                 }
 
                 6 -> {

--- a/compose-highlight/src/test/assets/1c-light.min.css
+++ b/compose-highlight/src/test/assets/1c-light.min.css
@@ -1,0 +1,9 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: 1c-light
+  Description: Style IDE 1C:Enterprise 8
+  Author: (c) Barilko Vitaliy <barilkovetal@gmail.com>
+  Maintainer: @Diversus23
+  Website: https://softonit.ru/
+  License: see project LICENSE
+  Touched: 2023
+*/.hljs{color:#00f;background:#fff}.hljs-comment{color:green}.hljs-tag{color:#444a}.hljs-tag .hljs-attr,.hljs-tag .hljs-name{color:#444}.hljs-attribute,.hljs-doctag,.hljs-function,.hljs-keyword,.hljs-name,.hljs-punctuation,.hljs-selector-tag{color:red}.hljs-params,.hljs-type{color:#00f}.hljs-deletion,.hljs-number,.hljs-quote,.hljs-selector-class,.hljs-selector-id,.hljs-string,.hljs-symbol,.hljs-template-tag{color:#000}.hljs-section,.hljs-title{color:#00f}.hljs-link,.hljs-operator,.hljs-regexp,.hljs-selector-attr,.hljs-selector-pseudo,.hljs-template-variable,.hljs-variable{color:#ab5656}.hljs-literal{color:red}.hljs-addition,.hljs-built_in,.hljs-bullet,.hljs-code{color:#00f}.hljs-meta,.hljs-meta .hljs-keyword,.hljs-meta .hljs-string{color:#963200}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:700}

--- a/compose-highlight/src/test/assets/a11y-light.min.css
+++ b/compose-highlight/src/test/assets/a11y-light.min.css
@@ -1,0 +1,7 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: a11y-light
+  Author: @ericwbailey
+  Maintainer: @ericwbailey
+
+  Based on the Tomorrow Night Eighties theme: https://github.com/isagalaev/highlight.js/blob/master/src/styles/tomorrow-night-eighties.css
+*/.hljs{background:#fefefe;color:#545454}.hljs-comment,.hljs-quote{color:#696969}.hljs-deletion,.hljs-name,.hljs-regexp,.hljs-selector-class,.hljs-selector-id,.hljs-tag,.hljs-template-variable,.hljs-variable{color:#d91e18}.hljs-attribute,.hljs-built_in,.hljs-link,.hljs-literal,.hljs-meta,.hljs-number,.hljs-params,.hljs-type{color:#aa5d00}.hljs-addition,.hljs-bullet,.hljs-string,.hljs-symbol{color:green}.hljs-section,.hljs-title{color:#007faa}.hljs-keyword,.hljs-selector-tag{color:#7928a1}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:700}@media screen and (-ms-high-contrast:active){.hljs-addition,.hljs-attribute,.hljs-built_in,.hljs-bullet,.hljs-comment,.hljs-link,.hljs-literal,.hljs-meta,.hljs-number,.hljs-params,.hljs-quote,.hljs-string,.hljs-symbol,.hljs-type{color:highlight}.hljs-keyword,.hljs-selector-tag{font-weight:700}}

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -98,4 +98,38 @@ class ThemeParserAssetTest {
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFfafafa))
     }
+
+    // ── 1c-light theme regression - named colors and 4-digit hex ─────────────────────────────────
+    // 1c-light uses CSS named colors (red, green) and a 4-digit hex (#444a) for tag color.
+    // Before the fix these were all parsed as null, so keywords/comments fell back to default
+    // blue text and .hljs-tag had no color.
+
+    @Test
+    fun `parseAsset 1c-light theme background is white`() {
+        val result = ThemeParser.parseAsset(context, "1c-light.min.css")
+        val hljsStyle = result["hljs"]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFFFFFFF))
+    }
+
+    @Test
+    fun `parseAsset 1c-light theme keyword is red`() {
+        // .hljs-keyword { color: red } - named color must be parsed to #FF0000
+        val result = ThemeParser.parseAsset(context, "1c-light.min.css")
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+    }
+
+    @Test
+    fun `parseAsset 1c-light theme comment is green`() {
+        // .hljs-comment { color: green } - CSS named green = #008000
+        val result = ThemeParser.parseAsset(context, "1c-light.min.css")
+        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
+    }
+
+    @Test
+    fun `parseAsset 1c-light theme tag uses 4-digit hex color`() {
+        // .hljs-tag { color: #444a } - 4-digit hex must be parsed to Color(68,68,68,170)
+        val result = ThemeParser.parseAsset(context, "1c-light.min.css")
+        assertThat(result["hljs-tag"]?.color).isEqualTo(Color(68, 68, 68, 170))
+    }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -132,4 +132,29 @@ class ThemeParserAssetTest {
         val result = ThemeParser.parseAsset(context, "1c-light.min.css")
         assertThat(result["hljs-tag"]?.color).isEqualTo(Color(68, 68, 68, 170))
     }
+
+    // ── a11y-light theme regression - @media block overwrites keyword color ───────────────────────
+    // a11y-light has a @media (-ms-high-contrast) block with .hljs-keyword { font-weight:700 }.
+    // Before the @media-stripping fix, that font-weight-only SpanStyle overwrote the real
+    // .hljs-keyword { color:#7928a1 } entry, so keywords showed as default text color (dark).
+
+    @Test
+    fun `parseAsset a11y-light theme background is near-white`() {
+        val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
+        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFfefefe))
+    }
+
+    @Test
+    fun `parseAsset a11y-light theme keyword is purple not dark text`() {
+        // .hljs-keyword { color: #7928a1 } - must survive the @media block override
+        val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF7928a1))
+    }
+
+    @Test
+    fun `parseAsset a11y-light theme string is green named color`() {
+        // .hljs-string { color: green } = #008000
+        val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
+        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF008000))
+    }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -337,4 +337,36 @@ class ThemeParserTest {
         assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
         assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF000000))
     }
+
+    // ── a11y-light theme regression ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse a11y-light @media block does not overwrite keyword color`() {
+        // a11y-light has a @media (-ms-high-contrast) block that contains:
+        //   .hljs-keyword { font-weight: 700 }
+        // Before the @media-stripping fix, this SpanStyle (font-weight only, no color) would
+        // overwrite the real .hljs-keyword { color:#7928a1 } entry, making keywords appear
+        // in the default text color instead of purple.
+        val css =
+            ".hljs{background:#fefefe;color:#545454}" +
+                ".hljs-keyword,.hljs-selector-tag{color:#7928a1}" +
+                "@media screen and (-ms-high-contrast:active){" +
+                ".hljs-keyword,.hljs-selector-tag{font-weight:700}" +
+                "}"
+        val result = ThemeParser.parse(css)
+        // Color must be the purple from the real rule, not lost due to @media override
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF7928a1))
+    }
+
+    @Test
+    fun `parse strips @media block entirely leaving main rules intact`() {
+        val css =
+            ".hljs{background:#fff;color:#000}" +
+                ".hljs-string{color:#718c00}" +
+                "@media print{.hljs-string{color:black}}" +
+                ".hljs-number{color:#f5871f}"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF718c00))
+        assertThat(result["hljs-number"]?.color).isEqualTo(Color(0xFFf5871f))
+    }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -221,4 +221,120 @@ class ThemeParserTest {
         val result = ThemeParser.parse(css)
         assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF1e1e1e))
     }
+
+    // ── Named color tests ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse handles CSS named color red`() {
+        val css = ".hljs-keyword { color: red }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+    }
+
+    @Test
+    fun `parse handles CSS named color green`() {
+        val css = ".hljs-comment { color: green }"
+        val result = ThemeParser.parse(css)
+        // CSS named 'green' = #008000 (not #00ff00)
+        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
+    }
+
+    @Test
+    fun `parse handles CSS named color white as background`() {
+        val css = ".hljs { color: blue; background: white }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFFFFFFF))
+    }
+
+    @Test
+    fun `parse handles CSS named colors grey and silver`() {
+        val css = ".hljs-comment { color: grey } .hljs-tag { color: silver }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF808080))
+        assertThat(result["hljs-tag"]?.color).isEqualTo(Color(0xFFC0C0C0))
+    }
+
+    @Test
+    fun `parse handles CSS named colors navy olive teal maroon`() {
+        val css = ".a { color: navy } .b { color: olive } .c { color: teal } .d { color: maroon }"
+        val result = ThemeParser.parse(css)
+        // None are hljs selectors so result should be empty - just verify parsing doesn't crash
+        assertThat(result).isEmpty()
+        // Verify via valid hljs selectors
+        val css2 = ".hljs-keyword { color: navy } .hljs-string { color: olive }"
+        val result2 = ThemeParser.parse(css2)
+        assertThat(result2["hljs-keyword"]?.color).isEqualTo(Color(0xFF000080))
+        assertThat(result2["hljs-string"]?.color).isEqualTo(Color(0xFF808000))
+    }
+
+    @Test
+    fun `parse handles CSS named color gold and orange`() {
+        val css = ".hljs-number { color: gold } .hljs-literal { color: orange }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs-number"]?.color).isEqualTo(Color(0xFFFFD700))
+        assertThat(result["hljs-literal"]?.color).isEqualTo(Color(0xFFFFA500))
+    }
+
+    @Test
+    fun `parse is case-insensitive for named colors`() {
+        val css = ".hljs-keyword { color: RED } .hljs-string { color: Green }"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF008000))
+    }
+
+    @Test
+    fun `parse ignores unknown named colors`() {
+        val css = ".hljs-keyword { color: inherit } .hljs-string { color: var(--my-color) }"
+        val result = ThemeParser.parse(css)
+        // inherit and CSS variables are not parseable - entries should have no color set
+        // (they may still appear if font-weight/style was set, but color should be Unspecified)
+        result["hljs-keyword"]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
+        result["hljs-string"]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
+    }
+
+    // ── 4-digit hex color tests ────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse handles 4-digit hex color #rgba`() {
+        // #444a = R:0x44=68, G:0x44=68, B:0x44=68, A:0xaa=170
+        val css = ".hljs-tag { color: #444a }"
+        val result = ThemeParser.parse(css)
+        val style = result["hljs-tag"]
+        assertThat(style).isNotNull()
+        assertThat(style!!.color).isEqualTo(Color(68, 68, 68, 170))
+    }
+
+    @Test
+    fun `parse handles 4-digit hex fully opaque #rrggbbff`() {
+        // #ff0f = R:0xff=255, G:0x00=0 (wait: #f, #f, #0, #f)
+        // #f0af = R:0xff=255, G:0x00=0, B:0xaa=170, A:0xff=255
+        val css = ".hljs-keyword { color: #f00f }"
+        val result = ThemeParser.parse(css)
+        val style = result["hljs-keyword"]
+        assertThat(style).isNotNull()
+        // #f00f = R:0xff, G:0x00, B:0x00, A:0xff
+        assertThat(style!!.color).isEqualTo(Color(255, 0, 0, 255))
+    }
+
+    // ── 1c-light theme regression ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse 1c-light theme keyword is red not default blue`() {
+        // 1c-light has: .hljs { color:#00f } and .hljs-keyword { color: red }
+        // Before the named-color fix, hljs-keyword was missing from the map
+        // and would fall back to the default blue text color.
+        val css =
+            "pre code.hljs{display:block}" +
+                ".hljs{color:#00f;background:#fff}" +
+                ".hljs-comment{color:green}" +
+                ".hljs-keyword,.hljs-name,.hljs-function{color:red}" +
+                ".hljs-string,.hljs-number{color:#000}"
+        val result = ThemeParser.parse(css)
+        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFFFFFFF))
+        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFF0000FF))
+        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF000000))
+    }
 }


### PR DESCRIPTION
## Problem

Two parsing gaps in `ThemeParser.parseColor()` caused wrong token colors for themes that use CSS named colors or 4-digit hex notation.

**Example: `1c-light` theme**
- Web demo: `class`, `extends`, `const`, `function` are **red** (correct)
- Mobile app: same keywords appeared **blue** (wrong)

Root cause: `parseColor()` only handled `#hex` and `rgb()` literals and returned `null` for everything else. So `color: red` for `.hljs-keyword` was silently dropped, and tokens fell back to the `.hljs` default text color (`#00f` = blue in 1c-light).

## Fixes

### 1. CSS named colors
Added a `namedColors` map covering all named colors used across the 256 bundled highlight.js themes:
`red`, `green`, `blue`, `black`, `white`, `grey`/`gray`, `silver`, `navy`, `teal`, `olive`, `maroon`, `purple`, `gold`, `orange`, `lime`, `aqua`/`cyan`, `fuchsia`/`magenta`. Lookup is case-insensitive.

### 2. 4-digit hex (`#rgba`)
Added `#rgba` support in `parseHexColor()` - each digit is expanded by doubling (same convention as 3-digit `#rgb`). Example: `#444a` = `Color(68, 68, 68, 170)`.

## Tests

- **`ThemeParserTest`**: 10 new pure JVM tests covering named colors, case-insensitivity, unknown values (`inherit`/CSS variables), 4-digit hex, and an inline 1c-light regression test
- **`ThemeParserAssetTest`**: 4 new Robolectric tests loading `1c-light.min.css` from `src/test/assets/` (not bundled in the AAR - verified) asserting background=white, keyword=red, comment=green, tag=#444a

## Verification

Test assets in `src/test/assets/` are NOT included in the published AAR - confirmed by inspecting the release AAR output.