### PR TITLE
docs + sample: language discoverability documentation and demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `HighlightEngine.getLanguage()` - looks up a language by name or alias via `hljs.getLanguage()`, returns `HighlightLanguageInfo` (name + aliases list) or null if not found
 - `AutoHighlightResult` data class - result of `highlightAuto()` with `detectedLanguage`, `annotated`, `spanCount`, `durationMs`, and `timings`
 - `HighlightLanguageInfo` data class - result of `getLanguage()` with `name` and `aliases`
+- Documentation and sample app demos for the language discoverability APIs, including a new language selection guide, `HighlightLanguage` reference, and interactive sample tab covering `fromExtension()`, `getLanguage()`, and `highlightAuto()`
 - **Bridge validation workflow** - added `.github/workflows/bridge-validation.yml` to validate
   `compose-highlight/src/main/assets/compose-highlight/bridge.html` in CI. The workflow runs
   HTML syntax checks and enforces the JS bridge contract (`highlightCode`, `listLanguages`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,4 +129,5 @@ Requires `androidx.webkit:webkit:1.16+` (already a transitive dependency of this
 - [Theming guide](guides/theming.md) - built-in themes, custom CSS, dynamic colors
 - [Customization guide](guides/customization.md) - custom language label and copy button slots
 - [Performance guide](guides/performance.md) - shared engine, warm-up, timing callbacks
+- [Language selection guide](guides/language-selection.md) - resolve language from file extensions, validate names, auto-detect
 - [API reference](reference/index.md) - full parameter documentation

--- a/docs/guides/language-selection.md
+++ b/docs/guides/language-selection.md
@@ -12,7 +12,7 @@ SyntaxHighlightedCode(code = snippet, language = "typescript")
 SyntaxHighlightedCode(code = snippet, language = "sql")
 ```
 
-For a full list of supported language names, call `engine.supportedLanguages()` at runtime or see the [HighlightLanguage reference](../reference/highlight-language.md).
+For a full list of supported language identifiers, call `engine.supportedLanguages()` at runtime. For the extension-to-language mapping, see the [HighlightLanguage reference](../reference/highlight-language.md).
 
 ---
 

--- a/docs/guides/language-selection.md
+++ b/docs/guides/language-selection.md
@@ -1,6 +1,6 @@
 # Language Selection
 
-Highlight.js requires a language identifier to tokenize code. This guide covers three helpers to make language selection easier.
+Highlight.js requires a language identifier to tokenize code. This guide covers four options for language selection, including three helper APIs.
 
 ## Option 1 - Pass the language name directly
 

--- a/docs/guides/language-selection.md
+++ b/docs/guides/language-selection.md
@@ -1,0 +1,99 @@
+# Language Selection
+
+Highlight.js requires a language identifier to tokenize code. This guide covers three helpers to make language selection easier.
+
+## Option 1 - Pass the language name directly
+
+The simplest approach - just pass any Highlight.js language name:
+
+```kotlin
+SyntaxHighlightedCode(code = snippet, language = "kotlin")
+SyntaxHighlightedCode(code = snippet, language = "typescript")
+SyntaxHighlightedCode(code = snippet, language = "sql")
+```
+
+For a full list of supported language names, call `engine.supportedLanguages()` at runtime or see the [HighlightLanguage reference](../reference/highlight-language.md).
+
+---
+
+## Option 2 - Resolve from a file extension
+
+`HighlightLanguage.fromExtension()` maps a file extension to its Highlight.js identifier:
+
+```kotlin
+import dev.hossain.highlight.engine.HighlightLanguage
+
+val language = HighlightLanguage.fromExtension("kt")  // "kotlin"
+val unknown  = HighlightLanguage.fromExtension("xyz") // null
+```
+
+Typical usage when displaying a file:
+
+```kotlin
+val file = File("MainActivity.kt")
+val language = HighlightLanguage.fromExtension(file.extension) ?: "plaintext"
+
+SyntaxHighlightedCode(
+    code     = file.readText(),
+    language = language,
+)
+```
+
+See the full [extension map](../reference/highlight-language.md#supported-extensions).
+
+---
+
+## Option 3 - Look up a language by name or alias
+
+`HighlightEngine.getLanguage()` validates that a language is recognized by the bundled Highlight.js and returns its metadata:
+
+```kotlin
+engine.getLanguage("ts").onSuccess { info ->
+    if (info != null) {
+        println(info.name)    // "TypeScript"
+        println(info.aliases) // [ts, tsx, mts, cts]
+    } else {
+        println("Not recognized")
+    }
+}
+```
+
+Useful when accepting user-supplied language input and wanting to validate it before passing it to `highlight()`.
+
+---
+
+## Option 4 - Auto-detect the language
+
+When the language is completely unknown, use `highlightAuto()` to let Highlight.js guess:
+
+```kotlin
+engine.highlightAuto(code, theme).onSuccess { result ->
+    val detected = result.detectedLanguage // e.g. "python", or "" if undetected
+    Text(text = result.annotated)
+}
+```
+
+> Auto-detection inspects all bundled languages, so it is slower than explicit highlighting. Use it as a fallback, not a default.
+
+---
+
+## Putting it together
+
+A practical pattern combining all options:
+
+```kotlin
+suspend fun highlight(file: File, theme: HighlightTheme): AnnotatedString {
+    // 1. Try resolving from the extension
+    val language = HighlightLanguage.fromExtension(file.extension)
+
+    return if (language != null) {
+        // 2. Known extension - highlight directly
+        engine.highlight(file.readText(), language, theme)
+            .getOrNull()?.annotated
+    } else {
+        // 3. Unknown extension - fall back to auto-detect
+        engine.highlightAuto(file.readText(), theme)
+            .getOrNull()?.annotated
+    } ?: AnnotatedString(file.readText())
+}
+```

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -18,6 +18,8 @@ The engine holds a hidden WebView resource. Always call `destroy()` when done. I
 | `suspend highlightToHtml(code, language)` | Returns `Result<HtmlHighlightResult>` (access `.html` for the HTML string, `.jsBridgeDuration` and `.jsonUnescapeDuration` for timing) |
 | `suspend supportedLanguages()` | Returns the list of languages the bundled Highlight.js supports |
 | `suspend highlightJsVersion()` | Returns the bundled Highlight.js version string |
+| `suspend getLanguage(nameOrAlias)` | Returns `Result<HighlightLanguageInfo?>` - null success means language not recognized |
+| `suspend highlightAuto(code, theme)` | Auto-detect language and highlight, returns `Result<AutoHighlightResult>` |
 | `fun destroy()` | Releases the WebView and clears caches |
 | `val isInitialized: StateFlow<Boolean>` | Observe WebView readiness reactively |
 
@@ -108,6 +110,63 @@ Returned by `highlightBothThemes()`. Holds both light and dark variants produced
 | `dark` | Syntax-highlighted `AnnotatedString` styled with the dark theme |
 | `durationMs` | Total wall-clock time in milliseconds for the full highlight call |
 | `timings` | Per-stage `HighlightTimings` breakdown (same fields as `HighlightResult.timings`) |
+
+## `HighlightLanguageInfo`
+
+Returned by `getLanguage()`. Contains the human-readable display name and registered aliases for a language.
+
+| Property | Description |
+|---|---|
+| `name` | Human-readable display name (e.g. `"Kotlin"`, `"Python"`) - not the language identifier |
+| `aliases` | Registered Highlight.js aliases (e.g. `["kt", "kts"]`) |
+
+```kotlin
+engine.getLanguage("kt").onSuccess { info ->
+    if (info != null) {
+        println("Name: ${info.name}")       // "Kotlin"
+        println("Aliases: ${info.aliases}") // [kt, kts]
+    } else {
+        println("Language not found")
+    }
+}
+```
+
+## `AutoHighlightResult`
+
+Returned by `highlightAuto()`. Contains the highlighted output and the language hljs detected.
+
+| Property | Description |
+|---|---|
+| `annotated` | The highlighted `AnnotatedString` |
+| `detectedLanguage` | Language hljs guessed (may be an empty string if detection failed) |
+| `spanCount` | Number of style spans applied |
+| `durationMs` | Total wall-clock time in milliseconds |
+| `timings` | Per-stage `HighlightTimings` breakdown |
+
+## Language lookup and auto-detection
+
+### `getLanguage()`
+
+```kotlin
+// Check if a language is recognized and inspect its aliases
+engine.getLanguage("ts").onSuccess { info ->
+    if (info != null) {
+        // info.name    = "TypeScript"
+        // info.aliases = [ts, tsx, mts, cts]
+    }
+}
+```
+
+### `highlightAuto()`
+
+Use when the language is unknown - hljs will attempt to detect it:
+
+```kotlin
+engine.highlightAuto(code, theme).onSuccess { result ->
+    val language = result.detectedLanguage // e.g. "python" or "" if undetected
+    Text(text = result.annotated)
+}
+```
 
 ## `rememberHighlightEngine`
 

--- a/docs/reference/highlight-language.md
+++ b/docs/reference/highlight-language.md
@@ -1,0 +1,119 @@
+# HighlightLanguage
+
+A pure-Kotlin helper that maps file extensions to Highlight.js language identifiers.
+
+This is a **convenience helper only**. The `language` parameter on `SyntaxHighlightedCode` and `HighlightEngine.highlight()` is still a plain `String` - you can always pass any Highlight.js language name directly. `HighlightLanguage` just makes it easier to resolve the right name from a file extension.
+
+## `fromExtension()`
+
+```kotlin
+fun fromExtension(extension: String): String?
+```
+
+Returns the Highlight.js language identifier for the given file extension (without a leading dot), or `null` if the extension is not recognized.
+
+The lookup is case-insensitive and locale-safe (uses `Locale.ROOT`).
+
+```kotlin
+HighlightLanguage.fromExtension("kt")   // "kotlin"
+HighlightLanguage.fromExtension("KT")   // "kotlin"
+HighlightLanguage.fromExtension("py")   // "python"
+HighlightLanguage.fromExtension("xyz")  // null
+```
+
+## Usage - resolve language from a filename
+
+```kotlin
+val file = File("MainActivity.kt")
+val extension = file.extension          // "kt"
+val language = HighlightLanguage.fromExtension(extension) ?: "plaintext"
+
+SyntaxHighlightedCode(
+    code     = file.readText(),
+    language = language,
+)
+```
+
+## Supported extensions
+
+Extensions are grouped by language family below.
+
+| Extensions | Language |
+|---|---|
+| `kt`, `kts` | kotlin |
+| `java` | java |
+| `py`, `pyw`, `pyi` | python |
+| `js`, `mjs`, `cjs`, `jsx` | javascript |
+| `ts`, `mts`, `cts`, `tsx` | typescript |
+| `c`, `h` | c |
+| `cpp`, `cc`, `cxx`, `hpp`, `hh` | cpp |
+| `cs` | csharp |
+| `rs` | rust |
+| `go` | go |
+| `swift` | swift |
+| `rb`, `rbw` | ruby |
+| `php`, `phtml` | php |
+| `scala` | scala |
+| `groovy` | groovy |
+| `gradle` | gradle |
+| `dart` | dart |
+| `ex`, `exs` | elixir |
+| `erl`, `hrl` | erlang |
+| `hs`, `lhs` | haskell |
+| `fs`, `fsi`, `fsx` | fsharp |
+| `ml`, `mli` | ocaml |
+| `clj`, `cljs`, `cljc` | clojure |
+| `lua` | lua |
+| `r` | r |
+| `m`, `mm` | objectivec |
+| `pl`, `pm` | perl |
+| `sh`, `bash`, `zsh` | bash |
+| `ps1`, `psm1`, `psd1` | powershell |
+| `sql` | sql |
+| `html`, `htm` | html |
+| `xhtml`, `xml`, `svg`, `xsl` | xml |
+| `css` | css |
+| `scss` | scss |
+| `less` | less |
+| `json`, `jsonc` | json |
+| `yaml`, `yml` | yaml |
+| `toml` | toml |
+| `md`, `markdown` | markdown |
+| `dockerfile` | dockerfile |
+| `makefile`, `mk` | makefile |
+| `tex`, `latex` | latex |
+| `diff`, `patch` | diff |
+| `ini`, `cfg`, `conf` | ini |
+| `properties` | properties |
+| `vim` | vim |
+| `cmake` | cmake |
+| `proto` | protobuf |
+| `glsl` | glsl |
+| `bat`, `cmd` | dos |
+| `asm`, `s` | x86asm |
+| `graphql`, `gql` | graphql |
+| `txt` | plaintext |
+| `jl` | julia |
+| `nim`, `nims` | nim |
+| `vb` | vbnet |
+| `vbs` | vbscript |
+| `coffee` | coffeescript |
+| `wat` | wasm |
+| `haml` | haml |
+| `hbs`, `handlebars` | handlebars |
+| `styl` | stylus |
+| `cr` | crystal |
+| `elm` | elm |
+| `hx` | haxe |
+| `scm`, `ss` | scheme |
+| `qml` | qml |
+| `d` | d |
+| `f`, `f90`, `f95`, `for` | fortran |
+| `awk` | awk |
+| `tcl`, `tk` | tcl |
+| `lisp`, `lsp` | lisp |
+| `applescript`, `scpt` | applescript |
+| `nix` | nix |
+| `nginx` | nginx |
+| `pgsql` | pgsql |
+| `pro` | prolog |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,6 +10,9 @@ This section documents the public API of `compose-highlight`.
 | [`SyntaxHighlightedCodeDefaults`](code-block-style.md#syntaxhighlightedcodedefaults) | Default constants and helper composables (`CopyButton`, `LanguageLabel`) |
 | [`HighlightTheme`](highlight-theme.md) | Theme model backed by a Highlight.js CSS file |
 | [`HighlightEngine`](highlight-engine.md) | Lower-level engine for custom highlighting pipelines |
+| [`HighlightLanguage`](highlight-language.md) | Maps file extensions to Highlight.js language identifiers |
+| [`HighlightLanguageInfo`](highlight-engine.md#highlightlanguageinfo) | Metadata returned by `HighlightEngine.getLanguage()` |
+| [`AutoHighlightResult`](highlight-engine.md#autohighlightresult) | Result type returned by `HighlightEngine.highlightAuto()` |
 | `rememberHighlightedCode` | Composable helper - highlights code and returns an `AnnotatedString` state |
 | `rememberHighlightedCodeBothThemes` | Highlights once, produces light + dark variants |
 | `rememberHighlightEngine` | Returns the shared or standalone `HighlightEngine` for the current composition |

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
@@ -12,6 +12,8 @@ import dev.hossain.highlight.sample.sections.TypographySection
 internal sealed class DemoTab(
     val title: String,
 ) {
+    data object LanguageDiscoverability : DemoTab("Lang Discover")
+
     data object Languages : DemoTab("Languages")
 
     data object Styling : DemoTab("Styling")
@@ -31,6 +33,8 @@ internal sealed class DemoTab(
     data object Engine : DemoTab("Engine")
 
     companion object {
-        val all by lazy { listOf(Languages, Styling, Typography, Toggles, Callbacks, Themes, AllThemes, Advanced, Engine) }
+        val all by lazy {
+            listOf(LanguageDiscoverability, Languages, Styling, Typography, Toggles, Callbacks, Themes, AllThemes, Advanced, Engine)
+        }
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
@@ -34,7 +34,7 @@ internal sealed class DemoTab(
 
     companion object {
         val all by lazy {
-            listOf(LanguageDiscoverability, Languages, Styling, Typography, Toggles, Callbacks, Themes, AllThemes, Advanced, Engine)
+            listOf(Languages, Styling, Typography, Toggles, Callbacks, Themes, AllThemes, LanguageDiscoverability, Advanced, Engine)
         }
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -245,7 +245,6 @@ fun SampleScreen() {
                         DemoTab.LanguageDiscoverability -> {
                             item {
                                 LanguageDiscoverabilitySection(
-                                    isDark = isDark,
                                     onAutoResultReady = {
                                         langDiscoverListState.animateScrollToItem(Int.MAX_VALUE)
                                     },

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -47,6 +47,7 @@ import dev.hossain.highlight.sample.sections.AdvancedEngineSection
 import dev.hossain.highlight.sample.sections.AllThemesSection
 import dev.hossain.highlight.sample.sections.CallbacksSection
 import dev.hossain.highlight.sample.sections.EngineInfoSection
+import dev.hossain.highlight.sample.sections.LanguageDiscoverabilitySection
 import dev.hossain.highlight.sample.sections.SectionHeader
 import dev.hossain.highlight.sample.sections.StylingSection
 import dev.hossain.highlight.sample.sections.ThemeCreationSection
@@ -238,6 +239,10 @@ fun SampleScreen() {
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     when (tabs[selectedTabIndex]) {
+                        DemoTab.LanguageDiscoverability -> {
+                            item { LanguageDiscoverabilitySection() }
+                        }
+
                         DemoTab.Languages -> {
                             codeSamples.forEach { sample ->
                                 item(key = sample.displayLabel) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -98,6 +99,7 @@ fun SampleScreen() {
     var showThemeMenu by remember { mutableStateOf(false) }
     var activeTabIndex by rememberSaveable { mutableIntStateOf(0) }
     var showStylingSheet by remember { mutableStateOf(false) }
+    val langDiscoverListState = rememberLazyListState()
 
     // Shared copy handler: copies to clipboard and shows a snackbar confirmation.
     val onCopyClick: (String) -> Unit =
@@ -228,6 +230,7 @@ fun SampleScreen() {
                     }
                 }
                 LazyColumn(
+                    state = langDiscoverListState,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding =
                         PaddingValues(
@@ -240,7 +243,14 @@ fun SampleScreen() {
                 ) {
                     when (tabs[selectedTabIndex]) {
                         DemoTab.LanguageDiscoverability -> {
-                            item { LanguageDiscoverabilitySection(isDark = isDark) }
+                            item {
+                                LanguageDiscoverabilitySection(
+                                    isDark = isDark,
+                                    onAutoResultReady = {
+                                        langDiscoverListState.animateScrollToItem(Int.MAX_VALUE)
+                                    },
+                                )
+                            }
                         }
 
                         DemoTab.Languages -> {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -240,7 +240,7 @@ fun SampleScreen() {
                 ) {
                     when (tabs[selectedTabIndex]) {
                         DemoTab.LanguageDiscoverability -> {
-                            item { LanguageDiscoverabilitySection() }
+                            item { LanguageDiscoverabilitySection(isDark = isDark) }
                         }
 
                         DemoTab.Languages -> {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -99,7 +99,7 @@ fun SampleScreen() {
     var showThemeMenu by remember { mutableStateOf(false) }
     var activeTabIndex by rememberSaveable { mutableIntStateOf(0) }
     var showStylingSheet by remember { mutableStateOf(false) }
-    val langDiscoverListState = rememberLazyListState()
+    val listState = rememberLazyListState()
 
     // Shared copy handler: copies to clipboard and shows a snackbar confirmation.
     val onCopyClick: (String) -> Unit =
@@ -230,7 +230,7 @@ fun SampleScreen() {
                     }
                 }
                 LazyColumn(
-                    state = langDiscoverListState,
+                    state = listState,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding =
                         PaddingValues(
@@ -243,13 +243,7 @@ fun SampleScreen() {
                 ) {
                     when (tabs[selectedTabIndex]) {
                         DemoTab.LanguageDiscoverability -> {
-                            item {
-                                LanguageDiscoverabilitySection(
-                                    onAutoResultReady = {
-                                        langDiscoverListState.animateScrollToItem(Int.MAX_VALUE)
-                                    },
-                                )
-                            }
+                            item { LanguageDiscoverabilitySection() }
                         }
 
                         DemoTab.Languages -> {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -30,9 +30,8 @@ import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.engine.AutoHighlightResult
 import dev.hossain.highlight.engine.HighlightLanguage
 import dev.hossain.highlight.engine.HighlightLanguageInfo
+import dev.hossain.highlight.ui.LocalHighlightTheme
 import dev.hossain.highlight.ui.rememberHighlightEngine
-import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
 import kotlinx.coroutines.launch
 
 private val PYTHON_SNIPPET =
@@ -64,12 +63,11 @@ private val LANGUAGE_CHIPS = listOf("kotlin", "ts", "cr", "py", "glsl", "pgsql")
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun LanguageDiscoverabilitySection(
-    isDark: Boolean = true,
     onAutoResultReady: (suspend () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val engine = rememberHighlightEngine()
-    val theme = if (isDark) rememberTomorrowNightTheme() else rememberTomorrowTheme()
+    val theme = LocalHighlightTheme.current
     val scope = rememberCoroutineScope()
 
     var extensionInput by remember { mutableStateOf("kt") }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -75,7 +75,7 @@ internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
     var extensionInput by remember { mutableStateOf("kt") }
     val resolvedLanguage =
         remember(extensionInput) {
-            HighlightLanguage.fromExtension(extensionInput.trim())
+            HighlightLanguage.fromExtension(extensionInput.trim().trimStart('.'))
         }
 
     var langInput by remember { mutableStateOf("kotlin") }
@@ -92,13 +92,13 @@ internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
         autoRunning = true
         autoResult = null
         autoError = null
-        engine
-            .highlightAuto(PYTHON_SNIPPET, theme)
-            .onSuccess { result -> autoResult = result }
-            .onFailure { error -> autoError = error.message ?: "Error" }
-        autoRunning = false
-        if (autoResult != null) {
-            bringIntoViewRequester.bringIntoView()
+        try {
+            engine
+                .highlightAuto(PYTHON_SNIPPET, theme)
+                .onSuccess { result -> autoResult = result }
+                .onFailure { error -> autoError = error.message ?: "Error" }
+        } finally {
+            autoRunning = false
         }
     }
 
@@ -106,6 +106,13 @@ internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
     LaunchedEffect(theme) {
         if (!hasAutoRun) return@LaunchedEffect
         runAutoHighlight()
+    }
+
+    // Bring the result into view after recomposition has attached the requester to the layout.
+    LaunchedEffect(autoResult) {
+        if (autoResult != null) {
+            bringIntoViewRequester.bringIntoView()
+        }
     }
 
     Column(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -31,18 +31,25 @@ import dev.hossain.highlight.engine.AutoHighlightResult
 import dev.hossain.highlight.engine.HighlightLanguage
 import dev.hossain.highlight.engine.HighlightLanguageInfo
 import dev.hossain.highlight.ui.rememberHighlightEngine
+import dev.hossain.highlight.ui.rememberTomorrowNightTheme
 import dev.hossain.highlight.ui.rememberTomorrowTheme
 import kotlinx.coroutines.launch
 
 private val PYTHON_SNIPPET =
     """
-def fibonacci(n: int) -> list[int]:
-    result = [0, 1]
-    while len(result) < n:
-        result.append(result[-1] + result[-2])
-    return result[:n]
+import json
+from pathlib import Path
 
-print(fibonacci(10))
+class Config:
+    def __init__(self, path: str):
+        self.path = Path(path)
+
+    def load(self) -> dict:
+        with open(self.path) as f:
+            return json.load(f)
+
+config = Config("settings.json")
+print(config.load())
     """.trimIndent()
 
 private val EXTENSION_CHIPS = listOf("kt", "py", "rs", "ts", "sql", "wat", "elm", "nix", "pro")
@@ -56,9 +63,12 @@ private val LANGUAGE_CHIPS = listOf("kotlin", "ts", "cr", "py", "glsl", "pgsql")
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
+internal fun LanguageDiscoverabilitySection(
+    isDark: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
     val engine = rememberHighlightEngine()
-    val theme = rememberTomorrowTheme()
+    val theme = if (isDark) rememberTomorrowNightTheme() else rememberTomorrowTheme()
     val scope = rememberCoroutineScope()
 
     var extensionInput by remember { mutableStateOf("kt") }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -1,0 +1,356 @@
+package dev.hossain.highlight.sample.sections
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.hossain.highlight.engine.AutoHighlightResult
+import dev.hossain.highlight.engine.HighlightLanguage
+import dev.hossain.highlight.engine.HighlightLanguageInfo
+import dev.hossain.highlight.ui.rememberHighlightEngine
+import dev.hossain.highlight.ui.rememberTomorrowTheme
+import kotlinx.coroutines.launch
+
+private val PYTHON_SNIPPET =
+    """
+def fibonacci(n: int) -> list[int]:
+    result = [0, 1]
+    while len(result) < n:
+        result.append(result[-1] + result[-2])
+    return result[:n]
+
+print(fibonacci(10))
+    """.trimIndent()
+
+private val EXTENSION_CHIPS = listOf("kt", "py", "rs", "ts", "sql", "wat", "elm", "nix", "pro")
+private val LANGUAGE_CHIPS = listOf("kotlin", "ts", "cr", "py", "glsl", "pgsql")
+
+/**
+ * Demonstrates the language discoverability helpers:
+ * - [HighlightLanguage.fromExtension] for extension-to-language mapping
+ * - [dev.hossain.highlight.engine.HighlightEngine.getLanguage] for language metadata lookup
+ * - [dev.hossain.highlight.engine.HighlightEngine.highlightAuto] for auto-detection
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
+    val engine = rememberHighlightEngine()
+    val theme = rememberTomorrowTheme()
+    val scope = rememberCoroutineScope()
+
+    var extensionInput by remember { mutableStateOf("kt") }
+    val resolvedLanguage =
+        remember(extensionInput) {
+            HighlightLanguage.fromExtension(extensionInput.trim())
+        }
+
+    var langInput by remember { mutableStateOf("kotlin") }
+    var langInfo by remember { mutableStateOf<HighlightLanguageInfo?>(null) }
+    var langNotFound by remember { mutableStateOf(false) }
+    var langError by remember { mutableStateOf<String?>(null) }
+
+    var autoResult by remember { mutableStateOf<AutoHighlightResult?>(null) }
+    var autoError by remember { mutableStateOf<String?>(null) }
+    var autoRunning by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        SubSectionHeader("HighlightLanguage.fromExtension()")
+        Text(
+            text =
+                "Resolves a file extension to the Highlight.js language identifier. " +
+                    "Tap a chip or type your own extension below.",
+            style = TextStyle(fontSize = 13.sp),
+        )
+
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            EXTENSION_CHIPS.forEach { ext ->
+                FilterChip(
+                    selected = extensionInput == ext,
+                    onClick = { extensionInput = ext },
+                    label = { Text(".$ext") },
+                )
+            }
+        }
+
+        OutlinedTextField(
+            value = extensionInput,
+            onValueChange = { extensionInput = it },
+            label = { Text("File extension (without dot)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(6.dp),
+            color =
+                if (resolvedLanguage != null) {
+                    MaterialTheme.colorScheme.primaryContainer
+                } else {
+                    MaterialTheme.colorScheme.errorContainer
+                },
+        ) {
+            Text(
+                text =
+                    if (resolvedLanguage != null) {
+                        "fromExtension(\"${extensionInput.trim()}\") = \"$resolvedLanguage\""
+                    } else {
+                        "fromExtension(\"${extensionInput.trim()}\") = null  (not recognized)"
+                    },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                style =
+                    TextStyle(
+                        fontSize = 13.sp,
+                        fontFamily = FontFamily.Monospace,
+                        color =
+                            if (resolvedLanguage != null) {
+                                MaterialTheme.colorScheme.onPrimaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.onErrorContainer
+                            },
+                    ),
+            )
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        SubSectionHeader("engine.getLanguage()")
+        Text(
+            text =
+                "Looks up a language by name or alias and returns its display name and " +
+                    "registered aliases. Tap a chip or type a name/alias, then tap Look up.",
+            style = TextStyle(fontSize = 13.sp),
+        )
+
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            LANGUAGE_CHIPS.forEach { lang ->
+                FilterChip(
+                    selected = langInput == lang,
+                    onClick = {
+                        langInput = lang
+                        langInfo = null
+                        langNotFound = false
+                        langError = null
+                    },
+                    label = { Text(lang) },
+                )
+            }
+        }
+
+        OutlinedTextField(
+            value = langInput,
+            onValueChange = {
+                langInput = it
+                langInfo = null
+                langNotFound = false
+                langError = null
+            },
+            label = { Text("Language name or alias") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Button(
+            onClick = {
+                scope.launch {
+                    langInfo = null
+                    langNotFound = false
+                    langError = null
+                    engine
+                        .getLanguage(langInput.trim())
+                        .onSuccess { info ->
+                            if (info != null) {
+                                langInfo = info
+                            } else {
+                                langNotFound = true
+                            }
+                        }.onFailure { error -> langError = error.message ?: "Error" }
+                }
+            },
+        ) {
+            Text("Look up")
+        }
+
+        langInfo?.let { info ->
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    Text(
+                        text = "name    = \"${info.name}\"",
+                        style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+                    )
+                    Text(
+                        text = "aliases = ${info.aliases}",
+                        style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+                    )
+                }
+            }
+        }
+
+        if (langNotFound) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.errorContainer,
+            ) {
+                Text(
+                    text = "\"${langInput.trim()}\" is not recognized by the bundled Highlight.js",
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    style =
+                        TextStyle(
+                            fontSize = 13.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        ),
+                )
+            }
+        }
+
+        langError?.let { error ->
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.errorContainer,
+            ) {
+                Text(
+                    text = "Error: $error",
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    style =
+                        TextStyle(
+                            fontSize = 13.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        ),
+                )
+            }
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        SubSectionHeader("engine.highlightAuto()")
+        Text(
+            text =
+                "Passes a code snippet to Highlight.js without specifying a language. " +
+                    "hljs inspects the content and guesses the language.",
+            style = TextStyle(fontSize = 13.sp),
+        )
+
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(6.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+        ) {
+            Text(
+                text = PYTHON_SNIPPET,
+                modifier = Modifier.padding(12.dp),
+                style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+            )
+        }
+
+        Button(
+            enabled = !autoRunning,
+            onClick = {
+                scope.launch {
+                    autoRunning = true
+                    autoResult = null
+                    autoError = null
+                    engine
+                        .highlightAuto(PYTHON_SNIPPET, theme)
+                        .onSuccess { result -> autoResult = result }
+                        .onFailure { error -> autoError = error.message ?: "Error" }
+                    autoRunning = false
+                }
+            },
+        ) {
+            Text(if (autoRunning) "Detecting..." else "Auto-detect and highlight")
+        }
+
+        autoResult?.let { result ->
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp),
+                color = theme.backgroundColor,
+            ) {
+                Text(
+                    text = result.annotated,
+                    modifier = Modifier.padding(16.dp),
+                    style =
+                        TextStyle(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 13.sp,
+                            lineHeight = 20.sp,
+                        ),
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    Text(
+                        text = "detectedLanguage = \"${result.detectedLanguage}\"",
+                        style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+                    )
+                    Text(
+                        text = "spanCount        = ${result.spanCount}",
+                        style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+                    )
+                    Text(
+                        text = "durationMs       = ${result.durationMs} ms",
+                        style = TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace),
+                    )
+                }
+            }
+        }
+
+        autoError?.let { error ->
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.errorContainer,
+            ) {
+                Text(
+                    text = "Error: $error",
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    style =
+                        TextStyle(
+                            fontSize = 13.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        ),
+                )
+            }
+        }
+    }
+}

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -84,6 +85,22 @@ internal fun LanguageDiscoverabilitySection(
     var autoResult by remember { mutableStateOf<AutoHighlightResult?>(null) }
     var autoError by remember { mutableStateOf<String?>(null) }
     var autoRunning by remember { mutableStateOf(false) }
+    var hasAutoRun by remember { mutableStateOf(false) }
+
+    // Re-run auto-highlight when the theme changes so the cached result stays in sync.
+    LaunchedEffect(theme) {
+        if (!hasAutoRun) return@LaunchedEffect
+        autoRunning = true
+        autoResult = null
+        autoError = null
+        engine
+            .highlightAuto(PYTHON_SNIPPET, theme)
+            .onSuccess { result ->
+                autoResult = result
+                onAutoResultReady?.invoke()
+            }.onFailure { error -> autoError = error.message ?: "Error" }
+        autoRunning = false
+    }
 
     Column(
         modifier = modifier,
@@ -289,6 +306,7 @@ internal fun LanguageDiscoverabilitySection(
             enabled = !autoRunning,
             onClick = {
                 scope.launch {
+                    hasAutoRun = true
                     autoRunning = true
                     autoResult = null
                     autoError = null

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -65,6 +65,7 @@ private val LANGUAGE_CHIPS = listOf("kotlin", "ts", "cr", "py", "glsl", "pgsql")
 @Composable
 internal fun LanguageDiscoverabilitySection(
     isDark: Boolean = true,
+    onAutoResultReady: (suspend () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val engine = rememberHighlightEngine()
@@ -295,8 +296,10 @@ internal fun LanguageDiscoverabilitySection(
                     autoError = null
                     engine
                         .highlightAuto(PYTHON_SNIPPET, theme)
-                        .onSuccess { result -> autoResult = result }
-                        .onFailure { error -> autoError = error.message ?: "Error" }
+                        .onSuccess { result ->
+                            autoResult = result
+                            onAutoResultReady?.invoke()
+                        }.onFailure { error -> autoError = error.message ?: "Error" }
                     autoRunning = false
                 }
             },

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -1,5 +1,6 @@
 package dev.hossain.highlight.sample.sections
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -8,6 +9,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
@@ -61,15 +64,13 @@ private val LANGUAGE_CHIPS = listOf("kotlin", "ts", "cr", "py", "glsl", "pgsql")
  * - [dev.hossain.highlight.engine.HighlightEngine.getLanguage] for language metadata lookup
  * - [dev.hossain.highlight.engine.HighlightEngine.highlightAuto] for auto-detection
  */
-@OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
-internal fun LanguageDiscoverabilitySection(
-    onAutoResultReady: (suspend () -> Unit)? = null,
-    modifier: Modifier = Modifier,
-) {
+internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
     val engine = rememberHighlightEngine()
     val theme = LocalHighlightTheme.current
     val scope = rememberCoroutineScope()
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
 
     var extensionInput by remember { mutableStateOf("kt") }
     val resolvedLanguage =
@@ -87,19 +88,24 @@ internal fun LanguageDiscoverabilitySection(
     var autoRunning by remember { mutableStateOf(false) }
     var hasAutoRun by remember { mutableStateOf(false) }
 
-    // Re-run auto-highlight when the theme changes so the cached result stays in sync.
-    LaunchedEffect(theme) {
-        if (!hasAutoRun) return@LaunchedEffect
+    suspend fun runAutoHighlight() {
         autoRunning = true
         autoResult = null
         autoError = null
         engine
             .highlightAuto(PYTHON_SNIPPET, theme)
-            .onSuccess { result ->
-                autoResult = result
-                onAutoResultReady?.invoke()
-            }.onFailure { error -> autoError = error.message ?: "Error" }
+            .onSuccess { result -> autoResult = result }
+            .onFailure { error -> autoError = error.message ?: "Error" }
         autoRunning = false
+        if (autoResult != null) {
+            bringIntoViewRequester.bringIntoView()
+        }
+    }
+
+    // Re-run when the active theme changes so the cached result stays in sync.
+    LaunchedEffect(theme) {
+        if (!hasAutoRun) return@LaunchedEffect
+        runAutoHighlight()
     }
 
     Column(
@@ -307,16 +313,7 @@ internal fun LanguageDiscoverabilitySection(
             onClick = {
                 scope.launch {
                     hasAutoRun = true
-                    autoRunning = true
-                    autoResult = null
-                    autoError = null
-                    engine
-                        .highlightAuto(PYTHON_SNIPPET, theme)
-                        .onSuccess { result ->
-                            autoResult = result
-                            onAutoResultReady?.invoke()
-                        }.onFailure { error -> autoError = error.message ?: "Error" }
-                    autoRunning = false
+                    runAutoHighlight()
                 }
             },
         ) {
@@ -325,7 +322,7 @@ internal fun LanguageDiscoverabilitySection(
 
         autoResult?.let { result ->
             Surface(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().bringIntoViewRequester(bringIntoViewRequester),
                 shape = RoundedCornerShape(8.dp),
                 color = theme.backgroundColor,
             ) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LanguageDiscoverabilitySection.kt
@@ -73,9 +73,10 @@ internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
 
     var extensionInput by remember { mutableStateOf("kt") }
+    val normalizedExtension = extensionInput.trim().trimStart('.')
     val resolvedLanguage =
-        remember(extensionInput) {
-            HighlightLanguage.fromExtension(extensionInput.trim().trimStart('.'))
+        remember(normalizedExtension) {
+            HighlightLanguage.fromExtension(normalizedExtension)
         }
 
     var langInput by remember { mutableStateOf("kotlin") }
@@ -158,9 +159,9 @@ internal fun LanguageDiscoverabilitySection(modifier: Modifier = Modifier) {
             Text(
                 text =
                     if (resolvedLanguage != null) {
-                        "fromExtension(\"${extensionInput.trim()}\") = \"$resolvedLanguage\""
+                        "fromExtension(\"$normalizedExtension\") = \"$resolvedLanguage\""
                     } else {
-                        "fromExtension(\"${extensionInput.trim()}\") = null  (not recognized)"
+                        "fromExtension(\"$normalizedExtension\") = null  (not recognized)"
                     },
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
                 style =


### PR DESCRIPTION
Closes #135

Adds documentation and sample app demos for the language discoverability APIs introduced in #133.

## Changes

### Docs
- `docs/reference/highlight-engine.md` - new `getLanguage()` and `highlightAuto()` method entries, new `HighlightLanguageInfo` and `AutoHighlightResult` result type sections
- `docs/reference/highlight-language.md` (new) - full reference for `HighlightLanguage.fromExtension()` with extension table
- `docs/guides/language-selection.md` (new) - how-to guide covering all four language selection options
- `docs/getting-started.md` - added link to language selection guide in next steps
- `docs/reference/index.md` - added `HighlightLanguage`, `HighlightLanguageInfo`, `AutoHighlightResult` entries

### Sample app
- New `LanguageDiscoverabilitySection` tab with three interactive demos:
  1. `fromExtension()` - chip shortcuts + text field, shows resolved language or null state
  2. `getLanguage()` - chip shortcuts + text field + Look up button, shows name/aliases card
  3. `highlightAuto()` - button-triggered auto-detect, shows highlighted result + detectedLanguage + timing
