### PR TITLE
fix: apply system dark/light color scheme to MaterialTheme for status bar legibility

### DIFF
--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/MainActivity.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
 
 class MainActivity : ComponentActivity() {
@@ -14,7 +17,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            MaterialTheme {
+            MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     SampleScreen()
                 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfActivity.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfActivity.kt
@@ -4,7 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 
 /**
  * Performance benchmark Activity that renders all code samples in a scrollable list and
@@ -17,7 +20,7 @@ class PerfActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            MaterialTheme {
+            MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()) {
                 PerfScreen()
             }
         }


### PR DESCRIPTION
## Problem

The status bar icons were invisible on devices in dark mode. `enableEdgeToEdge()` from `ComponentActivity` correctly sets **light (white) icons** when the system is in dark mode - but `MaterialTheme` had no `colorScheme` parameter, so it always defaulted to Material3's **light color scheme** (white backgrounds). The result: white icons on a white TopAppBar background.

## Fix

Pass `colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()` to `MaterialTheme` in both `MainActivity` and `PerfActivity`. Now the app's background color always matches the icon color chosen by `enableEdgeToEdge()`, keeping status bar icons legible in both light and dark mode.

## Files changed

- `sample/.../MainActivity.kt`
- `sample/.../perf/PerfActivity.kt`