### PR TITLE
fix: add missing imports to resolve Dokka KDoc link warnings in HighlightEngine

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -3,6 +3,8 @@ package dev.hossain.highlight.engine
 import android.content.Context
 import android.webkit.WebView
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import dev.hossain.highlight.ui.rememberHighlightEngine
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException


### PR DESCRIPTION
Fixes two Dokka warnings seen in CI:

```
w: Couldn't resolve link: [SpanStyle] in HighlightEngine.kt
w: Couldn't resolve link: [rememberHighlightEngine] in HighlightEngine.kt
```

Both symbols are referenced in KDoc but were not imported, so Dokka could not resolve the links. Adding the imports for `SpanStyle` and `rememberHighlightEngine` fixes the warnings.