### PR TITLE
docs: fix site content accuracy

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -63,7 +63,7 @@ import dev.hossain.highlight.engine.HighlightEngine
 import dev.hossain.highlight.engine.HighlightTheme
 
 class CodeViewModel(application: Application) : AndroidViewModel(application) {
-    private val engine = HighlightEngine(application)
+    private val engine = HighlightEngine(application.applicationContext)
 
     init {
         viewModelScope.launch {

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -133,4 +133,4 @@ val (lightAnnotated, darkAnnotated) by produceState(fallback to fallback, code) 
 // Switch between lightAnnotated and darkAnnotated instantly
 ```
 
-See [`rememberHighlightedCodeBothThemes`](../reference/highlight-engine.md) for the ready-made composable helper.
+See [`rememberHighlightedCodeBothThemes`](../reference/syntax-highlighted-code.md#rememberhighlightedcodeboththemes) for the ready-made composable helper.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ That's it. `HighlightThemeProvider` automatically picks Tomorrow (light) or Tomo
 
 ## Key features
 
-- **180+ languages** - every language Highlight.js supports
+- **Wide language coverage** - use any language supported by the bundled Highlight.js build
 - **Light + dark themes** - automatic system-mode switching, or manual override
 - **Built-in themes** - Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light
 - **Custom themes** - load any Highlight.js CSS from `assets/`, raw CSS string, or a `Map<String, SpanStyle>`

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -42,7 +42,7 @@ import dev.hossain.highlight.engine.HighlightEngine
 import dev.hossain.highlight.engine.HighlightTheme
 
 class CodeViewModel(application: Application) : AndroidViewModel(application) {
-    private val engine = HighlightEngine(application)
+    private val engine = HighlightEngine(application.applicationContext)
 
     init {
         viewModelScope.launch {

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -33,15 +33,20 @@ Drop any [Highlight.js CSS theme](https://github.com/highlightjs/highlight.js/tr
 ```kotlin
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.ui.HighlightThemeProvider
+import androidx.compose.ui.platform.LocalContext
 
 // src/main/assets/themes/github.css  <- place the CSS here
+val appContext = LocalContext.current.applicationContext
 val theme = HighlightTheme.fromAsset(
-    context   = context,
+    context   = appContext,
     assetPath = "themes/github.css",
     name      = "github",
 )
 HighlightThemeProvider(lightHighlightTheme = theme) { ... }
 ```
+
+!!! note
+    Always pass `applicationContext` to `HighlightTheme` factories.
 
 !!! note
     `fromAsset()` is lazy - CSS parsing happens on first use, not at factory-call time.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,9 +17,9 @@ This section documents the public API of `compose-highlight`.
 | [`HighlightTimings`](../guides/performance.md#timing-callbacks) | Per-stage timing breakdown (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) |
 | [`HighlightLanguageInfo`](highlight-engine.md#highlightlanguageinfo) | Metadata returned by `HighlightEngine.getLanguage()` |
 | [`HighlightException`](highlight-engine.md) | Sealed exception hierarchy for all engine errors |
-| `rememberHighlightedCode` | Composable helper - highlights code and returns an `AnnotatedString` state |
-| `rememberHighlightedCodeBothThemes` | Highlights once, produces light + dark variants |
-| `rememberHighlightEngine` | Returns the shared or standalone `HighlightEngine` for the current composition |
+| [`rememberHighlightedCode`](syntax-highlighted-code.md#rememberhighlightedcode) | Composable helper - highlights code and returns an `AnnotatedString` state |
+| [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md#rememberhighlightedcodeboththemes) | Highlights once, produces light + dark variants |
+| [`rememberHighlightEngine`](highlight-engine.md#rememberhighlightengine) | Returns the shared or standalone `HighlightEngine` for the current composition |
 | `rememberTomorrowTheme` | Composable factory for the built-in Tomorrow (light) theme |
 | `rememberTomorrowNightTheme` | Composable factory for the built-in Tomorrow Night (dark) theme |
 | `rememberAtomOneDarkTheme` | Composable factory for the built-in Atom One Dark theme |

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -197,3 +197,76 @@ HighlightThemeProvider(
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) { ... }
 ```
+
+## `rememberHighlightedCode`
+
+Highlights code in a composable and returns `State<AnnotatedString?>`.
+
+```kotlin
+@Composable
+fun rememberHighlightedCode(
+    code: String,
+    language: String,
+    theme: HighlightTheme = LocalHighlightTheme.current,
+    onHighlightComplete: ((HighlightResult) -> Unit)? = null,
+    onError: ((HighlightException) -> Unit)? = null,
+): State<AnnotatedString?>
+```
+
+Returns `null` while highlighting is still running or if highlighting fails, so callers should
+always render a plain-text fallback.
+
+```kotlin
+val highlighted by rememberHighlightedCode(code = snippet, language = "kotlin")
+
+Text(text = highlighted ?: AnnotatedString(snippet))
+```
+
+Use `onHighlightComplete` for metrics and `onError` for typed failure handling:
+
+```kotlin
+val highlighted by rememberHighlightedCode(
+    code = snippet,
+    language = "kotlin",
+    onHighlightComplete = { result ->
+        metrics["highlightMs"] = result.durationMs
+    },
+    onError = { error ->
+        println("Highlight failed: ${error.message}")
+    },
+)
+```
+
+## `rememberHighlightedCodeBothThemes`
+
+Highlights once and returns both light and dark variants as `State<ThemedHighlightResult?>`.
+
+```kotlin
+@Composable
+fun rememberHighlightedCodeBothThemes(
+    code: String,
+    language: String,
+    lightTheme: HighlightTheme = LocalLightHighlightTheme.current,
+    darkTheme: HighlightTheme = LocalDarkHighlightTheme.current,
+    onHighlightComplete: ((ThemedHighlightResult) -> Unit)? = null,
+    onError: ((HighlightException) -> Unit)? = null,
+): State<ThemedHighlightResult?>
+```
+
+This is the Compose helper for zero-extra-latency theme switching. It tokenizes the source once,
+then applies both color maps to the same HTML result.
+
+```kotlin
+val themed by rememberHighlightedCodeBothThemes(
+    code = snippet,
+    language = "kotlin",
+)
+
+Text(
+    text = if (isDark) themed?.dark ?: AnnotatedString(snippet)
+    else themed?.light ?: AnnotatedString(snippet),
+)
+```
+
+Inside `HighlightThemeProvider`, `lightTheme` and `darkTheme` default from the provider. Outside a
+provider, pass both themes explicitly.


### PR DESCRIPTION
## Summary
- remove stale or brittle docs-site claims
- align examples with current applicationContext guidance
- improve API reference coverage and cross-links for remember* helpers