### PR TITLE
fix: make copyButtonSize work and add custom language label demo to StylingSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`CodeBlockStyle.copyButtonSize` now takes effect on the default copy button** - previously
+  the value was stored in `CodeBlockStyle` but never forwarded to `SyntaxHighlightedCodeDefaults.CopyButton`,
+  so changing it had no visible impact. The default button now correctly reads `style.copyButtonSize`.
+- **`SyntaxHighlightedCodeDefaults.CopyButton` - `size` parameter now scales the icon glyph** -
+  previously the `⧉` glyph was rendered at a hardcoded `16.sp` regardless of the `size` argument.
+  Font size is now derived proportionally from `size` (`size * 0.5f`), so the glyph visually
+  scales when `copyButtonSize` is changed via `CodeBlockStyle` or passed directly.
+
 ## [0.19.0] - 2026-05-17
 
 ### Changed (Breaking)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -37,6 +37,12 @@ import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import kotlinx.coroutines.launch
 
+// Sentinel used to detect when the caller did not supply a custom copyButtonContent.
+// This allows the composable body to resolve the default CopyButton with the correct
+// size from CodeBlockStyle.copyButtonSize, which cannot be referenced in a parameter
+// default value (Kotlin does not allow forward references to other parameters).
+private val DefaultCopyButtonSentinel: (@Composable (onClick: () -> Unit) -> Unit) = { }
+
 /**
  * Displays syntax-highlighted code in a styled block.
  *
@@ -156,9 +162,7 @@ fun SyntaxHighlightedCode(
         } else {
             null
         },
-    copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)? = { onClick ->
-        SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick)
-    },
+    copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)? = DefaultCopyButtonSentinel,
     onCopyClick: ((String) -> Unit)? = null,
     onHighlightComplete: ((HighlightResult) -> Unit)? = null,
 ) {
@@ -184,6 +188,19 @@ fun SyntaxHighlightedCode(
     val themedCodeStyle = remember(theme, style) { style.textStyle.copy(color = textColor) }
     val themedLineNumStyle = remember(theme, style) { style.textStyle.copy(color = lineNumberColor) }
 
+    // Resolve the effective copy button: when the caller used the default (sentinel),
+    // substitute a real lambda that forwards style.copyButtonSize so the CodeBlockStyle
+    // property actually takes effect.
+    val effectiveCopyButton: (@Composable (onClick: () -> Unit) -> Unit)? =
+        when {
+            copyButtonContent === DefaultCopyButtonSentinel -> {
+                { onClick -> SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick, size = style.copyButtonSize) }
+            }
+
+            else -> {
+                copyButtonContent
+            }
+        }
     // In Android Studio Preview, WebView cannot be created. Render a themed fallback
     // (using the active theme's background and text colors) so that @Preview composables
     // work without crashing.
@@ -215,7 +232,7 @@ fun SyntaxHighlightedCode(
     ) {
         Column {
             // Header: language badge + copy button
-            if (languageLabelContent != null || copyButtonContent != null) {
+            if (languageLabelContent != null || effectiveCopyButton != null) {
                 Row(
                     modifier =
                         Modifier
@@ -225,8 +242,8 @@ fun SyntaxHighlightedCode(
                 ) {
                     languageLabelContent?.invoke()
                     Spacer(modifier = Modifier.weight(1f))
-                    if (copyButtonContent != null) {
-                        copyButtonContent {
+                    if (effectiveCopyButton != null) {
+                        effectiveCopyButton {
                             val handler = onCopyClick
                             if (handler != null) {
                                 handler(code)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
@@ -133,7 +133,7 @@ object SyntaxHighlightedCodeDefaults {
         ) {
             Text(
                 text = "⧉",
-                style = TextStyle(color = tint, fontSize = 16.sp),
+                style = TextStyle(color = tint, fontSize = (size.value * 0.5f).sp),
             )
         }
     }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -65,6 +65,7 @@ internal fun StylingSection(
     var showLineNumbers by remember { mutableStateOf(true) }
     var showLanguageLabel by remember { mutableStateOf(true) }
     var showCopyButton by remember { mutableStateOf(true) }
+    var useCustomLanguageLabel by remember { mutableStateOf(false) }
     var useCustomCopyIcon by remember { mutableStateOf(false) }
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
@@ -96,10 +97,25 @@ internal fun StylingSection(
         style = style,
         showLineNumbers = showLineNumbers,
         languageLabelContent =
-            if (showLanguageLabel) {
-                { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
-            } else {
+            if (!showLanguageLabel) {
                 null
+            } else if (useCustomLanguageLabel) {
+                {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(text = "Kotlin", style = MaterialTheme.typography.labelMedium)
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.stars_2_24dp),
+                            contentDescription = null,
+                            modifier = Modifier.size(12.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            } else {
+                { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
             },
         copyButtonContent =
             if (!showCopyButton) {
@@ -146,6 +162,7 @@ internal fun StylingSection(
                 SheetSectionLabel("Visibility")
                 ToggleRow("Show line numbers", showLineNumbers) { showLineNumbers = it }
                 ToggleRow("Show language label", showLanguageLabel) { showLanguageLabel = it }
+                ToggleRow("Custom language label", useCustomLanguageLabel) { useCustomLanguageLabel = it }
                 ToggleRow("Show copy button", showCopyButton) { showCopyButton = it }
                 ToggleRow("Custom copy icon", useCustomCopyIcon) { useCustomCopyIcon = it }
 

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StylingSection.kt
@@ -106,16 +106,19 @@ internal fun StylingSection(
                 null
             } else if (useCustomCopyIcon) {
                 { onClick ->
-                    androidx.compose.material3.IconButton(onClick = onClick) {
+                    androidx.compose.material3.IconButton(
+                        onClick = onClick,
+                        modifier = Modifier.size(style.copyButtonSize),
+                    ) {
                         Icon(
                             imageVector = ImageVector.vectorResource(R.drawable.content_copy_24dp),
                             contentDescription = "Copy code",
-                            modifier = Modifier.size(16.dp),
+                            modifier = Modifier.size(style.copyButtonSize * 0.5f),
                         )
                     }
                 }
             } else {
-                { onClick -> SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick) }
+                { onClick -> SyntaxHighlightedCodeDefaults.CopyButton(onClick = onClick, size = style.copyButtonSize) }
             },
     )
 


### PR DESCRIPTION
## Summary

Fixes `CodeBlockStyle.copyButtonSize` having no visual effect, and adds a custom language label toggle to the Styling section demo.

## Library bug fixes

### `CodeBlockStyle.copyButtonSize` was silently ignored
- Added a private `DefaultCopyButtonSentinel` in `SyntaxHighlightedCode` - Kotlin does not allow default parameter values to reference sibling parameters, so the sentinel is resolved in the function body to forward `style.copyButtonSize` to `CopyButton`.

### `CopyButton(size=...)` glyph did not scale
- The `size` parameter only resized the touch target (`IconButton`), but the `glyph` was hardcoded at `16.sp`. Font size is now derived as `size * 0.5f` so the icon visually scales (default 32dp still produces 16sp).

## Sample changes

- `StylingSection`: forward `style.copyButtonSize` in both the default and custom icon `copyButtonContent` lambdas.
- `StylingSection`: add `useCustomLanguageLabel` toggle to the bottom sheet, demonstrating the `languageLabelContent` slot live - mirrors the demo already in TogglesSection.

## Changelog
Updated `CHANGELOG.md` with both bug fixes under `[Unreleased]`.