### PR TITLE
feat: add provider vs no-provider toggle to PerfScreen

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
@@ -74,8 +74,10 @@ internal val LocalHighlightEngine =
  *
  * A single [HighlightEngine] (and thus a single hidden WebView) is created for the entire
  * subtree and destroyed when this composable leaves the composition. This means all
- * [SyntaxHighlightedCode] blocks inside share one WebView instead of creating one per block,
- * saving ~200 ms warm-up time and ~2-4 MB RAM per extra block.
+ * [SyntaxHighlightedCode] blocks inside share one WebView instead of creating one per block.
+ * Measured on a Pixel 8 Pro debug build (cold start, 17 blocks): with provider takes ~224 ms
+ * total and ~15 MB heap vs ~866 ms and ~34 MB heap without - roughly 4x faster and 55% less RAM.
+ * Each extra standalone engine adds ~37 ms average latency and ~1-2 MB heap while on-screen.
  *
  * **1 provider = 1 WebView.** Place it above all the code blocks you want to share.
  *
@@ -99,9 +101,10 @@ internal val LocalHighlightEngine =
  * ## Without a provider
  *
  * Without `HighlightThemeProvider`, each [SyntaxHighlightedCode] (or [rememberHighlightEngine]
- * call) creates its own [HighlightEngine] and hidden WebView. For a screen with 3 code blocks
- * that means 3 WebViews, ~600 ms extra warm-up, and ~6-12 MB extra RAM. Wrapping the screen
- * in a single provider reduces this to 1 WebView regardless of how many blocks are inside.
+ * call) creates its own [HighlightEngine] and hidden WebView. For a screen with 17 code blocks
+ * that measured ~866 ms total highlight time and ~34 MB heap vs ~224 ms and ~15 MB with a
+ * provider (Pixel 8 Pro, cold start, debug build). Wrapping the screen in a single provider
+ * reduces this to 1 WebView regardless of how many blocks are inside.
  *
  * ## Multiple screens
  *

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
@@ -76,7 +76,7 @@ internal val LocalHighlightEngine =
  * subtree and destroyed when this composable leaves the composition. This means all
  * [SyntaxHighlightedCode] blocks inside share one WebView instead of creating one per block.
  * Measured on a Pixel 8 Pro debug build (cold start, 17 blocks): with provider takes ~224 ms
- * total and ~15 MB heap vs ~866 ms and ~34 MB heap without - roughly 4x faster and 55% less RAM.
+ * total and ~15 MB heap vs ~866 ms and ~34 MB heap without - roughly 4x faster and 55% less heap.
  * Each extra standalone engine adds ~37 ms average latency and ~1-2 MB heap while on-screen.
  *
  * **1 provider = 1 WebView.** Place it above all the code blocks you want to share.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -4,10 +4,14 @@
 
 The most impactful optimization is wrapping your content in `HighlightThemeProvider`. Without it, every `SyntaxHighlightedCode` creates its own hidden WebView:
 
-| Setup | WebViews | Warm-up cost |
-|---|---|---|
-| No provider - 3 blocks | 3 | ~600 ms |
-| With provider - 3 blocks | 1 | ~200 ms |
+| Setup | WebViews | Avg per block | Total (17 blocks) | Heap (cold start) |
+|---|---|---|---|---|
+| No provider - 17 blocks | 17 | ~50 ms | ~866 ms | ~34 MB |
+| With provider - 17 blocks | 1 | ~13 ms | ~224 ms | ~15 MB |
+
+Measured on a Pixel 8 Pro, debug build, cold start. With provider is roughly **4x faster** and uses **~55% less heap**.
+
+Each extra standalone engine adds roughly **~37 ms** to average highlight time and **~1-2 MB** of additional heap per engine while the screen is active.
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -114,27 +117,6 @@ fun PerfScreen() {
                         }
                     },
                     actions = {
-                        // Provider toggle - switches between shared engine (1 WebView) and
-                        // standalone engines (1 WebView per block) to measure the cost difference
-                        IconButton(onClick = {
-                            useProvider = !useProvider
-                            metricsMap.clear()
-                            heapSnapshotKb = null
-                            runId++
-                        }) {
-                            Icon(
-                                imageVector =
-                                    ImageVector.vectorResource(
-                                        if (useProvider) R.drawable.speed_24dp else R.drawable.bar_chart_4_bars_24,
-                                    ),
-                                contentDescription =
-                                    if (useProvider) {
-                                        "Switch to standalone engines (no provider)"
-                                    } else {
-                                        "Switch to shared engine (with provider)"
-                                    },
-                            )
-                        }
                         // Light/dark toggle - also resets the benchmark since theme affects timing
                         IconButton(onClick = {
                             isDark = !isDark
@@ -186,6 +168,12 @@ fun PerfScreen() {
                         totalSamples = codeSamples.size,
                         heapSnapshotKb = heapSnapshotKb,
                         useProvider = useProvider,
+                        onToggleProvider = {
+                            useProvider = !useProvider
+                            metricsMap.clear()
+                            heapSnapshotKb = null
+                            runId++
+                        },
                     )
                 }
 
@@ -232,8 +220,8 @@ fun PerfScreen() {
 /**
  * Sticky summary card shown at the top of the list.
  *
- * Displays: engine mode, completed/total count, avg/min/max highlight time, and heap snapshot
- * once all blocks have completed.
+ * Displays: engine mode toggle, completed/total count, avg/min/max highlight time, and heap
+ * snapshot once all blocks have completed.
  */
 @Composable
 private fun SummaryHeader(
@@ -241,6 +229,7 @@ private fun SummaryHeader(
     totalSamples: Int,
     heapSnapshotKb: Long?,
     useProvider: Boolean,
+    onToggleProvider: () -> Unit,
 ) {
     val completed = metricsMap.size
     val times = metricsMap.values.map { it.highlightMs }
@@ -250,12 +239,35 @@ private fun SummaryHeader(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = "Benchmark Summary",
-                fontWeight = FontWeight.Bold,
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Benchmark Summary",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                FilledTonalButton(
+                    onClick = onToggleProvider,
+                ) {
+                    Icon(
+                        imageVector =
+                            ImageVector.vectorResource(
+                                if (useProvider) R.drawable.hub_24dp else R.drawable.call_split_24dp,
+                            ),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = if (useProvider) "Use Provider" else "No Provider",
+                        fontSize = 12.sp,
+                    )
+                }
+            }
             Spacer(modifier = Modifier.height(6.dp))
             HorizontalDivider(color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f))
             Spacer(modifier = Modifier.height(6.dp))

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -263,7 +263,7 @@ private fun SummaryHeader(
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
-                        text = if (useProvider) "Use Provider" else "No Provider",
+                        text = if (useProvider) "Provider: On" else "Provider: Off",
                         fontSize = 12.sp,
                     )
                 }
@@ -275,7 +275,7 @@ private fun SummaryHeader(
             SummaryRow(label = "Completed", value = "$completed / $totalSamples blocks")
             SummaryRow(
                 label = "Engine mode",
-                value = if (useProvider) "Shared - 1 WebView" else "Standalone - $totalSamples WebViews",
+                value = if (useProvider) "Shared - 1 WebView" else "Standalone - up to $totalSamples WebViews",
             )
 
             if (times.isNotEmpty()) {
@@ -476,8 +476,8 @@ private fun MetricChip(
  * When [useProvider] is true, all [SyntaxHighlightedCode] blocks in [content] share a single
  * [HighlightEngine][dev.hossain.highlight.engine.HighlightEngine] (1 hidden WebView). When
  * false, each block creates its own standalone engine, which is the "no provider" baseline used
- * to validate the WebView sharing cost documented in [HighlightThemeProvider]'s KDoc (~200 ms
- * warm-up and ~2-4 MB RAM per block).
+ * to validate the WebView sharing cost documented in [HighlightThemeProvider]'s KDoc (~37 ms
+ * extra avg latency and ~1-2 MB heap per extra standalone engine).
  *
  * This composable exists solely to make the provider vs. no-provider cost visible and
  * measurable inside [PerfScreen] - it should not be used outside of the benchmark screen.

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/perf/PerfScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.engine.HighlightTimings
 import dev.hossain.highlight.sample.CodeSample
 import dev.hossain.highlight.sample.R
@@ -78,6 +79,11 @@ fun PerfScreen() {
         value = withContext(Dispatchers.IO) { loadCodeSamples(context) }
     }
     var isDark by remember { mutableStateOf(true) }
+    var useProvider by remember { mutableStateOf(true) }
+
+    val lightTheme = rememberAtomOneLightTheme()
+    val darkTheme = rememberAtomOneDarkTheme()
+    val activeTheme = if (isDark) darkTheme else lightTheme
 
     val metricsMap = remember { mutableStateMapOf<String, HighlightMetrics>() }
     var runId by remember { mutableIntStateOf(0) }
@@ -89,10 +95,11 @@ fun PerfScreen() {
         heapSnapshotKb = (rt.totalMemory() - rt.freeMemory()) / 1024
     }
 
-    HighlightThemeProvider(
-        lightHighlightTheme = rememberAtomOneLightTheme(),
-        darkHighlightTheme = rememberAtomOneDarkTheme(),
-        darkTheme = isDark,
+    MaybeUseHighlightProvider(
+        useProvider = useProvider,
+        lightTheme = lightTheme,
+        darkTheme = darkTheme,
+        isDark = isDark,
     ) {
         Scaffold(
             topBar = {
@@ -107,6 +114,27 @@ fun PerfScreen() {
                         }
                     },
                     actions = {
+                        // Provider toggle - switches between shared engine (1 WebView) and
+                        // standalone engines (1 WebView per block) to measure the cost difference
+                        IconButton(onClick = {
+                            useProvider = !useProvider
+                            metricsMap.clear()
+                            heapSnapshotKb = null
+                            runId++
+                        }) {
+                            Icon(
+                                imageVector =
+                                    ImageVector.vectorResource(
+                                        if (useProvider) R.drawable.speed_24dp else R.drawable.bar_chart_4_bars_24,
+                                    ),
+                                contentDescription =
+                                    if (useProvider) {
+                                        "Switch to standalone engines (no provider)"
+                                    } else {
+                                        "Switch to shared engine (with provider)"
+                                    },
+                            )
+                        }
                         // Light/dark toggle - also resets the benchmark since theme affects timing
                         IconButton(onClick = {
                             isDark = !isDark
@@ -157,6 +185,7 @@ fun PerfScreen() {
                         metricsMap = metricsMap,
                         totalSamples = codeSamples.size,
                         heapSnapshotKb = heapSnapshotKb,
+                        useProvider = useProvider,
                     )
                 }
 
@@ -173,6 +202,9 @@ fun PerfScreen() {
                             SyntaxHighlightedCode(
                                 code = sample.code,
                                 language = sample.language,
+                                // Always pass theme explicitly - avoids LocalHighlightTheme.current
+                                // throwing when useProvider is false (no provider in the tree).
+                                theme = activeTheme,
                                 modifier = Modifier.fillMaxWidth(),
                                 showLineNumbers = true,
                                 onHighlightComplete = { result ->
@@ -200,14 +232,15 @@ fun PerfScreen() {
 /**
  * Sticky summary card shown at the top of the list.
  *
- * Displays: completed/total count, avg/min/max highlight time, and heap snapshot once all blocks
- * have completed.
+ * Displays: engine mode, completed/total count, avg/min/max highlight time, and heap snapshot
+ * once all blocks have completed.
  */
 @Composable
 private fun SummaryHeader(
     metricsMap: Map<String, HighlightMetrics>,
     totalSamples: Int,
     heapSnapshotKb: Long?,
+    useProvider: Boolean,
 ) {
     val completed = metricsMap.size
     val times = metricsMap.values.map { it.highlightMs }
@@ -228,6 +261,10 @@ private fun SummaryHeader(
             Spacer(modifier = Modifier.height(6.dp))
 
             SummaryRow(label = "Completed", value = "$completed / $totalSamples blocks")
+            SummaryRow(
+                label = "Engine mode",
+                value = if (useProvider) "Shared - 1 WebView" else "Standalone - $totalSamples WebViews",
+            )
 
             if (times.isNotEmpty()) {
                 SummaryRow(label = "Avg time", value = "${times.average().toLong()} ms")
@@ -418,5 +455,38 @@ private fun MetricChip(
             fontSize = 10.sp,
             color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
         )
+    }
+}
+
+/**
+ * Benchmark helper that conditionally wraps [content] in a [HighlightThemeProvider].
+ *
+ * When [useProvider] is true, all [SyntaxHighlightedCode] blocks in [content] share a single
+ * [HighlightEngine][dev.hossain.highlight.engine.HighlightEngine] (1 hidden WebView). When
+ * false, each block creates its own standalone engine, which is the "no provider" baseline used
+ * to validate the WebView sharing cost documented in [HighlightThemeProvider]'s KDoc (~200 ms
+ * warm-up and ~2-4 MB RAM per block).
+ *
+ * This composable exists solely to make the provider vs. no-provider cost visible and
+ * measurable inside [PerfScreen] - it should not be used outside of the benchmark screen.
+ */
+@Composable
+private fun MaybeUseHighlightProvider(
+    useProvider: Boolean,
+    lightTheme: HighlightTheme,
+    darkTheme: HighlightTheme,
+    isDark: Boolean,
+    content: @Composable () -> Unit,
+) {
+    if (useProvider) {
+        HighlightThemeProvider(
+            lightHighlightTheme = lightTheme,
+            darkHighlightTheme = darkTheme,
+            darkTheme = isDark,
+            content = content,
+        )
+    } else {
+        // No provider - each SyntaxHighlightedCode creates its own engine (1 WebView per block).
+        content()
     }
 }

--- a/sample/src/main/res/drawable/call_split_24dp.xml
+++ b/sample/src/main/res/drawable/call_split_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,800v-304L240,296v104h-80v-240h240v80L296,240l224,224v336h-80ZM594,424 L536,366 664,240L560,240v-80h240v240h-80v-104L594,424Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/sample/src/main/res/drawable/hub_24dp.xml
+++ b/sample/src/main/res/drawable/hub_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M155,885q-35,-35 -35,-85t35,-85q35,-35 85,-35 14,0 26,3t23,8l57,-71q-28,-31 -39,-70t-5,-78l-81,-27q-17,25 -43,40t-58,15q-50,0 -85,-35T0,380q0,-50 35,-85t85,-35q50,0 85,35t35,85v8l81,28q20,-36 53.5,-61t75.5,-32v-87q-39,-11 -64.5,-42.5T360,120q0,-50 35,-85t85,-35q50,0 85,35t35,85q0,42 -26,73.5T510,236v87q42,7 75.5,32t53.5,61l81,-28v-8q0,-50 35,-85t85,-35q50,0 85,35t35,85q0,50 -35,85t-85,35q-32,0 -58.5,-15T739,445l-81,27q6,39 -5,77.5T614,620l57,70q11,-5 23,-7.5t26,-2.5q50,0 85,35t35,85q0,50 -35,85t-85,35q-50,0 -85,-35t-35,-85q0,-20 6.5,-38.5T624,728l-57,-71q-41,23 -87.5,23T392,657l-56,71q11,15 17.5,33.5T360,800q0,50 -35,85t-85,35q-50,0 -85,-35ZM120,420q17,0 28.5,-11.5T160,380q0,-17 -11.5,-28.5T120,340q-17,0 -28.5,11.5T80,380q0,17 11.5,28.5T120,420ZM268.5,828.5Q280,817 280,800t-11.5,-28.5Q257,760 240,760t-28.5,11.5Q200,783 200,800t11.5,28.5Q223,840 240,840t28.5,-11.5ZM508.5,148.5Q520,137 520,120t-11.5,-28.5Q497,80 480,80t-28.5,11.5Q440,103 440,120t11.5,28.5Q463,160 480,160t28.5,-11.5ZM480,600q42,0 71,-29t29,-71q0,-42 -29,-71t-71,-29q-42,0 -71,29t-29,71q0,42 29,71t71,29ZM748.5,828.5Q760,817 760,800t-11.5,-28.5Q737,760 720,760t-28.5,11.5Q680,783 680,800t11.5,28.5Q703,840 720,840t28.5,-11.5ZM868.5,408.5Q880,397 880,380t-11.5,-28.5Q857,340 840,340t-28.5,11.5Q800,363 800,380t11.5,28.5Q823,420 840,420t28.5,-11.5ZM480,120ZM120,380ZM480,500ZM840,380ZM240,800ZM720,800Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
Closes #139

## Summary

Adds a **provider / no-provider toggle** to `PerfScreen` so the shared engine (1 WebView) vs. standalone engines (N WebViews) cost can be measured side-by-side to validate the numbers documented in `HighlightThemeProvider`'s KDoc.

## Changes

- **New `MaybeUseHighlightProvider` composable** - conditionally wraps content in `HighlightThemeProvider`. Includes KDoc explaining its purpose and that it is benchmark-only.
- **Provider toggle button** in `TopAppBar` - tapping switches modes and resets the benchmark automatically (same as Re-run)
- **Explicit `theme` on `SyntaxHighlightedCode`** - `lightTheme`/`darkTheme`/`activeTheme` are now remembered at `PerfScreen` level and passed explicitly, so `LocalHighlightTheme.current` never throws when the provider is off
- **Engine mode row in `SummaryHeader`** - shows `Shared - 1 WebView` or `Standalone - N WebViews` so the active mode is captured when sharing benchmark screenshots

## How to test

1. Open the Perf Benchmark screen
2. Let the benchmark complete (shared engine mode, default)
3. Tap the new engine toggle icon in the top bar
4. Benchmark resets and re-runs in standalone mode
5. Compare total time and heap in `SummaryHeader` between the two modes