### PR TITLE
fix: use Result.onFailure directly in Trigger Engine Error demo

### DIFF
--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AdvancedEngineSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/AdvancedEngineSection.kt
@@ -383,19 +383,17 @@ internal fun AdvancedEngineSection(
                         assetPath = "nonexistent-theme.css",
                         name = "broken",
                     )
-                runCatching {
-                    // runCatching is needed because theme.colorMap is a lazy property that can
-                    // throw an IOException (wrapped in HighlightException) when first accessed
-                    // during highlight(). The Result returned by highlight() only covers
-                    // failures that occur after colorMap succeeds.
-                    directEngine.highlight("val x = 42", "kotlin", brokenTheme)
-                }.onFailure { e ->
-                    caughtException =
-                        when (e) {
-                            is HighlightException -> e
-                            else -> HighlightException.HtmlParseFailed(e)
-                        }
-                }
+                // highlight() catches all theme and parsing exceptions via withHtmlParsingErrorHandling
+                // and returns them as Result.failure - no throw, so check the Result directly.
+                directEngine
+                    .highlight("val x = 42", "kotlin", brokenTheme)
+                    .onFailure { e ->
+                        caughtException =
+                            when (e) {
+                                is HighlightException -> e
+                                else -> HighlightException.HtmlParseFailed(e)
+                            }
+                    }
             }
         }) {
             Text("Trigger Engine Error")


### PR DESCRIPTION
## Problem

The **Trigger Engine Error** button in the Advanced Engine section was broken - tapping it showed nothing.

**Root cause:** `highlight()` uses `withHtmlParsingErrorHandling` internally, which catches the `IOException` from the missing asset and returns it as `Result.failure()` - it never throws. The old code wrapped the call in `runCatching { }`, which always "succeeded" (no exception was raised), so `.onFailure` never fired and `caughtException` stayed `null`.

## Fix

Drop `runCatching` and call `.onFailure { }` directly on the `Result` returned by `highlight()`.

```kotlin
// before - runCatching always succeeds, onFailure never fires
runCatching {
    directEngine.highlight("val x = 42", "kotlin", brokenTheme)
}.onFailure { e -> ... }

// after - checks the Result directly
directEngine.highlight("val x = 42", "kotlin", brokenTheme)
    .onFailure { e -> ... }
```