### PR TITLE
docs: document why minSdk is 24 (required by AndroidX WebKit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Run on your target device to get accurate numbers. Results are printed in logcat
 
 ## Requirements
 
-- Android minSdk 24+
+- Android minSdk 24+ (required by [AndroidX WebKit](https://developer.android.com/jetpack/androidx/releases/webkit))
 - Kotlin 2.x
 - Jetpack Compose (BOM 2026.05+)
 

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 24 // required by androidx.webkit
         testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] =
             "DEBUGGABLE,EMULATOR,LOW-BATTERY,UNLOCKED"


### PR DESCRIPTION
Adds a brief note in README.md and a comment in `compose-highlight/build.gradle.kts` explaining that the minSdk 24 requirement comes from the `androidx.webkit` dependency.