### PR TITLE
chore: prepare release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-22
+
 ### Changed (Breaking)
 - **`SyntaxHighlightedCode` slot parameter rename** - `languageLabelContent` renamed to
   `languageLabel` and `copyButtonContent` renamed to `copyButton` to match Material 3 naming

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.20.0")
+    implementation("dev.hossain:compose-highlight:0.21.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.20.0
+VERSION_NAME=0.21.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 23
-        versionName = "0.20.0"
+        versionCode = 24
+        versionName = "0.21.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Bumps version from 0.20.0 to 0.21.0.

- Updates `gradle.properties` VERSION_NAME
- Updates `README.md` dependency snippet
- Updates `sample/build.gradle.kts` versionName and versionCode (23 -> 24)
- Updates `CHANGELOG.md` `[Unreleased]` -> `[0.21.0] - 2026-05-22`