### PR TITLE
Remove AI assistance note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 A Jetpack Compose library for beautiful syntax highlighting — powered by [Highlight.js](https://highlightjs.org/) running in a hidden WebView, converting tokenised HTML output to native Compose `AnnotatedString`. No custom lexers, no bundled grammars to maintain: just drop in the library and highlight any of 190+ languages.
 
-
-> [!NOTE]
-> This project was developed with the assistance of AI coding agents (GitHub Copilot).
-> Code, architecture, tests, and documentation were generated or refined through
-> AI-assisted pair programming. Review accordingly before using in production.
-
 ---
 
 ## Quick Start


### PR DESCRIPTION
Removed note about AI assistance in project development.

🤔 I think the commit and contribution author gives it away! doesn't have to be up in the face.