### PR TITLE
cleanup: minor docs cleanup

### DIFF
--- a/compose-highlight/MODULE.md
+++ b/compose-highlight/MODULE.md
@@ -2,178 +2,100 @@
 
 A Jetpack Compose library for beautiful syntax highlighting powered by [Highlight.js](https://highlightjs.org/) running in a hidden WebView. Tokenized HTML is converted to native Compose `AnnotatedString` — no custom lexers, no grammars to maintain: 190+ languages out of the box.
 
-## Quick Start
-
-Wrap your screen (or root composable) in `HighlightThemeProvider`, then place `SyntaxHighlightedCode` anywhere inside it:
-
-```kotlin
-// In your Activity or top-level composable
-HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
-    darkHighlightTheme  = rememberAtomOneDarkTheme(),
-) {
-    SyntaxHighlightedCode(
-        code     = """fun greet(name: String) = "Hello, ${'$'}name!"""",
-        language = "kotlin",
-        showLineNumbers = true,
-    )
-}
-```
-
-`HighlightThemeProvider` automatically selects the correct theme based on `isSystemInDarkTheme()`.
-
-## Supported Built-in Themes
-
-| `@Composable` helper | Context factory | Style |
-|---|---|---|
-| `rememberTomorrowTheme()` | `HighlightTheme.tomorrow(context)` | Light (Base16) |
-| `rememberTomorrowNightTheme()` | `HighlightTheme.tomorrowNight(context)` | Dark (Base16) |
-| `rememberAtomOneDarkTheme()` | `HighlightTheme.atomOneDark(context)` | Dark (Atom One) |
-| `rememberAtomOneLightTheme()` | `HighlightTheme.atomOneLight(context)` | Light (Atom One) |
-
-The `@Composable` helpers resolve `LocalContext` internally — no need to pass a `Context`.
-
-Custom themes: any Highlight.js CSS file works — load from assets with `HighlightTheme.fromAsset()` or supply raw CSS with `HighlightTheme.fromCss()`.
-
-## Headless / Engine-Only Usage
-
-Use `HighlightEngine` directly when you need an `AnnotatedString` without the built-in composable:
-
-```kotlin
-// In a ViewModel or repository
-val engine = HighlightEngine(context)
-
-// Optional: warm up the WebView before the first call
-engine.initialize()
-    .onFailure { /* handle WebView init failure if needed */ }
-
-val result = engine.highlight(
-    code     = "SELECT * FROM users WHERE active = 1",
-    language = "sql",
-    theme    = HighlightTheme.tomorrow(context),
-)
-result.onSuccess { r ->
-    // r.annotated   — AnnotatedString ready for Text()
-    // r.spanCount   — 0 signals a silent failure (unsupported language / empty input)
-    // r.durationMs  — total JS pipeline time in ms (equals r.timings.total.inWholeMilliseconds)
-    // r.timings     — per-stage Duration breakdown (jsBridge, htmlParse, treeWalk, etc.)
-    // r.language    — the language identifier that was requested
-}
-
-// Always destroy to release WebView resources
-engine.destroy()
-```
-
-When used inside a Composable, prefer `rememberHighlightEngine()` — it handles destruction automatically.
-
-## Reactive Initialization State
-
-`HighlightEngine.isInitialized` is a `StateFlow<Boolean>` — observe it in Compose to react when the hidden WebView finishes loading:
-
-```kotlin
-val engine = rememberHighlightEngine()
-val isReady by engine.isInitialized.collectAsState()
-
-if (isReady) {
-    Text("WebView warm — first highlight will be fast")
-}
-```
-
-## Raw HTML Output with Timing
-
-Use `highlightToHtml()` when you need the raw `<span class="hljs-*">` HTML (e.g. for a custom renderer or benchmarking):
-
-```kotlin
-engine.highlightToHtml(code, "kotlin").onSuccess { result ->
-    renderCustomHtml(result.html)
-    log("JS round-trip: ${result.durationMs} ms")  // true JS-only time
-}
-```
-
-`HtmlHighlightResult` carries `.html` and `.durationMs` (measured after WebView is ready and the internal mutex is acquired — excludes warm-up and queue-wait time).
-
-## Engine Introspection
-
-```kotlin
-engine.highlightJsVersion().onSuccess { v -> log("hljs $v") }
-engine.supportedLanguages().onSuccess { langs -> log("${langs.size} languages") }
-```
-
-## Theme Switching Without Extra JS Round-Trips
-
-`highlightBothThemes()` tokenizes code once and applies two color maps, so live light/dark switching is instant:
-
-```kotlin
-val themed = engine.highlightBothThemes(
-    code       = sourceCode,
-    language   = "typescript",
-    lightTheme = HighlightTheme.tomorrow(context),
-    darkTheme  = HighlightTheme.tomorrowNight(context),
-)
-themed.onSuccess { result ->
-    // ThemedHighlightResult — both variants pre-computed, no extra JS call
-    val displayString = if (isDark) result.dark else result.light
-    // result.durationMs — total pipeline time in ms; result.timings has per-stage breakdown
-}
-```
-
-Inside a Composable, use `rememberHighlightedCodeBothThemes()` for the same behaviour with automatic state management:
-
-```kotlin
-HighlightThemeProvider(lightHighlightTheme = ..., darkHighlightTheme = ...) {
-    // Themes default to LocalLightHighlightTheme / LocalDarkHighlightTheme — no explicit args needed
-    val result by rememberHighlightedCodeBothThemes(
-        code     = sourceCode,
-        language = "kotlin",
-        onHighlightComplete = { r ->
-            // r.timings has per-stage Duration fields: jsBridge, htmlParse, treeWalk, etc.
-            log("done in ${r.durationMs} ms (JS: ${r.timings.jsBridge.inWholeMilliseconds}ms)")
-        },
-    )
-    val text = if (isSystemInDarkTheme()) result?.dark else result?.light
-    if (text != null) Text(text)
-}
-```
-
-## CompositionLocals
-
-`HighlightThemeProvider` exposes three CompositionLocals:
-
-| Local | Type | Content |
-|---|---|---|
-| `LocalHighlightTheme` | `HighlightTheme` | Active theme (light or dark based on system) |
-| `LocalLightHighlightTheme` | `HighlightTheme` | Always the light variant |
-| `LocalDarkHighlightTheme` | `HighlightTheme` | Always the dark variant |
-
-`LocalLightHighlightTheme` and `LocalDarkHighlightTheme` are useful when a composable needs both variants simultaneously (e.g. `rememberHighlightedCodeBothThemes`).
-
-## Custom Styling
-
-Pass a `CodeBlockStyle` to control padding, shape, line-number column width, and copy-button size:
-
-```kotlin
-val compact = CodeBlockStyle(
-    shape   = RoundedCornerShape(4.dp),
-    padding = PaddingValues(8.dp),
-)
-SyntaxHighlightedCode(
-    code     = snippet,
-    language = "json",
-    style    = compact,
-    copyButton = null,   // hide the copy button
-)
-```
+For detailed API documentation and usage examples, see the [generated API docs](../docs/api/) and [getting started guide](../docs/getting-started.md).
 
 ## Architecture
 
+Public API is split across two layers:
+
 ```
-SyntaxHighlightedCode      (Compose UI)
- └── rememberHighlightEngine / rememberHighlightedCode
-       └── HighlightEngine            (coroutine pipeline)
-             ├── WebViewManager       (hidden WebView + JS bridge)
-             ├── HighlightTheme       (CSS theme model, lazy-parsed)
-             ├── ThemeParser          (CSS → Map<selector, SpanStyle>)
-             └── HtmlToAnnotatedString (jsoup → AnnotatedString)
+UI Layer (public)
+  ├── SyntaxHighlightedCode        ← Compose wrapper around HighlightEngine
+  ├── HighlightThemeProvider       ← Provides shared engine + active theme to subtree
+  ├── rememberHighlightEngine()    ← Lifecycle-aware engine factory (uses provider's engine when available)
+  ├── rememberHighlightedCode()    ← State holder for single-language highlighting
+  └── rememberHighlightedCodeBothThemes()  ← State holder for dual-theme highlighting
+
+Engine Layer (public)
+  ├── HighlightEngine              ← Main entry point, owns WebView and serialization
+  ├── HighlightTheme               ← Lazy CSS-backed color map model
+  ├── HighlightResult / HtmlHighlightResult / ThemedHighlightResult  ← Result types
+  └── HighlightLanguage / HighlightLanguageInfo  ← Helper lookups
+
+Internal (compose-highlight package-internal)
+  ├── WebViewManager               ← Hidden WebView lifecycle, JS bridge
+  ├── ThemeParser                  ← CSS selector → Map<String, SpanStyle> parsing
+  ├── HtmlToAnnotatedString        ← jsoup-based HTML → AnnotatedString conversion
+  └── Helper functions (unescapeJsString, escapeForJs, etc.)
 ```
 
-All WebView operations run on the Main thread; callers interact via `suspend` functions backed by a `Mutex`. The WebView loads `bridge.html` from the library's bundled assets which in turn loads the full Highlight.js bundle — no network requests at runtime.
+**WebView threading:** All `WebView` APIs run on the Main thread. `HighlightEngine` serializes concurrent highlight calls via an internal `Mutex` and dispatches theme-parsing / HTML-conversion work to `Dispatchers.Default` off the Main thread.
+
+**Shared engine via `HighlightThemeProvider`:** Creates one `HighlightEngine` (one hidden WebView) for its entire subtree. `rememberHighlightEngine()` detects the provider via `LocalHighlightEngine` and returns the shared engine if present; otherwise creates a standalone engine with automatic lifecycle cleanup via `DisposableEffect`.
+
+**Asset loading:** `WebViewAssetLoader` maps requests to `https://appassets.androidplatform.net/assets/` to the app's `assets/` folder, bypassing Same-Origin Policy restrictions on `file://` URLs and enabling `<script>` execution.
+
+## Implementation conventions
+
+**Public vs internal API boundary:** Only `ui/*`, `engine/HighlightEngine.kt`, `engine/HighlightTheme.kt`, and `engine/HighlightException.kt` are public. All other engine helpers (`WebViewManager`, `ThemeParser`, `HtmlToAnnotatedString`, `unescapeJsString`, etc.) are `internal`. Note: `unescapeJsString` is a package-level `internal fun` so it can be tested directly in JVM unit tests without mocking Android.
+
+**`android.util.Log` is banned.** Any `Log.*` call in code that runs in JVM tests causes `RuntimeException: Method d in android.util.Log not mocked`. Use structured logging via test assertions instead.
+
+**Results use `Result<T>`, never throw from public methods.** All public engine methods return `Result<T>`. Failures wrap `HighlightException` (a sealed class). Add new exception variants to the sealed class rather than throwing arbitrary exceptions.
+
+**Application context only.** Both `HighlightEngine` and `HighlightTheme` hold contexts beyond Activity lifecycle. Always pass `context.applicationContext` from call sites - never Activity contexts. Internals defensively normalize any provided context to `applicationContext`.
+
+**Main thread threading model.** All WebView APIs run on the Main thread via `Dispatchers.Main` callbacks. `HighlightEngine` serializes concurrent highlight calls via `Mutex` and offloads theme parsing / HTML conversion to `Dispatchers.Default`.
+
+**Lazy theme initialization.** `HighlightTheme.colorMap` is backed by `lazy {}`. CSS parsing and any asset I/O happen on first access to `colorMap`, not at factory time. Errors surface on first use, not theme construction.
+
+**Static CompositionLocals.** `LocalHighlightTheme`, `LocalLightHighlightTheme`, `LocalDarkHighlightTheme`, and internal `LocalHighlightEngine` use `staticCompositionLocalOf` (not `compositionLocalOf`) because they carry stable objects (themes, engine) that do not change within their provider subtree. This avoids unnecessary recomposition tracking.
+
+**Asset path structure.** All library assets live under `assets/compose-highlight/` to avoid collisions. CSS themes are in `assets/compose-highlight/themes/`.
+
+**Formatting.** ktlint via `org.jmailen.kotlinter`. The `.editorconfig` suppresses the function-naming rule for composables. Run `./gradlew formatKotlin` before committing.
+
+**KDoc on public API.** Every public class, function, and property must have KDoc. Non-trivial classes and composables should include usage examples in triple-backtick blocks. Dokka generates published API docs from KDoc to GitHub Pages. Internal classes benefit from KDoc but are not required.
+
+**Test structure.** JVM unit tests in `src/test/` run fast without a device. Use `ThemeParser.parse(cssString)` for theme tests and call `unescapeJsString(...)` directly - both work without Android mocks. Use [Google Truth](https://github.com/google/truth) for assertions. Instrumented tests in `src/androidTest/` require a connected device; includes `HighlightEngineTest` and microbenchmarks using `BenchmarkRule`.
+
+## Git workflow and release process
+
+**Always create new commits.** Never use `git commit --amend`, `git push --force`, or similar rewriting operations. Always create a new commit for changes. This preserves attribution and clean history. If changes are needed after pushing, create a new commit with a descriptive message (e.g., "fix: address code review feedback in X").
+
+**Before every commit - verify stability.** Run the following and ensure all pass:
+```bash
+./gradlew formatKotlin
+./gradlew :compose-highlight:assembleDebug :sample:assembleDebug
+./gradlew :compose-highlight:test
+```
+Do not commit if any fail.
+
+**Git tags must not use `v` prefix.** Use `0.3.0`, not `v0.3.0`. Maven Central uses the tag as the dependency version, so the version consumers write matches the tag exactly.
+
+**Release process uses a script.** Before tagging, use the release script to update version references atomically:
+```bash
+./scripts/prepare-release.sh <new-version>
+# Example: ./scripts/prepare-release.sh 0.18.0
+```
+This script updates `gradle.properties`, `README.md`, `sample/build.gradle.kts`, and `CHANGELOG.md` in one step. Never update these manually one-by-one - you will miss files.
+
+**Release PR workflow:** Create a release branch, run all checks, commit, push, and open a PR into `main`:
+```bash
+git checkout -b release/<new-version>
+./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test
+git add -A && git commit -m "chore: prepare release <new-version>"
+git push -u origin release/<new-version>
+gh pr create --title "chore: prepare release <new-version>" --base main
+```
+
+**Publishing is a manual two-step after the PR is merged.** Only after the release PR is merged into `main`:
+```bash
+git checkout main && git pull
+git tag <new-version> && git push origin <new-version>
+```
+Then manually trigger the GitHub Actions publish workflow in **dry-run mode first**, then again **without dry-run** to actually publish to Maven Central.
+
+**CHANGELOG.md must stay current.** For every PR/commit that adds a feature, fixes a bug, or makes a breaking change, add an entry under `[Unreleased]` in `CHANGELOG.md`. When releasing, rename the `[Unreleased]` section to the version number with today's date.
+
+**No em dashes in text.** Write `-` (regular hyphen) instead of `-` (em dash) in commit messages, code comments, KDoc, and CHANGELOG entries.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightLanguage.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightLanguage.kt
@@ -1,5 +1,7 @@
 package dev.hossain.highlight.engine
 
+import java.util.Locale
+
 /**
  * Maps file extensions to Highlight.js language identifiers.
  *
@@ -163,5 +165,5 @@ public object HighlightLanguage {
      * @return Highlight.js language name such as `"kotlin"`, or `null` if the extension is not
      *   recognised.
      */
-    fun fromExtension(extension: String): String? = extensionMap[extension.lowercase(java.util.Locale.ROOT)]
+    fun fromExtension(extension: String): String? = extensionMap[extension.lowercase(Locale.ROOT)]
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/WebViewManager.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.withContext
  *
  * `bridge.html` is a minimal HTML page (loaded once at startup) that:
  * 1. Loads the bundled `highlight.min.js` library
- * 2. Defines a single JS function: `highlightCode(code, lang) → HTML string`
+ * 2. Defines multiple highlight JS function like, `highlightCode(code, lang) → HTML string`
  *
  * After the page finishes loading, [HighlightEngine] calls `highlightCode()` via
  * [android.webkit.WebView.evaluateJavascript] for every syntax-highlight request,


### PR DESCRIPTION
This pull request updates the documentation and makes a minor code improvement for locale handling. The most significant change is a comprehensive rewrite of the `MODULE.md` documentation, which now provides a more structured and detailed overview of the library's architecture, usage, conventions, and release workflow. Additionally, a small code cleanup replaces a fully-qualified locale reference with a direct import, and a documentation comment is clarified.

**Documentation and API Usage Updates:**

- Major rewrite of `MODULE.md`:
  - Replaces the quick start and theme tables with references to generated API docs and a getting started guide.
  - Adds detailed sections on architecture, implementation conventions, threading, API boundaries, asset structure, formatting, KDoc requirements, test structure, and the full release workflow.
  - Clarifies best practices for context usage, threading, error handling, and Git workflow.
  - Removes inline code samples and theme tables in favor of external documentation references.

**Code Quality Improvements:**

- Imports `java.util.Locale` at the top of `HighlightLanguage.kt` and uses the imported `Locale.ROOT` instead of the fully-qualified name in the `fromExtension` function, improving readability. [[1]](diffhunk://#diff-d8dcb63903ffb4f729e2514f07a34e0a5e21de595b50e18ffe407dd6bed4aabbR3-R4) [[2]](diffhunk://#diff-d8dcb63903ffb4f729e2514f07a34e0a5e21de595b50e18ffe407dd6bed4aabbL166-R168)

**Minor Documentation Fix:**

- Updates a comment in `WebViewManager.kt` to clarify that multiple highlight JS functions are defined, not just one.