### PR TITLE
docs: update release process to use PR branch workflow

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -73,10 +73,17 @@ Then verify everything builds and tests pass:
 ./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test
 ```
 
-Commit, push, and create the git tag:
+Create a release branch, commit, push, and open a PR (direct pushes to `main` are blocked):
 ```bash
+git checkout -b release/0.18.0
 git add -A && git commit -m "chore: prepare release 0.18.0"
-git push
+git push -u origin release/0.18.0
+gh pr create --title "chore: prepare release 0.18.0" --base main
+```
+
+After the PR is merged, pull `main` and create the git tag:
+```bash
+git checkout main && git pull
 git tag 0.18.0 && git push origin 0.18.0
 ```
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -13,8 +13,16 @@
 #
 # After running, verify the diff with `git diff`, then:
 #   ./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test
+#   git checkout -b release/<version>
 #   git add -A && git commit -m "chore: prepare release <version>"
-#   git push && git tag <version> && git push origin <version>
+#   git push -u origin release/<version>
+#   gh pr create --title "chore: prepare release <version>" --base main
+#
+# After the PR is merged:
+#   git checkout main && git pull
+#   git tag <version> && git push origin <version>
+#
+# Then trigger the publish workflow manually (dry run first, then real).
 
 set -euo pipefail
 
@@ -65,6 +73,17 @@ echo ""
 echo "Done. Verify with: git diff"
 echo ""
 echo "Next steps:"
-echo "  ./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test"
-echo "  git add -A && git commit -m \"chore: prepare release $NEW_VERSION\""
-echo "  git push && git tag $NEW_VERSION && git push origin $NEW_VERSION"
+echo "  1. Run checks:"
+echo "     ./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test"
+echo ""
+echo "  2. Create a release branch, commit, push, and open a PR:"
+echo "     git checkout -b release/$NEW_VERSION"
+echo "     git add -A && git commit -m \"chore: prepare release $NEW_VERSION\""
+echo "     git push -u origin release/$NEW_VERSION"
+echo "     gh pr create --title \"chore: prepare release $NEW_VERSION\" --base main"
+echo ""
+echo "  3. After the PR is merged, pull main and create the git tag:"
+echo "     git checkout main && git pull"
+echo "     git tag $NEW_VERSION && git push origin $NEW_VERSION"
+echo ""
+echo "  4. Trigger the publish workflow manually (dry run first, then real)."


### PR DESCRIPTION
## Summary

The `prepare-release.sh` script and `PUBLISHING.md` both showed tagging directly after `git push`, but main is branch-protected - direct pushes are blocked. Both files now reflect the correct workflow.

## Changes

### `scripts/prepare-release.sh`
- Updated the header comment and the printed "Next steps" to show the release branch + PR workflow
- Step 1: run checks
- Step 2: create `release/<version>` branch, commit, push, open PR
- Step 3: after PR is merged, pull main and tag

### `PUBLISHING.md`
- Updated Step 1 to use `git checkout -b release/` and `gh pr create` before tagging
- Tag is created only after the release PR is merged

## No code changes
This is documentation-only - CI will skip the full build.