### PR TITLE
api: replace boolean flags with composable slots in SyntaxHighlightedCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed (Breaking)
+- **`SyntaxHighlightedCode` - slot API hardening** - replaced boolean visibility flags and partial
+  slot parameters with full composable slots:
+  - `showLanguageLabel: Boolean` removed; replaced by `languageLabelContent: (@Composable () -> Unit)?`
+    (`null` = hide, non-null = custom content; default shows language identifier in dimmed style).
+  - `showCopyButton: Boolean`, `copyButtonIcon: (@Composable (tint: Color) -> Unit)?`, and
+    `copyButtonContentDescription: String` removed; replaced by
+    `copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)?`
+    (`null` = hide; slot receives a pre-wired `onClick` action; default uses
+    `SyntaxHighlightedCodeDefaults.CopyButton`).
+  - `Surface` now explicitly sets `contentColor = textColor` so `LocalContentColor.current` resolves
+    correctly inside both slots.
+
+### Added
+- **`SyntaxHighlightedCodeDefaults.CopyButton`** - public composable helper that renders the
+  default `⧉` copy icon inside an `IconButton`. Accepts `onClick`, `tint`, `contentDescription`,
+  and `size` parameters so callers can compose on top of the default look.
+- **`SyntaxHighlightedCodeDefaults.LanguageLabel`** - public composable helper that renders
+  the language badge. Accepts `language`, `color`, and `fontSize` parameters. Useful for
+  toggling visibility at runtime without reconstructing the full default style.
+
+### Fixed
+- **Private `LineNumberedCode` composable** - now accepts `modifier: Modifier = Modifier` and
+  applies it to the root `Row`, consistent with Compose modifier conventions.
+
 ## [0.18.0] - 2026-05-16
 
 ### Added

--- a/compose-highlight/MODULE.md
+++ b/compose-highlight/MODULE.md
@@ -160,7 +160,7 @@ SyntaxHighlightedCode(
     code     = snippet,
     language = "json",
     style    = compact,
-    showCopyButton = false,
+    copyButtonContent = null,   // hide the copy button
 )
 ```
 

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeTest.kt
@@ -50,7 +50,6 @@ class SyntaxHighlightedCodeTest {
                 SyntaxHighlightedCode(
                     code = "val x = 1",
                     language = "kotlin",
-                    showLanguageLabel = true,
                 )
             }
         }
@@ -64,7 +63,7 @@ class SyntaxHighlightedCodeTest {
                 SyntaxHighlightedCode(
                     code = "val x = 1",
                     language = "kotlin",
-                    showLanguageLabel = false,
+                    languageLabelContent = null,
                 )
             }
         }
@@ -79,7 +78,6 @@ class SyntaxHighlightedCodeTest {
                 SyntaxHighlightedCode(
                     code = sampleCode,
                     language = "python",
-                    showCopyButton = true,
                     onCopyClick = { copyCalled = true },
                 )
             }
@@ -149,7 +147,6 @@ class SyntaxHighlightedCodeTest {
                 SyntaxHighlightedCode(
                     code = sampleCode,
                     language = "kotlin",
-                    showCopyButton = true,
                 )
             }
         }
@@ -183,7 +180,6 @@ class SyntaxHighlightedCodeTest {
                 SyntaxHighlightedCode(
                     code = sampleCode,
                     language = "python",
-                    showCopyButton = true,
                     onCopyClick = { copyCalled = true },
                 )
             }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -12,11 +12,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,12 +28,9 @@ import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightResult
@@ -76,18 +72,31 @@ import kotlinx.coroutines.launch
  * )
  * ```
  *
- * ## Custom styling
+ * ## Custom copy button slot
  *
  * ```kotlin
  * SyntaxHighlightedCode(
- *     code     = jsonSnippet,
+ *     code = snippet,
+ *     language = "kotlin",
+ *     copyButtonContent = { onClick ->
+ *         IconButton(onClick = onClick) {
+ *             Icon(
+ *                 imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+ *                 contentDescription = "Copy",
+ *             )
+ *         }
+ *     },
+ * )
+ * ```
+ *
+ * ## Hide header elements
+ *
+ * ```kotlin
+ * SyntaxHighlightedCode(
+ *     code = jsonSnippet,
  *     language = "json",
- *     style    = CodeBlockStyle(
- *         shape     = RoundedCornerShape(4.dp),
- *         padding   = PaddingValues(8.dp),
- *         textStyle = SyntaxHighlightedCodeDefaults.codeTextStyle.copy(fontSize = 15.sp),
- *     ),
- *     showCopyButton = false,
+ *     languageLabelContent = null,   // hide the language badge
+ *     copyButtonContent    = null,   // hide the copy button
  * )
  * ```
  *
@@ -101,32 +110,26 @@ import kotlinx.coroutines.launch
  *   Use [CodeBlockStyle.textStyle] to override typography (font family, size, line height).
  *   See [SyntaxHighlightedCodeDefaults] for the default values.
  * @param showLineNumbers Whether to show a line-number gutter on the left.
- * @param showLanguageLabel Whether to show the language badge in the header.
- * @param showCopyButton Whether to show the copy-to-clipboard button.
+ * @param languageLabelContent Optional composable content for the language badge in the header.
+ *   `null` hides the badge entirely. The default shows [language] in a dimmed style derived from
+ *   the active theme. Renders inside a [Surface] whose [LocalContentColor] is the theme foreground
+ *   — use `LocalContentColor.current` inside your slot to inherit it automatically.
+ *   Use [SyntaxHighlightedCodeDefaults.LanguageLabel] as a starting point for customisation.
+ *   Wrap your lambda in `remember` if it captures an unstable value.
+ * @param copyButtonContent Optional composable slot for the copy button in the header. `null`
+ *   hides the button entirely. The slot receives an `onClick` action pre-wired to copy [code] to
+ *   the system clipboard (or call [onCopyClick] if provided) — pass it to your button's `onClick`.
+ *   The default uses [SyntaxHighlightedCodeDefaults.CopyButton].
+ *   ```kotlin
+ *   copyButtonContent = { onClick ->
+ *       TextButton(onClick = onClick) { Text("Copy") }
+ *   }
+ *   ```
+ *   Wrap your lambda in `remember` if it captures unstable values.
  * @param onCopyClick Optional custom copy handler. If `null`, copies to the system clipboard.
  *   This callback is your signal that a copy occurred — use it to show your own feedback
  *   (e.g. a `Snackbar`, `Toast`, or animated indicator). The library does not show any
  *   built-in "Copied!" confirmation.
- * @param copyButtonIcon Optional composable slot that replaces the default `⧉` copy icon.
- *   Receives the recommended `tint` [Color] derived from the active theme so the icon blends
- *   naturally with the code block background. Only used when [showCopyButton] is `true`.
- *   Example:
- *   ```kotlin
- *   SyntaxHighlightedCode(
- *       code = snippet,
- *       language = "kotlin",
- *       copyButtonIcon = { tint ->
- *           Icon(
- *               imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
- *               contentDescription = "Copy",
- *               tint = tint,
- *           )
- *       },
- *   )
- *   ```
- * @param copyButtonContentDescription The content description for the copy button, used by
- *   accessibility services like TalkBack. Defaults to `"Copy code"`. Provide a localized string
- *   for non-English users.
  * @param onHighlightComplete Optional callback invoked with a [HighlightResult] when highlighting
  *   succeeds. Use [HighlightResult.durationMs] for timing, [HighlightResult.spanCount] to detect
  *   silent failures (0 = no tokens produced), and [HighlightResult.language] to confirm the
@@ -140,11 +143,23 @@ fun SyntaxHighlightedCode(
     theme: HighlightTheme = LocalHighlightTheme.current,
     style: CodeBlockStyle = CodeBlockStyle.Default,
     showLineNumbers: Boolean = false,
-    showLanguageLabel: Boolean = true,
-    showCopyButton: Boolean = true,
+    languageLabelContent: (@Composable () -> Unit)? =
+        if (language.isNotBlank()) {
+            {
+                SyntaxHighlightedCodeDefaults.LanguageLabel(
+                    language = language,
+                    color =
+                        LocalContentColor.current.copy(alpha = 0.6f),
+                    fontSize = 12.sp,
+                )
+            }
+        } else {
+            null
+        },
+    copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)? = { onClick ->
+        SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick)
+    },
     onCopyClick: ((String) -> Unit)? = null,
-    copyButtonIcon: (@Composable (tint: Color) -> Unit)? = null,
-    copyButtonContentDescription: String = "Copy code",
     onHighlightComplete: ((HighlightResult) -> Unit)? = null,
 ) {
     // Remember derived colors and text styles keyed on theme and style so they are only
@@ -168,14 +183,6 @@ fun SyntaxHighlightedCode(
     // Apply the theme's foreground color on top of the caller-supplied text style.
     val themedCodeStyle = remember(theme, style) { style.textStyle.copy(color = textColor) }
     val themedLineNumStyle = remember(theme, style) { style.textStyle.copy(color = lineNumberColor) }
-    val languageLabelStyle =
-        remember(theme, style) {
-            style.textStyle.copy(
-                color = textColor.copy(alpha = 0.6f),
-                fontSize = 12.sp,
-                lineHeight = TextUnit.Unspecified,
-            )
-        }
 
     // In Android Studio Preview, WebView cannot be created. Render a themed fallback
     // (using the active theme's background and text colors) so that @Preview composables
@@ -185,6 +192,7 @@ fun SyntaxHighlightedCode(
             modifier = modifier.testTag("syntax-highlighted-code"),
             shape = style.shape,
             color = backgroundColor,
+            contentColor = textColor,
         ) {
             Text(
                 text = code,
@@ -203,10 +211,11 @@ fun SyntaxHighlightedCode(
         modifier = modifier.testTag("syntax-highlighted-code"),
         shape = style.shape,
         color = backgroundColor,
+        contentColor = textColor,
     ) {
         Column {
             // Header: language badge + copy button
-            if (showLanguageLabel || showCopyButton) {
+            if (languageLabelContent != null || copyButtonContent != null) {
                 Row(
                     modifier =
                         Modifier
@@ -214,32 +223,21 @@ fun SyntaxHighlightedCode(
                             .padding(style.headerPadding),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (showLanguageLabel && language.isNotBlank()) {
-                        Text(
-                            text = language,
-                            style = languageLabelStyle,
-                        )
-                    }
+                    languageLabelContent?.invoke()
                     Spacer(modifier = Modifier.weight(1f))
-                    if (showCopyButton) {
-                        CopyButton(
-                            size = style.copyButtonSize,
-                            tint = textColor.copy(alpha = 0.7f),
-                            customIcon = copyButtonIcon,
-                            contentDescription = copyButtonContentDescription,
-                            onClick = {
-                                val handler = onCopyClick
-                                if (handler != null) {
-                                    handler(code)
-                                } else {
-                                    scope.launch {
-                                        clipboard.setClipEntry(
-                                            ClipEntry(ClipData.newPlainText("code", code)),
-                                        )
-                                    }
+                    if (copyButtonContent != null) {
+                        copyButtonContent {
+                            val handler = onCopyClick
+                            if (handler != null) {
+                                handler(code)
+                            } else {
+                                scope.launch {
+                                    clipboard.setClipEntry(
+                                        ClipEntry(ClipData.newPlainText("code", code)),
+                                    )
                                 }
-                            },
-                        )
+                            }
+                        }
                     }
                 }
             }
@@ -281,13 +279,14 @@ private fun LineNumberedCode(
     codeTextStyle: TextStyle,
     lineNumTextStyle: TextStyle,
     style: CodeBlockStyle,
+    modifier: Modifier = Modifier,
 ) {
     // Count lines from the text that will actually be rendered so line numbers always align.
     // Memoized to avoid recomputing on every recomposition when the rendered text is unchanged.
     val lineCount = remember(highlighted?.text, code) { (highlighted?.text ?: code).lines().size }
     val lineNumbers = remember(lineCount) { (1..lineCount).joinToString("\n") }
 
-    Row(modifier = Modifier.padding(style.padding)) {
+    Row(modifier = modifier.padding(style.padding)) {
         // Line number gutter — rendered as a single Text to share the same line-height
         // behaviour as the code Text, keeping numbers and code visually aligned.
         Text(
@@ -302,30 +301,6 @@ private fun LineNumberedCode(
             Text(text = highlighted, style = codeTextStyle)
         } else {
             Text(text = code, style = codeTextStyle)
-        }
-    }
-}
-
-@Composable
-private fun CopyButton(
-    size: androidx.compose.ui.unit.Dp,
-    tint: Color,
-    customIcon: (@Composable (tint: Color) -> Unit)?,
-    contentDescription: String,
-    onClick: () -> Unit,
-) {
-    IconButton(
-        onClick = onClick,
-        modifier = Modifier.size(size).semantics { this.contentDescription = contentDescription },
-    ) {
-        if (customIcon != null) {
-            customIcon(tint)
-        } else {
-            // Default: simple text icon — no bundled icon dependency
-            Text(
-                text = "⧉",
-                style = TextStyle(color = tint, fontSize = 16.sp),
-            )
         }
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
@@ -1,18 +1,28 @@
 package dev.hossain.highlight.ui
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
- * Default values used by [SyntaxHighlightedCode] and [CodeBlockStyle].
+ * Default values and helper composables used by [SyntaxHighlightedCode] and [CodeBlockStyle].
  *
- * Expose these constants so callers can build on them without hard-coding magic numbers:
+ * Expose constants so callers can build on them without hard-coding magic numbers, and helper
+ * composables so callers can compose on top of the built-in defaults:
  *
  * ```kotlin
  * // Use the library default text style with only fontSize overridden
@@ -23,6 +33,18 @@ import androidx.compose.ui.unit.sp
  * // Start from Compact but widen the line-number gutter
  * val myCompact = CodeBlockStyle.Compact.copy(
  *     lineNumberWidth = SyntaxHighlightedCodeDefaults.lineNumberWidth + 16.dp,
+ * )
+ *
+ * // Customise the copy button slot while keeping the default icon
+ * SyntaxHighlightedCode(
+ *     code = snippet,
+ *     language = "kotlin",
+ *     copyButtonContent = { onClick ->
+ *         SyntaxHighlightedCodeDefaults.CopyButton(
+ *             onClick = onClick,
+ *             contentDescription = stringResource(R.string.copy_code),
+ *         )
+ *     },
  * )
  * ```
  */
@@ -63,4 +85,100 @@ object SyntaxHighlightedCodeDefaults {
 
     /** Default size (width and height) of the copy button. */
     val copyButtonSize: Dp = 32.dp
+
+    /**
+     * Default copy-to-clipboard button used by [SyntaxHighlightedCode]'s `copyButtonContent` slot.
+     *
+     * Renders a simple `⧉` text icon inside an [IconButton]. Tint and size default to values
+     * that blend naturally with the code block background when placed inside a
+     * [SyntaxHighlightedCode] block.
+     *
+     * Pass to `copyButtonContent` to retain the default look while customising other parameters:
+     *
+     * ```kotlin
+     * SyntaxHighlightedCode(
+     *     code = snippet,
+     *     language = "kotlin",
+     *     copyButtonContent = { onClick ->
+     *         SyntaxHighlightedCodeDefaults.CopyButton(
+     *             onClick = onClick,
+     *             contentDescription = stringResource(R.string.copy_code_label),
+     *         )
+     *     },
+     * )
+     * ```
+     *
+     * @param onClick Action invoked when the button is clicked. Wire this to the `onClick`
+     *   parameter received from the `copyButtonContent` slot.
+     * @param tint Icon color. Defaults to [LocalContentColor] at 70 % opacity, which resolves
+     *   correctly when inside a [SyntaxHighlightedCode] block.
+     * @param contentDescription Accessibility label for TalkBack and other assistive services.
+     *   Provide a localized string for non-English users.
+     * @param size Width and height of the button touch target. Defaults to [copyButtonSize].
+     */
+    @Composable
+    fun CopyButton(
+        onClick: () -> Unit,
+        tint: Color = LocalContentColor.current.copy(alpha = 0.7f),
+        contentDescription: String = "Copy code",
+        size: Dp = copyButtonSize,
+    ) {
+        IconButton(
+            onClick = onClick,
+            modifier =
+                Modifier
+                    .size(size)
+                    .semantics { this.contentDescription = contentDescription },
+        ) {
+            androidx.compose.material3.Text(
+                text = "⧉",
+                style = TextStyle(color = tint, fontSize = 16.sp),
+            )
+        }
+    }
+
+    /**
+     * Default language badge used by [SyntaxHighlightedCode]'s `languageLabelContent` slot.
+     *
+     * Renders the language identifier as a dimmed [Text]. Color and size default to values that
+     * blend naturally with the code block header when placed inside a [SyntaxHighlightedCode] block.
+     *
+     * Use this helper when toggling label visibility at runtime so you don't need to reconstruct
+     * the full default style:
+     *
+     * ```kotlin
+     * var showLabel by remember { mutableStateOf(true) }
+     *
+     * SyntaxHighlightedCode(
+     *     code = snippet,
+     *     language = "kotlin",
+     *     languageLabelContent = if (showLabel) {
+     *         { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
+     *     } else null,
+     * )
+     * ```
+     *
+     * @param language Text to display (typically the Highlight.js language identifier).
+     * @param color Label color. Defaults to [LocalContentColor] at 60 % opacity, which resolves
+     *   correctly when inside a [SyntaxHighlightedCode] block.
+     * @param fontSize Label font size. Defaults to 12 sp.
+     */
+    @Composable
+    fun LanguageLabel(
+        language: String,
+        color: Color = LocalContentColor.current.copy(alpha = 0.6f),
+        fontSize: TextUnit = 12.sp,
+    ) {
+        if (language.isNotBlank()) {
+            androidx.compose.material3.Text(
+                text = language,
+                style =
+                    TextStyle(
+                        fontFamily = FontFamily.Monospace,
+                        color = color,
+                        fontSize = fontSize,
+                    ),
+            )
+        }
+    }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -130,7 +131,7 @@ object SyntaxHighlightedCodeDefaults {
                     .size(size)
                     .semantics { this.contentDescription = contentDescription },
         ) {
-            androidx.compose.material3.Text(
+            Text(
                 text = "⧉",
                 style = TextStyle(color = tint, fontSize = 16.sp),
             )
@@ -170,7 +171,7 @@ object SyntaxHighlightedCodeDefaults {
         fontSize: TextUnit = 12.sp,
     ) {
         if (language.isNotBlank()) {
-            androidx.compose.material3.Text(
+            Text(
                 text = language,
                 style =
                     TextStyle(

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRobolectricTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRobolectricTest.kt
@@ -61,14 +61,14 @@ class SyntaxHighlightedCodeRobolectricTest {
     }
 
     @Test
-    fun hidesLanguageLabelWhenFlagIsFalse() {
+    fun hidesLanguageLabelWhenContentIsNull() {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 HighlightThemeProvider {
                     SyntaxHighlightedCode(
                         code = "val x = 42",
                         language = "kotlin",
-                        showLanguageLabel = false,
+                        languageLabelContent = null,
                     )
                 }
             }
@@ -80,14 +80,14 @@ class SyntaxHighlightedCodeRobolectricTest {
     }
 
     @Test
-    fun hidesCopyButtonWhenFlagIsFalse() {
+    fun hidesCopyButtonWhenContentIsNull() {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 HighlightThemeProvider {
                     SyntaxHighlightedCode(
                         code = "val x = 42",
                         language = "kotlin",
-                        showCopyButton = false,
+                        copyButtonContent = null,
                     )
                 }
             }
@@ -108,7 +108,6 @@ class SyntaxHighlightedCodeRobolectricTest {
                 SyntaxHighlightedCode(
                     code = "val x = 42",
                     language = "kotlin",
-                    showCopyButton = true,
                 )
             }
         }
@@ -125,8 +124,12 @@ class SyntaxHighlightedCodeRobolectricTest {
                 SyntaxHighlightedCode(
                     code = "x = 1",
                     language = "python",
-                    showCopyButton = true,
-                    copyButtonContentDescription = "Copiar código",
+                    copyButtonContent = { onClick ->
+                        SyntaxHighlightedCodeDefaults.CopyButton(
+                            onClick = onClick,
+                            contentDescription = "Copiar código",
+                        )
+                    },
                 )
             }
         }
@@ -144,7 +147,6 @@ class SyntaxHighlightedCodeRobolectricTest {
                 SyntaxHighlightedCode(
                     code = "val x = 42",
                     language = "kotlin",
-                    showCopyButton = true,
                     onCopyClick = { copiedCode = it },
                 )
             }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -23,7 +23,7 @@ internal data class CodeSample(
  * The prefix is stripped for the display label. The file extension is mapped to
  * a Highlight.js language identifier via [extensionToLanguage].
  *
- * Adding a new sample only requires dropping a file into `assets/samples/` —
+ * Adding a new sample only requires dropping a file into `assets/samples/` -
  * no Kotlin changes needed.
  */
 internal fun loadCodeSamples(context: Context): List<CodeSample> =
@@ -73,7 +73,7 @@ internal data class ThemePair(
     val dark: HighlightTheme,
 )
 
-// Short snippets used in demo sections (not loaded from assets — intentionally inline).
+// Short snippets used in demo sections (not loaded from assets - intentionally inline).
 internal val KOTLIN_SNIPPET =
     """
 data class User(val name: String, val age: Int)
@@ -103,7 +103,7 @@ httpApiClient.get("/users")
     """.trimIndent()
 
 /**
- * Kotlin snippet demonstrating [HighlightTheme.fromAsset] — intentionally shown
+ * Kotlin snippet demonstrating [HighlightTheme.fromAsset] - intentionally shown
  * inside a [dev.hossain.highlight.ui.SyntaxHighlightedCode] block so the demo
  * highlights its own loading code ("eat your own dog food").
  */

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -69,7 +69,7 @@ import kotlinx.coroutines.withContext
  * - **Light/Dark toggle**: switches between the light and dark variant of the selected theme.
  *
  * The GitHub themes are loaded from the sample app's own assets via [HighlightTheme.fromAsset],
- * showcasing that library users can bundle any Highlight.js CSS and use it as a theme — they are
+ * showcasing that library users can bundle any Highlight.js CSS and use it as a theme - they are
  * not limited to the built-in options.
  *
  * Sections are organized into tabs:
@@ -109,7 +109,7 @@ fun SampleScreen() {
             }
         }
 
-    // All available theme pairs — GitHub uses fromAsset() to demonstrate custom themes.
+    // All available theme pairs - GitHub uses fromAsset() to demonstrate custom themes.
     val themePairs =
         remember(context) {
             listOf(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -54,6 +54,7 @@ import dev.hossain.highlight.sample.sections.TogglesSection
 import dev.hossain.highlight.sample.sections.TypographySection
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -247,12 +248,10 @@ fun SampleScreen() {
                                         modifier = Modifier.fillMaxWidth(),
                                         showLineNumbers = sample.language == "python",
                                         onCopyClick = onCopyClick,
-                                        copyButtonIcon = { tint ->
-                                            Icon(
-                                                imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                                                modifier = Modifier.size(16.dp),
+                                        copyButtonContent = { onClick ->
+                                            SyntaxHighlightedCodeDefaults.CopyButton(
+                                                onClick = onClick,
                                                 contentDescription = "Copy code",
-                                                tint = tint,
                                             )
                                         },
                                     )

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -107,7 +107,7 @@ fun PerfScreen() {
                         }
                     },
                     actions = {
-                        // Light/dark toggle — also resets the benchmark since theme affects timing
+                        // Light/dark toggle - also resets the benchmark since theme affects timing
                         IconButton(onClick = {
                             isDark = !isDark
                             metricsMap.clear()

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AdvancedEngineSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AdvancedEngineSection.kt
@@ -57,15 +57,15 @@ private val LightCodeText = Color(0xFF333333)
  * initial load completes. The duration of the single JS call is shown below the code block.
  *
  * Also demonstrates:
- * - Silent failure detection via [HighlightResult.spanCount] — an unsupported language
+ * - Silent failure detection via [HighlightResult.spanCount] - an unsupported language
  *   produces 0 spans instead of throwing, displayed with an error-coloured card.
- * - Raw [dev.hossain.highlight.engine.HighlightEngine.highlightToHtml] pipeline — shows the
+ * - Raw [dev.hossain.highlight.engine.HighlightEngine.highlightToHtml] pipeline - shows the
  *   `<span class="hljs-*">` HTML string before any theme colour is applied.
- * - Pre-warming via [dev.hossain.highlight.engine.HighlightEngine.initialize] — measures
+ * - Pre-warming via [dev.hossain.highlight.engine.HighlightEngine.initialize] - measures
  *   WebView warm-up time with a button-triggered call.
- * - Direct [dev.hossain.highlight.engine.HighlightEngine.highlight] call — full pipeline in a
+ * - Direct [dev.hossain.highlight.engine.HighlightEngine.highlight] call - full pipeline in a
  *   single suspend call, showing [HighlightResult] metrics.
- * - [dev.hossain.highlight.engine.HighlightException] error handling — catches and displays
+ * - [dev.hossain.highlight.engine.HighlightException] error handling - catches and displays
  *   sealed class subtypes in an error-coloured card.
  *
  * @param isDark Whether the global light/dark toggle (from the top-bar button) is currently dark.
@@ -94,7 +94,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         Text(
             text =
                 "Highlights once for both light and dark in a single JS call. " +
-                    "Flip the toggle below — switching is instant after the initial load.",
+                    "Flip the toggle below - switching is instant after the initial load.",
             style = TextStyle(fontSize = 13.sp),
         )
 
@@ -142,7 +142,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Duration metric — read directly from the result state, no separate variable needed
+        // Duration metric - read directly from the result state, no separate variable needed
         result?.let { r ->
             Text(
                 text = "⏱ Both themes highlighted in ${r.durationMs}ms (single JS call)",
@@ -245,7 +245,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // Pre-warming demo
-        SubSectionHeader("Pre-warming — engine.initialize()")
+        SubSectionHeader("Pre-warming - engine.initialize()")
         Text(
             text =
                 "Calling initialize() warms up the hidden WebView before the first highlight. " +
@@ -301,10 +301,10 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // Direct engine.highlight() call demo
-        SubSectionHeader("Direct call — engine.highlight()")
+        SubSectionHeader("Direct call - engine.highlight()")
         Text(
             text =
-                "Use engine.highlight() directly when you need highlighting outside a composable — " +
+                "Use engine.highlight() directly when you need highlighting outside a composable - " +
                     "for example, in a ViewModel or background coroutine. " +
                     "Returns a HighlightResult with the AnnotatedString, span count, and timing.",
             style = TextStyle(fontSize = 13.sp),
@@ -361,7 +361,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // HighlightException error handling demo
-        SubSectionHeader("Error handling — HighlightException")
+        SubSectionHeader("Error handling - HighlightException")
         Text(
             text =
                 "Engine methods return Result<T> and wrap failures in HighlightException subtypes. " +
@@ -373,7 +373,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         var caughtException by remember { mutableStateOf<HighlightException?>(null) }
         Button(onClick = {
             errorScope.launch {
-                // Use a theme pointing to a non-existent asset — colorMap access throws IOException,
+                // Use a theme pointing to a non-existent asset - colorMap access throws IOException,
                 // which is wrapped in HighlightException.HtmlParseFailed by the engine.
                 val brokenTheme =
                     HighlightTheme.fromAsset(
@@ -430,7 +430,7 @@ internal fun AdvancedEngineSection(isDark: Boolean) {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // Comparison note
-        SubSectionHeader("For comparison — standard SyntaxHighlightedCode (re-highlights on toggle)")
+        SubSectionHeader("For comparison - standard SyntaxHighlightedCode (re-highlights on toggle)")
         Text(
             text =
                 "The block below uses the global theme from HighlightThemeProvider. " +

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AllThemesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AllThemesSection.kt
@@ -75,7 +75,7 @@ internal fun AllThemesSection() {
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
-            text = "Browse all ${allThemeNames.size} bundled highlight.js themes — select one to live-preview it.",
+            text = "Browse all ${allThemeNames.size} bundled highlight.js themes - select one to live-preview it.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -28,9 +28,9 @@ import dev.hossain.highlight.ui.rememberHighlightEngine
 
 /**
  * Demonstrates [SyntaxHighlightedCode] event callbacks:
- * - `onHighlightComplete` — shows full [HighlightResult] (duration, span count, language).
- * - `onCopyClick` — custom copy handler with inline feedback.
- * - `rememberHighlightEngine().isInitialized` — shows engine warm-up state.
+ * - `onHighlightComplete` - shows full [HighlightResult] (duration, span count, language).
+ * - `onCopyClick` - custom copy handler with inline feedback.
+ * - `rememberHighlightEngine().isInitialized` - shows engine warm-up state.
  */
 @Composable
 internal fun CallbacksSection() {
@@ -40,7 +40,7 @@ internal fun CallbacksSection() {
         // onHighlightComplete: show full HighlightResult fields
         var highlightResult by remember { mutableStateOf<HighlightResult?>(null) }
 
-        SubSectionHeader("onHighlightComplete — full HighlightResult")
+        SubSectionHeader("onHighlightComplete - full HighlightResult")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -113,13 +113,13 @@ internal fun CallbacksSection() {
         // onCopyClick custom handler demo
         var customCopyMessage by remember { mutableStateOf("") }
 
-        SubSectionHeader("onCopyClick — custom copy handler")
+        SubSectionHeader("onCopyClick - custom copy handler")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
             onCopyClick = { code ->
-                customCopyMessage = "📋 Custom handler received ${code.length} chars — not sent to clipboard!"
+                customCopyMessage = "📋 Custom handler received ${code.length} chars - not sent to clipboard!"
             },
         )
         if (customCopyMessage.isNotEmpty()) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -158,18 +158,19 @@ internal fun CallbacksSection() {
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                        contentDescription = null,
-                        modifier = Modifier.size(12.dp),
-                    )
                     Text(
                         text = "Kotlin",
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Bold,
                     )
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.star_24dp),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
                     Text(
-                        text = "⭐ 42 likes",
+                        text = "42 likes",
                         fontSize = 11.sp,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                     )

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -146,7 +146,7 @@ internal fun CallbacksSection() {
         // languageLabelContent rich custom slot demo
         SubSectionHeader("languageLabelContent — rich custom label")
         Text(
-            text = "The slot accepts any @Composable — icon, bold text, metadata badges, like counts, etc.",
+            text = "The slot accepts any @Composable — here is an example with a custom label, icon, and metadata badge.",
             style = TextStyle(fontSize = 13.sp),
         )
         SyntaxHighlightedCode(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -172,7 +172,9 @@ internal fun CallbacksSection() {
                     Text(
                         text = "42 likes",
                         fontSize = 11.sp,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        color =
+                            androidx.compose.material3.LocalContentColor.current
+                                .copy(alpha = 0.6f),
                     )
                 }
             },

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -2,6 +2,7 @@ package dev.hossain.highlight.sample.sections
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,11 +18,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightResult
@@ -138,6 +141,42 @@ internal fun CallbacksSection() {
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        // languageLabelContent rich custom slot demo
+        SubSectionHeader("languageLabelContent — rich custom label")
+        Text(
+            text = "The slot accepts any @Composable — icon, bold text, metadata badges, like counts, etc.",
+            style = TextStyle(fontSize = 13.sp),
+        )
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            languageLabelContent = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                    )
+                    Text(
+                        text = "Kotlin",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "⭐ 42 likes",
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    )
+                }
+            },
+        )
+
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // copyButtonContent custom slot demo

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -2,13 +2,10 @@ package dev.hossain.highlight.sample.sections
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -18,19 +15,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.sample.PYTHON_SNIPPET
-import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberHighlightEngine
 
@@ -141,62 +133,5 @@ internal fun CallbacksSection() {
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
-        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-        // languageLabelContent rich custom slot demo
-        SubSectionHeader("languageLabelContent — rich custom label")
-        Text(
-            text = "The slot accepts any @Composable — here is an example with a custom label, icon, and metadata badge.",
-            style = TextStyle(fontSize = 13.sp),
-        )
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            languageLabelContent = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = "Kotlin",
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.star_24dp),
-                        contentDescription = null,
-                        modifier = Modifier.size(12.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Text(
-                        text = "42 likes",
-                        fontSize = 11.sp,
-                        color =
-                            androidx.compose.material3.LocalContentColor.current
-                                .copy(alpha = 0.6f),
-                    )
-                }
-            },
-        )
-
-        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-        // copyButtonContent custom slot demo
-        SubSectionHeader("copyButtonContent — custom vector icon")
-        SyntaxHighlightedCode(
-            code = KOTLIN_SNIPPET,
-            language = "kotlin",
-            modifier = Modifier.fillMaxWidth(),
-            copyButtonContent = { onClick ->
-                androidx.compose.material3.IconButton(onClick = onClick) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                        modifier = Modifier.size(16.dp),
-                        contentDescription = "Copy code",
-                    )
-                }
-            },
-        )
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/CallbacksSection.kt
@@ -140,19 +140,20 @@ internal fun CallbacksSection() {
         }
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
-        // copyButtonIcon custom slot demo
-        SubSectionHeader("copyButtonIcon — custom vector icon")
+        // copyButtonContent custom slot demo
+        SubSectionHeader("copyButtonContent — custom vector icon")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
-            copyButtonIcon = { tint ->
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                    modifier = Modifier.size(16.dp),
-                    contentDescription = "Copy code",
-                    tint = tint,
-                )
+            copyButtonContent = { onClick ->
+                androidx.compose.material3.IconButton(onClick = onClick) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                        modifier = Modifier.size(16.dp),
+                        contentDescription = "Copy code",
+                    )
+                }
             },
         )
     }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -80,7 +80,7 @@ internal fun EngineInfoSection() {
         }
 
         // ── Language count badge ──────────────────────────────────────────
-        SubSectionHeader("Supported languages — hljs.listLanguages()")
+        SubSectionHeader("Supported languages - hljs.listLanguages()")
         Surface(
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colorScheme.secondaryContainer,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -39,7 +39,7 @@ import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
 
 /**
- * Interactive styling demo — a single live [SyntaxHighlightedCode] block whose [CodeBlockStyle]
+ * Interactive styling demo - a single live [SyntaxHighlightedCode] block whose [CodeBlockStyle]
  * and visibility flags are controlled via a [ModalBottomSheet].
  *
  * The sheet is opened externally (via the [Scaffold] FAB in [SampleScreen]) by passing
@@ -69,7 +69,7 @@ internal fun StylingSection(
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
 
-    // Build style from current state — recomputed on every state change so the
+    // Build style from current state - recomputed on every state change so the
     // code block behind the sheet updates live.
     val style =
         remember(cornerRadius, contentPadding, headerPadding, lineNumberWidth, copyButtonSize) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -36,6 +36,7 @@ import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.CodeBlockStyle
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
 
 /**
  * Interactive styling demo — a single live [SyntaxHighlightedCode] block whose [CodeBlockStyle]
@@ -94,20 +95,27 @@ internal fun StylingSection(
         modifier = Modifier.fillMaxWidth(),
         style = style,
         showLineNumbers = showLineNumbers,
-        showLanguageLabel = showLanguageLabel,
-        showCopyButton = showCopyButton,
-        copyButtonIcon =
-            if (useCustomCopyIcon) {
-                { tint ->
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
-                        contentDescription = "Copy code",
-                        tint = tint,
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
+        languageLabelContent =
+            if (showLanguageLabel) {
+                { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
             } else {
                 null
+            },
+        copyButtonContent =
+            if (!showCopyButton) {
+                null
+            } else if (useCustomCopyIcon) {
+                { onClick ->
+                    androidx.compose.material3.IconButton(onClick = onClick) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                            contentDescription = "Copy code",
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                }
+            } else {
+                { onClick -> SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick) }
             },
     )
 

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
@@ -67,16 +67,16 @@ private val MATERIAL3_LIGHT_CSS =
 /**
  * Demonstrates all four [HighlightTheme] factory methods:
  * - Built-in: [HighlightTheme.atomOneDark] (one representative bundled theme)
- * - [HighlightTheme.fromAsset] — any highlight.js CSS saved in `assets/`
- * - [HighlightTheme.fromCss] — Material 3–inspired inline CSS
- * - [HighlightTheme.fromColorMap] — Material 3–inspired precomputed color map (dark variant)
+ * - [HighlightTheme.fromAsset] - any highlight.js CSS saved in `assets/`
+ * - [HighlightTheme.fromCss] - Material 3–inspired inline CSS
+ * - [HighlightTheme.fromColorMap] - Material 3–inspired precomputed color map (dark variant)
  */
 @Composable
 internal fun ThemeCreationSection() {
-    // Built-in theme — @Composable helper resolves LocalContext internally
+    // Built-in theme - @Composable helper resolves LocalContext internally
     val atomOneDarkTheme = rememberAtomOneDarkTheme()
 
-    // fromCss() — Material 3–inspired inline CSS string
+    // fromCss() - Material 3–inspired inline CSS string
     val material3LightTheme =
         remember {
             HighlightTheme.fromCss(
@@ -85,7 +85,7 @@ internal fun ThemeCreationSection() {
             )
         }
 
-    // fromColorMap() — Material 3–inspired precomputed dark color map
+    // fromColorMap() - Material 3–inspired precomputed dark color map
     val material3DarkTheme =
         remember {
             HighlightTheme.fromColorMap(
@@ -119,7 +119,7 @@ internal fun ThemeCreationSection() {
         Text(
             text =
                 "The library bundles 4 ready-to-use themes: atomOneDark, atomOneLight, " +
-                    "tomorrow, and tomorrowNight. No extra assets needed — just call the " +
+                    "tomorrow, and tomorrowNight. No extra assets needed - just call the " +
                     "corresponding factory function. Here is atomOneDark as an example:",
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(horizontal = 4.dp),

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
@@ -26,8 +26,8 @@ import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
 
 /**
  * Demonstrates every [SyntaxHighlightedCode] visibility option:
- * - `languageLabelContent` — default, null (hidden), and rich custom slot
- * - `copyButtonContent` — default, null (hidden), and custom vector icon
+ * - `languageLabelContent` - default, null (hidden), and rich custom slot
+ * - `copyButtonContent` - default, null (hidden), and custom vector icon
  * - `showLineNumbers` × `languageLabelContent` (2×2)
  */
 @Composable
@@ -35,9 +35,9 @@ internal fun TogglesSection() {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        SubSectionHeader("languageLabelContent — rich custom label")
+        SubSectionHeader("languageLabelContent - rich custom label")
         androidx.compose.material3.Text(
-            text = "The slot accepts any @Composable — here is an example with a custom label, icon, and metadata badge.",
+            text = "The slot accepts any @Composable - here is an example with a custom label, icon, and metadata badge.",
             style =
                 androidx.compose.ui.text
                     .TextStyle(fontSize = 13.sp),
@@ -73,7 +73,7 @@ internal fun TogglesSection() {
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
-        SubSectionHeader("copyButtonContent — custom vector icon")
+        SubSectionHeader("copyButtonContent - custom vector icon")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
@@ -2,26 +2,95 @@ package dev.hossain.highlight.sample.sections
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.sample.PYTHON_SNIPPET
+import dev.hossain.highlight.sample.R
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
 
 /**
  * Demonstrates every [SyntaxHighlightedCode] visibility option:
+ * - `languageLabelContent` — default, null (hidden), and rich custom slot
+ * - `copyButtonContent` — default, null (hidden), and custom vector icon
  * - `showLineNumbers` × `languageLabelContent` (2×2)
- * - `copyButtonContent` on/off
  */
 @Composable
 internal fun TogglesSection() {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        SubSectionHeader("languageLabelContent — rich custom label")
+        androidx.compose.material3.Text(
+            text = "The slot accepts any @Composable — here is an example with a custom label, icon, and metadata badge.",
+            style =
+                androidx.compose.ui.text
+                    .TextStyle(fontSize = 13.sp),
+        )
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            languageLabelContent = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    androidx.compose.material3.Text(
+                        text = "Kotlin",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.star_24dp),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    androidx.compose.material3.Text(
+                        text = "42 likes",
+                        fontSize = 11.sp,
+                        color = LocalContentColor.current.copy(alpha = 0.6f),
+                    )
+                }
+            },
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        SubSectionHeader("copyButtonContent — custom vector icon")
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            copyButtonContent = { onClick ->
+                androidx.compose.material3.IconButton(onClick = onClick) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
+                        modifier = Modifier.size(16.dp),
+                        contentDescription = "Copy code",
+                    )
+                }
+            },
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
         SubSectionHeader("showLineNumbers=false, languageLabelContent=default")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
@@ -13,67 +13,64 @@ import dev.hossain.highlight.sample.PYTHON_SNIPPET
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 /**
- * Demonstrates every [SyntaxHighlightedCode] boolean flag combination:
- * - `showLineNumbers` × `showLanguageLabel` (2×2)
- * - `showCopyButton` on/off
+ * Demonstrates every [SyntaxHighlightedCode] visibility option:
+ * - `showLineNumbers` × `languageLabelContent` (2×2)
+ * - `copyButtonContent` on/off
  */
 @Composable
 internal fun TogglesSection() {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        SubSectionHeader("showLineNumbers=false, showLanguageLabel=true (defaults)")
+        SubSectionHeader("showLineNumbers=false, languageLabelContent=default")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
             showLineNumbers = false,
-            showLanguageLabel = true,
         )
 
-        SubSectionHeader("showLineNumbers=true, showLanguageLabel=true")
+        SubSectionHeader("showLineNumbers=true, languageLabelContent=default")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
             showLineNumbers = true,
-            showLanguageLabel = true,
         )
 
-        SubSectionHeader("showLineNumbers=false, showLanguageLabel=false")
+        SubSectionHeader("showLineNumbers=false, languageLabelContent=null (hidden)")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
             showLineNumbers = false,
-            showLanguageLabel = false,
+            languageLabelContent = null,
         )
 
-        SubSectionHeader("showLineNumbers=true, showLanguageLabel=false")
+        SubSectionHeader("showLineNumbers=true, languageLabelContent=null (hidden)")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
             showLineNumbers = true,
-            showLanguageLabel = false,
+            languageLabelContent = null,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
-        SubSectionHeader("showCopyButton=true (default)")
+        SubSectionHeader("copyButtonContent=default")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
-            showCopyButton = true,
         )
 
-        SubSectionHeader("showCopyButton=false")
+        SubSectionHeader("copyButtonContent=null (hidden)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
-            showCopyButton = false,
+            copyButtonContent = null,
         )
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TogglesSection.kt
@@ -141,5 +141,16 @@ internal fun TogglesSection() {
             modifier = Modifier.fillMaxWidth(),
             copyButtonContent = null,
         )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        SubSectionHeader("languageLabelContent=null + copyButtonContent=null (header row hidden)")
+        SyntaxHighlightedCode(
+            code = KOTLIN_SNIPPET,
+            language = "kotlin",
+            modifier = Modifier.fillMaxWidth(),
+            languageLabelContent = null,
+            copyButtonContent = null,
+        )
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TypographySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/TypographySection.kt
@@ -28,14 +28,14 @@ internal fun TypographySection() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Font size variants
-        SubSectionHeader("textStyle — fontSize = 13.sp (default)")
+        SubSectionHeader("textStyle - fontSize = 13.sp (default)")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
             modifier = Modifier.fillMaxWidth(),
         )
 
-        SubSectionHeader("textStyle — fontSize = 15.sp")
+        SubSectionHeader("textStyle - fontSize = 15.sp")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
@@ -46,7 +46,7 @@ internal fun TypographySection() {
                 ),
         )
 
-        SubSectionHeader("textStyle — fontSize = 18.sp")
+        SubSectionHeader("textStyle - fontSize = 18.sp")
         SyntaxHighlightedCode(
             code = PYTHON_SNIPPET,
             language = "python",
@@ -60,14 +60,14 @@ internal fun TypographySection() {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // Line height variants
-        SubSectionHeader("textStyle — lineHeight = 20.sp (default)")
+        SubSectionHeader("textStyle - lineHeight = 20.sp (default)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
         )
 
-        SubSectionHeader("textStyle — lineHeight = 28.sp (spacious)")
+        SubSectionHeader("textStyle - lineHeight = 28.sp (spacious)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -81,14 +81,14 @@ internal fun TypographySection() {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
         // Font family variants
-        SubSectionHeader("textStyle — fontFamily = FontFamily.Monospace (default)")
+        SubSectionHeader("textStyle - fontFamily = FontFamily.Monospace (default)")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
             modifier = Modifier.fillMaxWidth(),
         )
 
-        SubSectionHeader("textStyle — fontFamily = FontFamily.Serif")
+        SubSectionHeader("textStyle - fontFamily = FontFamily.Serif")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",
@@ -99,7 +99,7 @@ internal fun TypographySection() {
                 ),
         )
 
-        SubSectionHeader("textStyle — fontFamily = FontFamily.SansSerif")
+        SubSectionHeader("textStyle - fontFamily = FontFamily.SansSerif")
         SyntaxHighlightedCode(
             code = KOTLIN_SNIPPET,
             language = "kotlin",

--- a/sample/src/main/res/drawable/star_24dp.xml
+++ b/sample/src/main/res/drawable/star_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m354,673 l126,-76 126,77 -33,-144 111,-96 -146,-13 -58,-136 -58,135 -146,13 111,97 -33,143ZM263,798.46 L320.31,551.69 128.85,385.77 381.46,363.85L480,131.16l98.54,232.69 252.61,21.92 -191.46,165.92L697,798.46 480,667.54 263,798.46ZM480,490Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/stars_2_24dp.xml
+++ b/sample/src/main/res/drawable/stars_2_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M336.31,694.16 L480,607.77l144.08,87.77 -37.62,-163.62 126.39,-109.07 -166.39,-14.93L480,253.46l-66.08,153.46 -166.38,14.54 126.38,110.46 -37.61,162.24ZM245.31,820 L307.23,554L100,374.62l273.39,-23.47L480,100l107,251.15 273.38,23.47L653.15,554l61.93,266L480,678.69 245.31,820ZM693.46,281.15 L712.92,199.08 647.31,144.31 734,137.08 767.31,59.62 800.61,137.08 887.31,144.31 821.69,199.08 841.15,281.15 767.31,237.62 693.46,281.15ZM480.38,474Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
## Summary

Implements all items from issue #103 — full slot API hardening for `SyntaxHighlightedCode`.

## Changes

### Breaking (library)
- **`showLanguageLabel: Boolean`** removed; replaced by `languageLabelContent: (@Composable () -> Unit)?`
  - `null` hides the badge; non-null renders custom content
  - Default shows the language identifier in a dimmed style
- **`showCopyButton: Boolean`**, **`copyButtonIcon: (@Composable (tint: Color) -> Unit)?`**, **`copyButtonContentDescription: String`** removed (3 params); replaced by `copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)?`
  - `null` hides the button; slot receives a pre-wired `onClick` action
  - Default uses `SyntaxHighlightedCodeDefaults.CopyButton`
- `Surface` now explicitly sets `contentColor = textColor` so `LocalContentColor.current` resolves correctly inside both slots

### Additive (library)
- `SyntaxHighlightedCodeDefaults.CopyButton` — composable helper with `onClick`, `tint`, `contentDescription`, and `size` params
- `SyntaxHighlightedCodeDefaults.LanguageLabel` — composable helper with `language`, `color`, and `fontSize` params

### Internal
- Private `LineNumberedCode` composable now has `modifier: Modifier = Modifier` applied to its root `Row`
- Private `CopyButton` removed (superseded by `SyntaxHighlightedCodeDefaults.CopyButton`)

## Migration guide

```kotlin
// Before
SyntaxHighlightedCode(
    code = snippet,
    language = "kotlin",
    showLanguageLabel = false,
    showCopyButton = true,
    copyButtonIcon = { tint -> Icon(..., tint = tint) },
    copyButtonContentDescription = "Copy",
)

// After
SyntaxHighlightedCode(
    code = snippet,
    language = "kotlin",
    languageLabelContent = null,                    // hide label
    copyButtonContent = { onClick ->                // full button slot
        IconButton(onClick = onClick) { Icon(...) }
    },
)
```

Closes #103