### PR TITLE
Add dedicated bridge validation workflow

### DIFF
--- a/.github/workflows/bridge-validation.yml
+++ b/.github/workflows/bridge-validation.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Validate bridge.html syntax
         run: |
-          npx --yes htmlhint@1.6.3 \
+          npx --yes htmlhint@1.9.2 \
             --rules 'doctype-first:true,tag-pair:true,tagname-lowercase:true,attr-lowercase:true,attr-value-double-quotes:true,id-unique:true,src-not-empty:true,title-require:false' \
             compose-highlight/src/main/assets/compose-highlight/bridge.html
 

--- a/.github/workflows/bridge-validation.yml
+++ b/.github/workflows/bridge-validation.yml
@@ -1,0 +1,56 @@
+name: Bridge Validation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - compose-highlight/src/main/assets/compose-highlight/bridge.html
+      - compose-highlight/src/main/assets/compose-highlight/highlight.min.js
+      - compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt
+      - .github/workflows/bridge-validation.yml
+  pull_request:
+    branches: [ main ]
+    paths:
+      - compose-highlight/src/main/assets/compose-highlight/bridge.html
+      - compose-highlight/src/main/assets/compose-highlight/highlight.min.js
+      - compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt
+      - .github/workflows/bridge-validation.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate-bridge:
+    name: Validate Bridge HTML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+
+      - name: Validate bridge.html syntax
+        run: |
+          npx --yes htmlhint@1.6.3 \
+            --rules 'doctype-first:true,tag-pair:true,tagname-lowercase:true,attr-lowercase:true,attr-value-double-quotes:true,id-unique:true,src-not-empty:true,title-require:false' \
+            compose-highlight/src/main/assets/compose-highlight/bridge.html
+
+      - name: Validate bridge API contract
+        run: |
+          BRIDGE_FILE="compose-highlight/src/main/assets/compose-highlight/bridge.html"
+          WEBVIEW_FILE="compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt"
+
+          grep -q '<script src="highlight.min.js"></script>' "$BRIDGE_FILE"
+          grep -Eq 'function[[:space:]]+highlightCode[[:space:]]*\(' "$BRIDGE_FILE"
+          grep -Eq 'function[[:space:]]+listLanguages[[:space:]]*\(' "$BRIDGE_FILE"
+          grep -Eq 'function[[:space:]]+hljsVersion[[:space:]]*\(' "$BRIDGE_FILE"
+          grep -q 'getElementById("code")' "$BRIDGE_FILE"
+
+          grep -q 'https://appassets.androidplatform.net/assets/compose-highlight/bridge.html' "$WEBVIEW_FILE"
+
+      - name: Bridge validation passed
+        run: echo "bridge.html contract and syntax checks passed"

--- a/.github/workflows/bridge-validation.yml
+++ b/.github/workflows/bridge-validation.yml
@@ -44,11 +44,11 @@ jobs:
           BRIDGE_FILE="compose-highlight/src/main/assets/compose-highlight/bridge.html"
           WEBVIEW_FILE="compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt"
 
-          grep -q '<script src="highlight.min.js"></script>' "$BRIDGE_FILE"
+          grep -Eiq "<script[^>]*src=[\"']highlight\\.min\\.js[\"'][^>]*>" "$BRIDGE_FILE"
           grep -Eq 'function[[:space:]]+highlightCode[[:space:]]*\(' "$BRIDGE_FILE"
           grep -Eq 'function[[:space:]]+listLanguages[[:space:]]*\(' "$BRIDGE_FILE"
           grep -Eq 'function[[:space:]]+hljsVersion[[:space:]]*\(' "$BRIDGE_FILE"
-          grep -q 'getElementById("code")' "$BRIDGE_FILE"
+          grep -Eq "getElementById[[:space:]]*\([[:space:]]*['\"]code['\"][[:space:]]*\)|querySelector[[:space:]]*\([[:space:]]*['\"]#code['\"][[:space:]]*\)" "$BRIDGE_FILE"
 
           grep -q 'https://appassets.androidplatform.net/assets/compose-highlight/bridge.html' "$WEBVIEW_FILE"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Bridge validation workflow** - added `.github/workflows/bridge-validation.yml` to validate
+  `compose-highlight/src/main/assets/compose-highlight/bridge.html` in CI. The workflow runs
+  HTML syntax checks and enforces the JS bridge contract (`highlightCode`, `listLanguages`,
+  `hljsVersion`) plus the expected WebView `bridge.html` load URL.
+
 ## [0.19.1] - 2026-05-18
 
 ### Fixed


### PR DESCRIPTION
## Summary
Add a dedicated GitHub Actions workflow to validate the bundled native bridge HTML contract.

## Changes
- Add `.github/workflows/bridge-validation.yml`
- Run HTML syntax checks for `compose-highlight/src/main/assets/compose-highlight/bridge.html` using HTMLHint
- Validate bridge API contract in `bridge.html`:
  - `highlightCode(...)`
  - `listLanguages(...)`
  - `hljsVersion(...)`
  - expected `highlight.min.js` script include
  - expected `getElementById("code")` lookup
- Validate expected WebView load URL remains in `WebViewManager.kt`
- Scope workflow triggers to bridge-related file changes only
- Update action/runtime versions:
  - `actions/checkout@v6.0.2`
  - `actions/setup-node@v6.4.0`
  - Node.js `24`
- Add changelog entry under `[Unreleased]`

## Notes
- Local Android build checks could not be completed in this dev container before PR creation because Android SDK is not installed.
- CI on this PR will provide authoritative validation.