### PR TITLE
chore: prepare release 0.19.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -117,7 +117,20 @@ This script updates all four required files in one step:
 
 Never update these files manually one-by-one - always use the script to avoid missing files.
 
-Only create the git tag after all of the above are committed and pushed.
+After running the script, create a release branch, run all checks, commit, push, and open a PR into `main` (direct pushes to `main` are blocked by branch protection):
+```bash
+git checkout -b release/<new-version>
+./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test
+git add -A && git commit -m "chore: prepare release <new-version>"
+git push -u origin release/<new-version>
+gh pr create --title "chore: prepare release <new-version>" --base main
+```
+
+Only create the git tag **after the release PR is merged** and `main` is pulled:
+```bash
+git checkout main && git pull
+git tag <new-version> && git push origin <new-version>
+```
 
 **Publishing to Maven Central is a manual two-step workflow - it is NOT triggered automatically by pushing a tag.** After tagging:
 1. Manually trigger the publish GitHub Actions workflow in **dry-run mode** first and verify it passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-05-18
+
 ### Fixed
 - **`CodeBlockStyle.copyButtonSize` now takes effect on the default copy button** - previously
   the value was stored in `CodeBlockStyle` but never forwarded to `SyntaxHighlightedCodeDefaults.CopyButton`,

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the [dependency](https://central.sonatype.com/artifact/dev.hossain/compose-h
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.19.0")
+    implementation("dev.hossain:compose-highlight:0.19.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.19.0
+VERSION_NAME=0.19.1
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21
-        versionName = "0.19.0"
+        versionCode = 22
+        versionName = "0.19.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Version bump for 0.19.1 release.

- `gradle.properties`: VERSION_NAME 0.19.0 -> 0.19.1
- `README.md`: dependency snippet updated
- `sample/build.gradle.kts`: versionName 0.19.1, versionCode 22
- `CHANGELOG.md`: `[Unreleased]` renamed to `[0.19.1] - 2026-05-18`