### PR TITLE
chore: prepare release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-22
+
 ### Fixed
 - **`WebViewManager` - WebView unavailability now surfaces as `WebViewInitFailed` not
   `JsExecutionFailed`** - When WebView is not available on the device (Android Go, MDM-disabled,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.21.0")
+    implementation("dev.hossain:compose-highlight:0.22.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.21.0
+VERSION_NAME=0.22.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 24
-        versionName = "0.21.0"
+        versionCode = 25
+        versionName = "0.22.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Release preparation for 0.22.0.

### Changes
- `gradle.properties`: VERSION_NAME 0.21.0 -> 0.22.0
- `README.md`: dependency snippet updated
- `sample/build.gradle.kts`: versionName 0.22.0, versionCode 24 -> 25
- `CHANGELOG.md`: `[Unreleased]` renamed to `[0.22.0] - 2026-05-22`

### Next steps after merge
1. Pull main and tag: `git tag 0.22.0 && git push origin 0.22.0`
2. Trigger publish workflow (dry-run first, then real)