### PR TITLE
docs: refine docs accuracy pass

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,10 +6,10 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
-### Unreleased (on main, not yet published)
+### 0.22.0 - WebView and theme correctness fixes
 
-- CSS4 `rgb(R G B)` and `rgb(R G B / alpha)` space-separated syntax support in ThemeParser
-- `HighlightTheme` content-aware equality - `equals()`/`hashCode()` now includes content identity, not just name
+- CSS4 `rgb(R G B)` and `rgb(R G B / alpha)` space-separated syntax support in `ThemeParser`
+- `HighlightTheme` content-aware equality - `equals()` and `hashCode()` now include content identity, not just name
 - `unescapeJsString` surrogate pair handling for emoji and supplementary Unicode characters
 - `escapeForJs` now escapes null bytes and control characters (U+0000-U+001F)
 - WebView unavailability now surfaces as `WebViewInitFailed` instead of `JsExecutionFailed`

--- a/docs/guides/engine-only.md
+++ b/docs/guides/engine-only.md
@@ -60,8 +60,6 @@ fun CodeScreen(viewModel: CodeViewModel = viewModel()) {
 Get the raw Highlight.js HTML tokens for custom rendering pipelines:
 
 ```kotlin
-import android.util.Log
-
 engine.highlightToHtml("val x = 42", "kotlin").onSuccess { result ->
     // result.html: "<span class=\"hljs-keyword\">val</span> x = <span class=\"hljs-number\">42</span>"
     Log.d("HTML", result.html)
@@ -71,8 +69,6 @@ engine.highlightToHtml("val x = 42", "kotlin").onSuccess { result ->
 ## Querying engine metadata
 
 ```kotlin
-import android.util.Log
-
 engine.supportedLanguages().onSuccess { languages ->
     Log.d("Engine", "Supports ${languages.size} languages")
 }

--- a/docs/guides/engine-only.md
+++ b/docs/guides/engine-only.md
@@ -60,6 +60,8 @@ fun CodeScreen(viewModel: CodeViewModel = viewModel()) {
 Get the raw Highlight.js HTML tokens for custom rendering pipelines:
 
 ```kotlin
+import android.util.Log
+
 engine.highlightToHtml("val x = 42", "kotlin").onSuccess { result ->
     // result.html: "<span class=\"hljs-keyword\">val</span> x = <span class=\"hljs-number\">42</span>"
     Log.d("HTML", result.html)
@@ -69,6 +71,8 @@ engine.highlightToHtml("val x = 42", "kotlin").onSuccess { result ->
 ## Querying engine metadata
 
 ```kotlin
+import android.util.Log
+
 engine.supportedLanguages().onSuccess { languages ->
     Log.d("Engine", "Supports ${languages.size} languages")
 }

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -105,7 +105,6 @@ Inside Compose, use `rememberHighlightedCodeBothThemes(code, language)`.
 Monitor per-stage latency with `onHighlightComplete`:
 
 ```kotlin
-import android.util.Log
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 SyntaxHighlightedCode(

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -105,17 +105,20 @@ Inside Compose, use `rememberHighlightedCodeBothThemes(code, language)`.
 Monitor per-stage latency with `onHighlightComplete`:
 
 ```kotlin
+import android.util.Log
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 SyntaxHighlightedCode(
     code     = snippet,
     language = "kotlin",
     onHighlightComplete = { result ->
-        Log.d("HighlightPerf",
+        Log.d(
+            "HighlightPerf",
             "total=${result.durationMs}ms, " +
             "js=${result.timings.jsBridge.inWholeMilliseconds}ms, " +
             "parse=${result.timings.htmlParse.inWholeMilliseconds}ms, " +
-            "spans=${result.spanCount}")
+            "spans=${result.spanCount}",
+        )
     },
 )
 ```

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -70,6 +70,7 @@ HighlightThemeProvider(
 ### With an explicit theme
 
 ```kotlin
+import android.util.Log
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberTomorrowTheme
 
@@ -225,6 +226,8 @@ Text(text = highlighted ?: AnnotatedString(snippet))
 Use `onHighlightComplete` for metrics and `onError` for typed failure handling:
 
 ```kotlin
+import android.util.Log
+
 val highlighted by rememberHighlightedCode(
     code = snippet,
     language = "kotlin",
@@ -232,7 +235,7 @@ val highlighted by rememberHighlightedCode(
         metrics["highlightMs"] = result.durationMs
     },
     onError = { error ->
-        println("Highlight failed: ${error.message}")
+        Log.d("Highlight", "Failed: ${error.message}")
     },
 )
 ```

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -70,7 +70,6 @@ HighlightThemeProvider(
 ### With an explicit theme
 
 ```kotlin
-import android.util.Log
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberTomorrowTheme
 
@@ -145,9 +144,6 @@ SyntaxHighlightedCode(
 ### Custom placeholder while loading
 
 ```kotlin
-import androidx.compose.material3.Text
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 SyntaxHighlightedCode(
@@ -226,8 +222,6 @@ Text(text = highlighted ?: AnnotatedString(snippet))
 Use `onHighlightComplete` for metrics and `onError` for typed failure handling:
 
 ```kotlin
-import android.util.Log
-
 val highlighted by rememberHighlightedCode(
     code = snippet,
     language = "kotlin",


### PR DESCRIPTION
## Summary
- align docs/changelog.md with the current released state
- keep Android-focused docs examples using Log.d where appropriate
- tighten reference and guide snippets after a second docs review pass