### PR TITLE
ci: skip full build for docs-only or non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,41 @@ on:
   pull_request:
     branches: [ main ]
 
+# Skip the full build when only docs, assets, scripts, or repo config files change.
+# The `skip` job runs instead and satisfies the required branch protection check.
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'compose-highlight/**'
+              - 'sample/**'
+              - 'gradle/**'
+              - '*.kts'
+              - 'gradle.properties'
+              - '.github/workflows/ci.yml'
+
+  skip:
+    name: Build & Test
+    needs: changes
+    if: needs.changes.outputs.code == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: No code changes - skipping build
+        run: echo "Only non-code files changed. Skipping build and test."
+
   build-and-test:
     name: Build & Test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,32 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            code:
-              - 'compose-highlight/**'
-              - 'sample/**'
-              - 'gradle/**'
-              - '*.kts'
-              - 'gradle.properties'
-              - '.github/workflows/ci.yml'
+          fetch-depth: 0
+      - name: Check for code changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED=$(git diff --name-only HEAD^1 HEAD 2>/dev/null || git diff --name-only HEAD)
+          fi
+          echo "Changed files:"
+          echo "$CHANGED"
+          CODE_CHANGED=false
+          while IFS= read -r file; do
+            if [[ "$file" == compose-highlight/* || \
+                  "$file" == sample/* || \
+                  "$file" == gradle/* || \
+                  "$file" == *.kts || \
+                  "$file" == "gradle.properties" || \
+                  "$file" == ".github/workflows/ci.yml" ]]; then
+              CODE_CHANGED=true
+              break
+            fi
+          done <<< "$CHANGED"
+          echo "code=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Code changed: $CODE_CHANGED"
 
   skip:
     name: Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         run: ./gradlew :sample:assembleDebug
 
       - name: Upload test results
-        if: steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true' || failure()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,26 @@ on:
   pull_request:
     branches: [ main ]
 
-# Skip the full build when only docs, assets, scripts, or repo config files change.
-# The `skip` job runs instead and satisfies the required branch protection check.
+permissions:
+  contents: read
+  pull-requests: read
+
+# Skip the heavy Android build when only docs, assets, scripts, or repo config files change.
+# A single always-running "Build & Test" job satisfies the required branch protection check
+# in all cases - it exits early with a success message for non-code changes.
 jobs:
-  changes:
-    name: Detect changed paths
+  build-and-test:
+    name: Build & Test
     runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
+
     steps:
-      - uses: actions/checkout@v6.0.2
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+
       - name: Check for code changes
-        id: filter
+        id: changes
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
@@ -43,43 +49,32 @@ jobs:
           echo "code=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
           echo "Code changed: $CODE_CHANGED"
 
-  skip:
-    name: Build & Test
-    needs: changes
-    if: needs.changes.outputs.code == 'false'
-    runs-on: ubuntu-latest
-    steps:
       - name: No code changes - skipping build
+        if: steps.changes.outputs.code == 'false'
         run: echo "Only non-code files changed. Skipping build and test."
 
-  build-and-test:
-    name: Build & Test
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
       - name: Set up JDK 17
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
+        if: steps.changes.outputs.code == 'true'
         uses: gradle/actions/setup-gradle@v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Enable KVM (required for hardware-accelerated emulation)
+        if: steps.changes.outputs.code == 'true'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
       - name: Cache ATD system image
+        if: steps.changes.outputs.code == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -88,23 +83,29 @@ jobs:
           key: managed-device-pixel2api30-aosp-atd-${{ runner.os }}
 
       - name: Check Kotlin formatting
+        if: steps.changes.outputs.code == 'true'
         run: ./gradlew lintKotlin
 
       - name: Run unit tests
+        if: steps.changes.outputs.code == 'true'
         run: ./gradlew :compose-highlight:testDebugUnitTest
 
       - name: Accept Android SDK licenses
+        if: steps.changes.outputs.code == 'true'
         run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 
       - name: Run instrumented tests on Gradle Managed Device (ATD)
+        if: steps.changes.outputs.code == 'true'
         run: |
           ./gradlew :compose-highlight:pixel2api30DebugAndroidTest \
             -P android.testInstrumentationRunnerArguments.notPackage=dev.hossain.highlight.benchmark
 
       - name: Generate combined coverage report
+        if: steps.changes.outputs.code == 'true'
         run: ./gradlew :compose-highlight:jacocoTestReport
 
       - name: Upload coverage reports to Codecov
+        if: steps.changes.outputs.code == 'true'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -113,13 +114,15 @@ jobs:
           fail_ci_if_error: false
 
       - name: Assemble library (debug)
+        if: steps.changes.outputs.code == 'true'
         run: ./gradlew :compose-highlight:assembleDebug
 
       - name: Assemble sample app (debug)
+        if: steps.changes.outputs.code == 'true'
         run: ./gradlew :sample:assembleDebug
 
       - name: Upload test results
-        if: always()
+        if: steps.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: test-results


### PR DESCRIPTION
## Summary

Optimizes the CI workflow so docs-only PRs (logo, Zensical config, README updates, etc.) don't trigger a 10+ minute Android build.

## How it works

A `Check for code changes` step runs first using `git diff` to detect whether any source code files were modified.

| Changed files | What runs |
|---|---|
| `compose-highlight/`, `sample/`, `gradle/`, `*.kts`, `gradle.properties`, `ci.yml` | All build/test steps run as before |
| Anything else (`docs/`, `resources/`, `zensical.toml`, `README.md`, scripts, etc.) | Job exits after the detection step - passes in seconds |

## Design

- **Single `Build & Test` job** with per-step `if: steps.changes.outputs.code == 'true'` conditions - no duplicate job names, no ambiguity with required status checks
- **Pure `git diff` approach** - no third-party actions, no Node.js deprecation warnings
- **`permissions:` block** added for least-privilege `GITHUB_TOKEN` access (`contents: read`, `pull-requests: read`)
- **Test artifact upload** uses `steps.changes.outputs.code == 'true' || failure()` so debugging artifacts are always preserved on failure
