### PR TITLE
docs: update PUBLISHING.md release steps and add timings API references

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -60,21 +60,24 @@ The workflow maps these to `ORG_GRADLE_PROJECT_*` environment variables that the
 
 ### Step 1 — Bump the version
 
-Update `VERSION_NAME` in [`gradle.properties`](gradle.properties):
-```properties
-VERSION_NAME=0.12.0
+Use the release script to update all version references atomically:
+```bash
+./scripts/prepare-release.sh 0.18.0
 ```
 
-Also update these per the [project conventions](README.md#releasing):
-- `CHANGELOG.md` — rename `[Unreleased]` to `[0.12.0] - YYYY-MM-DD`
-- `compose-highlight/build.gradle.kts` — `version` in the `mavenPublishing` coordinates block
-- `sample/build.gradle.kts` — `versionName` and `versionCode`
-- `README.md` — dependency snippet version
+This updates `gradle.properties`, `README.md`, `sample/build.gradle.kts` (versionName + versionCode),
+and `CHANGELOG.md` (`[Unreleased]` -> `[0.18.0] - YYYY-MM-DD`) in one step.
+
+Then verify everything builds and tests pass:
+```bash
+./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test
+```
 
 Commit, push, and create the git tag:
 ```bash
-git tag 0.12.0
-git push origin 0.12.0
+git add -A && git commit -m "chore: prepare release 0.18.0"
+git push
+git tag 0.18.0 && git push origin 0.18.0
 ```
 
 ### Step 2 — Dry run (recommended)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ Highlights code and returns a `State<AnnotatedString?>`. Re-runs automatically w
 val highlighted by rememberHighlightedCode(
     code     = snippet,
     language = "kotlin",
-    onHighlightComplete = { result -> Log.d("Perf", "Highlighted in ${result.durationMs}ms") },
+        onHighlightComplete = { result ->
+            // result.timings exposes per-stage Duration fields: jsBridge, htmlParse, treeWalk, etc.
+            Log.d("Perf", "Highlighted in ${result.durationMs}ms " +
+                "(JS: ${result.timings.jsBridge.inWholeMilliseconds}ms)")
+        },
 )
 Text(text = highlighted ?: AnnotatedString(snippet))
 ```
@@ -129,7 +133,11 @@ val result by rememberHighlightedCodeBothThemes(
     language   = "kotlin",
     lightTheme = rememberTomorrowTheme(),
     darkTheme  = rememberTomorrowNightTheme(),
-    onHighlightComplete = { result -> Log.d("Perf", "Both themes in ${result.durationMs}ms") },
+    onHighlightComplete = { result ->
+        // result.timings exposes per-stage Duration fields: jsBridge, htmlParse, treeWalk, etc.
+        Log.d("Perf", "Both themes in ${result.durationMs}ms " +
+            "(JS: ${result.timings.jsBridge.inWholeMilliseconds}ms)")
+    },
 )
 Text(text = (if (isDark) result?.dark else result?.light) ?: AnnotatedString(snippet))
 ```

--- a/compose-highlight/MODULE.md
+++ b/compose-highlight/MODULE.md
@@ -55,7 +55,8 @@ val result = engine.highlight(
 result.onSuccess { r ->
     // r.annotated   — AnnotatedString ready for Text()
     // r.spanCount   — 0 signals a silent failure (unsupported language / empty input)
-    // r.durationMs  — JS round-trip time in ms
+    // r.durationMs  — total JS pipeline time in ms (equals r.timings.total.inWholeMilliseconds)
+    // r.timings     — per-stage Duration breakdown (jsBridge, htmlParse, treeWalk, etc.)
     // r.language    — the language identifier that was requested
 }
 
@@ -112,7 +113,7 @@ val themed = engine.highlightBothThemes(
 themed.onSuccess { result ->
     // ThemedHighlightResult — both variants pre-computed, no extra JS call
     val displayString = if (isDark) result.dark else result.light
-    // result.durationMs — JS round-trip time for the single highlight pass
+    // result.durationMs — total pipeline time in ms; result.timings has per-stage breakdown
 }
 ```
 
@@ -124,7 +125,10 @@ HighlightThemeProvider(lightHighlightTheme = ..., darkHighlightTheme = ...) {
     val result by rememberHighlightedCodeBothThemes(
         code     = sourceCode,
         language = "kotlin",
-        onHighlightComplete = { r -> log("done in ${r.durationMs} ms") },
+        onHighlightComplete = { r ->
+            // r.timings has per-stage Duration fields: jsBridge, htmlParse, treeWalk, etc.
+            log("done in ${r.durationMs} ms (JS: ${r.timings.jsBridge.inWholeMilliseconds}ms)")
+        },
     )
     val text = if (isSystemInDarkTheme()) result?.dark else result?.light
     if (text != null) Text(text)


### PR DESCRIPTION
## Summary

Updates three markdown files that were outdated after recent releases.

### PUBLISHING.md
Step 1 still described manually editing 4 files one by one. Replaced with the `scripts/prepare-release.sh` script created during the 0.17.2 cycle, which handles all version bumps atomically in one command.

### README.md
Two `onHighlightComplete` examples only showed `result.durationMs`. Updated to also demonstrate `result.timings` per-stage breakdown added in 0.18.0.

### MODULE.md (Dokka)
Three code examples with the same `durationMs`-only pattern. Updated consistently with README.md.