### PR TITLE
docs: replace em dashes with hyphens across all docs pages

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ SyntaxHighlightedCode(
 )
 ```
 
-The composable shows unstyled monospace text immediately and fades in highlighted colors once the WebView finishes processing — no visible flicker.
+The composable shows unstyled monospace text immediately and fades in highlighted colors once the WebView finishes processing - no visible flicker.
 
 ---
 
@@ -126,7 +126,7 @@ Requires `androidx.webkit:webkit:1.16+` (already a transitive dependency of this
 
 ## Next steps
 
-- [Theming guide](guides/theming.md) — built-in themes, custom CSS, dynamic colors
-- [Customization guide](guides/customization.md) — custom language label and copy button slots
-- [Performance guide](guides/performance.md) — shared engine, warm-up, timing callbacks
-- [API reference](reference/index.md) — full parameter documentation
+- [Theming guide](guides/theming.md) - built-in themes, custom CSS, dynamic colors
+- [Customization guide](guides/customization.md) - custom language label and copy button slots
+- [Performance guide](guides/performance.md) - shared engine, warm-up, timing callbacks
+- [API reference](reference/index.md) - full parameter documentation

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -2,7 +2,7 @@
 
 ## Language label
 
-The language label is a composable slot — replace it with any `@Composable`:
+The language label is a composable slot - replace it with any `@Composable`:
 
 ```kotlin
 import dev.hossain.highlight.ui.SyntaxHighlightedCode

--- a/docs/guides/engine-only.md
+++ b/docs/guides/engine-only.md
@@ -102,6 +102,6 @@ engine.highlight(code, language, theme)
 
 ## Important rules
 
-- Always pass `applicationContext` — never an Activity context. The engine retains the context beyond Activity lifecycle.
+- Always pass `applicationContext` - never an Activity context. The engine retains the context beyond Activity lifecycle.
 - Always call `destroy()` to release the WebView when done. Use `rememberHighlightEngine()` in Compose for automatic lifecycle management.
-- `HighlightEngine` is safe to call from any coroutine — all WebView operations are automatically dispatched to the Main thread internally.
+- `HighlightEngine` is safe to call from any coroutine - all WebView operations are automatically dispatched to the Main thread internally.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -6,8 +6,8 @@ The most impactful optimization is wrapping your content in `HighlightThemeProvi
 
 | Setup | WebViews | Warm-up cost |
 |---|---|---|
-| No provider — 3 blocks | 3 | ~600 ms |
-| With provider — 3 blocks | 1 | ~200 ms |
+| No provider - 3 blocks | 3 | ~600 ms |
+| With provider - 3 blocks | 1 | ~200 ms |
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
@@ -140,7 +140,7 @@ Use `.inWholeMilliseconds` to get a `Long`, or `.inWholeNanoseconds` for finer g
 
 ## `isInitialized` state flow
 
-Observe engine readiness reactively — for example to show a loading indicator:
+Observe engine readiness reactively - for example to show a loading indicator:
 
 ```kotlin
 import dev.hossain.highlight.ui.SyntaxHighlightedCode

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -61,7 +61,7 @@ HighlightThemeProvider(darkHighlightTheme = theme) { ... }
 ```
 
 !!! note
-    Always call `context.applicationContext` — never pass an Activity context to `HighlightTheme` factories, as the theme is retained beyond the Activity's lifecycle.
+    Always call `context.applicationContext` - never pass an Activity context to `HighlightTheme` factories, as the theme is retained beyond the Activity's lifecycle.
 
 ## Custom theme from raw CSS
 
@@ -76,7 +76,7 @@ val theme = HighlightTheme.fromCss(cssText = rawCss, name = "remote-theme")
 
 ## Custom theme from a color map
 
-Maximum flexibility — derive colors from Material 3 dynamic color, user palettes, or brand colors:
+Maximum flexibility - derive colors from Material 3 dynamic color, user palettes, or brand colors:
 
 ```kotlin
 import dev.hossain.highlight.engine.HighlightTheme
@@ -97,7 +97,7 @@ val theme = HighlightTheme.fromColorMap(
 
 ## Providing a theme without `HighlightThemeProvider`
 
-For one-off use — pass the theme directly:
+For one-off use - pass the theme directly:
 
 ```kotlin
 import dev.hossain.highlight.ui.SyntaxHighlightedCode

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,20 +40,20 @@ That's it. `HighlightThemeProvider` automatically picks Tomorrow (light) or Tomo
 
 ## Key features
 
-- **180+ languages** — every language Highlight.js supports
-- **Light + dark themes** — automatic system-mode switching, or manual override
-- **Built-in themes** — Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light
-- **Custom themes** — load any Highlight.js CSS from `assets/`, raw CSS string, or a `Map<String, SpanStyle>`
-- **Slots** — replace the language badge and copy button with any composable
-- **Line numbers** — optional gutter with configurable width and color
-- **Copy to clipboard** — built-in, with an `onCopyClick` callback for custom feedback
-- **Performance** — one hidden WebView shared across all code blocks via `HighlightThemeProvider`
+- **180+ languages** - every language Highlight.js supports
+- **Light + dark themes** - automatic system-mode switching, or manual override
+- **Built-in themes** - Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light
+- **Custom themes** - load any Highlight.js CSS from `assets/`, raw CSS string, or a `Map<String, SpanStyle>`
+- **Slots** - replace the language badge and copy button with any composable
+- **Line numbers** - optional gutter with configurable width and color
+- **Copy to clipboard** - built-in, with an `onCopyClick` callback for custom feedback
+- **Performance** - one hidden WebView shared across all code blocks via `HighlightThemeProvider`
 
 ---
 
 ## Next steps
 
-- [Getting Started](getting-started.md) — full setup walkthrough
-- [API Reference](reference/index.md) — all public classes and functions
-- [Guides](guides/theming.md) — theming, customization, line numbers, performance
-- [Changelog](changelog.md) — release history
+- [Getting Started](getting-started.md) - full setup walkthrough
+- [API Reference](reference/index.md) - all public classes and functions
+- [Guides](guides/theming.md) - theming, customization, line numbers, performance
+- [Changelog](changelog.md) - release history

--- a/docs/reference/code-block-style.md
+++ b/docs/reference/code-block-style.md
@@ -17,7 +17,7 @@ Visual style configuration for `SyntaxHighlightedCode`.
 The default `textStyle` is `SyntaxHighlightedCodeDefaults.codeTextStyle`: monospace font, 13 sp size, 20 sp line height.
 
 !!! note
-    The theme's foreground color is applied on top of `textStyle.color` at render time — any explicit `color` you set here is overridden by the active `HighlightTheme`.
+    The theme's foreground color is applied on top of `textStyle.color` at render time - any explicit `color` you set here is overridden by the active `HighlightTheme`.
 
 ## Presets
 

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -2,7 +2,7 @@
 
 The core engine that manages the hidden WebView and executes Highlight.js highlighting.
 
-For most use cases, use `SyntaxHighlightedCode` inside a `HighlightThemeProvider` — it handles the engine lifecycle automatically. Use `HighlightEngine` directly only when you need lower-level control, such as highlighting in a ViewModel or outside of Compose.
+For most use cases, use `SyntaxHighlightedCode` inside a `HighlightThemeProvider` - it handles the engine lifecycle automatically. Use `HighlightEngine` directly only when you need lower-level control, such as highlighting in a ViewModel or outside of Compose.
 
 ## Lifecycle
 
@@ -12,7 +12,7 @@ The engine holds a hidden WebView resource. Always call `destroy()` when done. I
 
 | Method | Description |
 |---|---|
-| `suspend initialize()` | Warms up the WebView. Optional — `highlight()` also initializes on first call |
+| `suspend initialize()` | Warms up the WebView. Optional - `highlight()` also initializes on first call |
 | `suspend highlight(code, language, theme)` | Full pipeline: tokenize, apply theme, return `Result<HighlightResult>` (access `.annotated` for the `AnnotatedString`) |
 | `suspend highlightBothThemes(code, language, lightTheme, darkTheme)` | Highlight once, return `Result<ThemedHighlightResult>` (access `.light` and `.dark` for the `AnnotatedString` variants) |
 | `suspend highlightToHtml(code, language)` | Returns `Result<HtmlHighlightResult>` (access `.html` for the HTML string, `.jsBridgeDuration` and `.jsonUnescapeDuration` for timing) |
@@ -21,7 +21,7 @@ The engine holds a hidden WebView resource. Always call `destroy()` when done. I
 | `fun destroy()` | Releases the WebView and clears caches |
 | `val isInitialized: StateFlow<Boolean>` | Observe WebView readiness reactively |
 
-All suspend methods return `Result<T>` — never throw. Wrap failures in `HighlightException`.
+All suspend methods return `Result<T>` - never throw. Wrap failures in `HighlightException`.
 
 ## Usage in a ViewModel
 
@@ -72,7 +72,7 @@ fun MyCodeBlock(code: String) {
 
 ## Highlight both themes (instant switching)
 
-Tokenizes once, applies two color maps — theme switching has zero extra latency:
+Tokenizes once, applies two color maps - theme switching has zero extra latency:
 
 ```kotlin
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -2,7 +2,7 @@
 
 Represents a syntax highlighting theme backed by a Highlight.js CSS file.
 
-The color map is lazily initialized and cached — CSS parsing happens at most once per theme instance.
+The color map is lazily initialized and cached - CSS parsing happens at most once per theme instance.
 
 ## Built-in themes
 
@@ -44,7 +44,7 @@ HighlightThemeProvider(lightHighlightTheme = theme) { ... }
 ```
 
 !!! note
-    `fromAsset()` is lazy — CSS parsing happens on first use, not at factory-call time.
+    `fromAsset()` is lazy - CSS parsing happens on first use, not at factory-call time.
 
 ## Custom theme from raw CSS
 
@@ -60,7 +60,7 @@ val theme = HighlightTheme.fromCss(
 
 ## Custom theme from a color map
 
-For full control — e.g. deriving colors from Material 3 dynamic color:
+For full control - e.g. deriving colors from Material 3 dynamic color:
 
 ```kotlin
 import dev.hossain.highlight.engine.HighlightTheme
@@ -81,7 +81,7 @@ val theme = HighlightTheme.fromColorMap(
 
 ## Theme identity
 
-`HighlightTheme` uses `name` for `equals()` and `hashCode()`. Compose APIs (`remember`, `LaunchedEffect`) detect theme changes by name. **Names must be unique** — do not create two themes with different content but the same name.
+`HighlightTheme` uses `name` for `equals()` and `hashCode()`. Compose APIs (`remember`, `LaunchedEffect`) detect theme changes by name. **Names must be unique** - do not create two themes with different content but the same name.
 
 ## Properties
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,13 +4,13 @@ This section documents the public API of `compose-highlight`.
 
 | Class / Function | Description |
 |---|---|
-| [`SyntaxHighlightedCode`](syntax-highlighted-code.md) | Primary composable — renders a styled, highlighted code block |
+| [`SyntaxHighlightedCode`](syntax-highlighted-code.md) | Primary composable - renders a styled, highlighted code block |
 | [`HighlightThemeProvider`](syntax-highlighted-code.md#highlightthemeprovider) | Provides a shared theme and engine to a composable subtree |
 | [`CodeBlockStyle`](code-block-style.md) | Visual style configuration (shape, padding, font, copy button size) |
 | [`SyntaxHighlightedCodeDefaults`](code-block-style.md#syntaxhighlightedcodedefaults) | Default constants and helper composables (`CopyButton`, `LanguageLabel`) |
 | [`HighlightTheme`](highlight-theme.md) | Theme model backed by a Highlight.js CSS file |
 | [`HighlightEngine`](highlight-engine.md) | Lower-level engine for custom highlighting pipelines |
-| `rememberHighlightedCode` | Composable helper — highlights code and returns an `AnnotatedString` state |
+| `rememberHighlightedCode` | Composable helper - highlights code and returns an `AnnotatedString` state |
 | `rememberHighlightedCodeBothThemes` | Highlights once, produces light + dark variants |
 | `rememberHighlightEngine` | Returns the shared or standalone `HighlightEngine` for the current composition |
 | `rememberTomorrowTheme` | Composable factory for the built-in Tomorrow (light) theme |

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -2,7 +2,7 @@
 
 The primary public composable. Displays syntax-highlighted code in a styled block.
 
-Shows unstyled monospace code immediately while async highlighting runs, then fades in the highlighted version when ready — no visible flicker.
+Shows unstyled monospace code immediately while async highlighting runs, then fades in the highlighted version when ready - no visible flicker.
 
 ## Signature
 
@@ -34,7 +34,7 @@ fun SyntaxHighlightedCode(
 | `language` | `String` | - | Highlight.js language identifier (e.g. `"kotlin"`, `"python"`) |
 | `modifier` | `Modifier` | `Modifier` | Modifier for the outer container |
 | `theme` | `HighlightTheme` | `LocalHighlightTheme.current` | Theme to use. Throws if no `HighlightThemeProvider` is present and no explicit theme is passed |
-| `style` | `CodeBlockStyle` | `CodeBlockStyle.Default` | Visual style — shape, padding, font, copy button size |
+| `style` | `CodeBlockStyle` | `CodeBlockStyle.Default` | Visual style - shape, padding, font, copy button size |
 | `showLineNumbers` | `Boolean` | `false` | Whether to show a line-number gutter |
 | `languageLabelContent` | `(@Composable () -> Unit)?` | Default badge | Header language badge slot. `null` hides it |
 | `copyButtonContent` | `(@Composable (onClick: () -> Unit) -> Unit)?` | Default button | Header copy button slot. `null` hides it |
@@ -157,7 +157,7 @@ fun HighlightThemeProvider(
 )
 ```
 
-Creates **one shared WebView** for the entire subtree. Screens with multiple `SyntaxHighlightedCode` blocks share this single WebView instead of creating one per block — saving ~200 ms warm-up time and ~2-4 MB RAM per extra block.
+Creates **one shared WebView** for the entire subtree. Screens with multiple `SyntaxHighlightedCode` blocks share this single WebView instead of creating one per block - saving ~200 ms warm-up time and ~2-4 MB RAM per extra block.
 
 ### Force a specific theme mode
 


### PR DESCRIPTION
## Summary

All em dash `—` characters in the `docs/` directory replaced with regular hyphen-minus `-` per project writing style conventions.

## Files changed (11)
- `docs/index.md`
- `docs/getting-started.md`
- `docs/guides/theming.md`
- `docs/guides/performance.md`
- `docs/guides/engine-only.md`
- `docs/guides/customization.md`
- `docs/reference/index.md`
- `docs/reference/syntax-highlighted-code.md`
- `docs/reference/highlight-engine.md`
- `docs/reference/highlight-theme.md`
- `docs/reference/code-block-style.md`

## Notes
- Docs-only change - CI will skip the full Android build.