### PR TITLE
fix(sample): replace deprecated MenuAnchorType with ExposedDropdownMenuAnchorType

### DIFF
--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AllThemesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AllThemesSection.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -97,7 +97,7 @@ internal fun AllThemesSection() {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .menuAnchor(MenuAnchorType.PrimaryEditable),
+                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
             )
 
             ExposedDropdownMenu(


### PR DESCRIPTION
## Summary

Fixes two Kotlin compiler deprecation warnings in `AllThemesSection.kt`.

`MenuAnchorType` typealias was renamed to `ExposedDropdownMenuAnchorType` in Material 3. The old name still compiles but emits `w:` warnings on every build.

## Changes

- `AllThemesSection.kt`: updated import and usage from `MenuAnchorType` to `ExposedDropdownMenuAnchorType`

## Verification

Clean build produces zero `w:` warnings.