### PR TITLE
[UPDATE] Add Shiki syntax highlighting for Kotlin code blocks

### DIFF
--- a/docs/javascripts/shiki-kotlin.js
+++ b/docs/javascripts/shiki-kotlin.js
@@ -1,0 +1,76 @@
+import { codeToHtml } from 'https://esm.sh/shiki@4.1.0'
+
+async function highlightKotlinBlocks() {
+  const wrappers = document.querySelectorAll(
+    'div.language-kotlin.highlight, div.language-kt.highlight'
+  )
+
+  if (wrappers.length === 0) return
+
+  for (const wrapper of wrappers) {
+    if (wrapper.hasAttribute('data-shiki-done')) continue
+
+    const pre = wrapper.querySelector('pre')
+    if (!pre) continue
+
+    const block = pre.querySelector('code')
+    if (!block) continue
+
+    const code = block.textContent
+
+    try {
+      const html = await codeToHtml(code, {
+        lang: 'kotlin',
+        // Themes: change these to switch Shiki color schemes.
+        // Browse all options at https://shiki.style/themes
+        // Other themes tried:
+        //   light: 'github-light', 'horizon-bright'
+        //   dark:  'github-dark',  'horizon'
+        themes: {
+          light: 'one-light',
+          dark: 'one-dark-pro',
+        },
+        defaultColor: false,
+      })
+
+      const tempDiv = document.createElement('div')
+      tempDiv.innerHTML = html
+
+      const shikiPre = tempDiv.querySelector('pre')
+      if (!shikiPre) continue
+
+      const shikiCode = shikiPre.querySelector('code')
+      if (!shikiCode) continue
+
+      // Swap just the code innerHTML and apply Shiki's CSS variables to existing elements.
+      // This preserves the DOM structure that Zensical's bundle uses for copy buttons.
+      block.innerHTML = shikiCode.innerHTML
+
+      // Apply Shiki's CSS custom properties to the pre without removing existing styles
+      const shikiStyle = shikiPre.getAttribute('style') || ''
+      const cssVars = shikiStyle.match(/--shiki[^;]+;?/g) || []
+      pre.style.cssText += cssVars.join('')
+      pre.setAttribute('data-shiki', 'true')
+
+      wrapper.setAttribute('data-shiki-done', 'true')
+    } catch (e) {
+      console.warn('[shiki-kotlin] Failed to highlight block:', e)
+    }
+  }
+}
+
+// Run on initial page load
+highlightKotlinBlocks()
+
+// Re-run on SPA navigation (Zensical/Material instant navigation)
+if (typeof document$ !== 'undefined') {
+  document$.subscribe(() => highlightKotlinBlocks())
+} else {
+  const waitForDocStream = setInterval(() => {
+    if (typeof document$ !== 'undefined') {
+      document$.subscribe(() => highlightKotlinBlocks())
+      clearInterval(waitForDocStream)
+    }
+  }, 200)
+  setTimeout(() => clearInterval(waitForDocStream), 10000)
+}

--- a/docs/javascripts/shiki-kotlin.js
+++ b/docs/javascripts/shiki-kotlin.js
@@ -1,5 +1,8 @@
 import { codeToHtml } from 'https://esm.sh/shiki@4.1.0'
 
+// Finds Kotlin code blocks rendered by Pygments and re-highlights them with Shiki.
+// Only swaps inner <code> content - preserves the <pre> and wrapper <div> so that
+// Zensical's copy buttons, positioning, and background styling remain intact.
 async function highlightKotlinBlocks() {
   const wrappers = document.querySelectorAll(
     'div.language-kotlin.highlight, div.language-kt.highlight'

--- a/docs/stylesheets/shiki-kotlin.css
+++ b/docs/stylesheets/shiki-kotlin.css
@@ -1,0 +1,17 @@
+/* Shiki-highlighted Kotlin code blocks */
+
+/* Ensure Shiki's line spans render as blocks so blank lines are visible */
+pre[data-shiki] code .line {
+  display: block;
+  min-height: 1.45em;
+}
+
+/* Light mode: use --shiki-light colors on spans */
+[data-md-color-scheme="default"] pre[data-shiki] span {
+  color: var(--shiki-light) !important;
+}
+
+/* Dark mode: use --shiki-dark colors on spans */
+[data-md-color-scheme="slate"] pre[data-shiki] span {
+  color: var(--shiki-dark) !important;
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,6 +9,12 @@ docs_dir         = "docs"
 repo_name        = "hossain-khan/android-compose-highlight"
 repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
+extra_css        = ["stylesheets/shiki-kotlin.css"]
+
+[[project.extra_javascript]]
+path = "javascripts/shiki-kotlin.js"
+type = "module"
+async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [


### PR DESCRIPTION
  ## Summary

  - Adds client-side Shiki (v4.1.0) highlighting for Kotlin code blocks, replacing Pygments' limited Kotlin grammar with VS Code-quality TextMate grammars
  - Pygments remains the default for all other languages - only Kotlin blocks are enhanced
  - Uses One Light / One Dark Pro themes with instant CSS variable-based theme switching

💬  Ref: https://discord.com/channels/1289187620659789824/1506439799500701768/1506439799500701768

Fixes #128 

  ## What's changed

  - `docs/javascripts/shiki-kotlin.js` - ES module that finds Kotlin blocks, highlights with Shiki, and injects spans into existing DOM (preserving copy buttons)
  - `docs/stylesheets/shiki-kotlin.css` - Maps Shiki CSS variables to light/dark themes, fixes blank line rendering
  - `zensical.toml` - Registers the new JS and CSS assets

  ## Why

  Pygments' regex-based Kotlin lexer doesn't distinguish types from variables, misses modern syntax (sealed interfaces, value classes, DSLs), and lags behind
  language updates. Shiki uses the same TextMate grammars as VS Code for accurate, fine-grained highlighting.

  ## How it works

  1. Pygments renders Kotlin blocks at build time (as before)
  2. On page load, Shiki re-highlights them client-side
  3. Only the inner `<code>` HTML is swapped - `<pre>` and wrapper `<div>` stay intact
  4. `defaultColor: false` embeds both theme colors as CSS variables for instant light/dark switching
  5. `document$.subscribe()` handles SPA page transitions

  ## Details

  See #128 for full implementation notes, gotchas, and theme options.