### PR TITLE
fix: close asset streams, reset scroll on code change, remove buildAn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`ThemeParser` - close InputStream after reading CSS assets** - `context.assets.open(...)`
+  streams in both `parse(Context, String)` and `parseAsset(Context, String)` were not explicitly
+  closed. Under repeated theme loading (configuration changes, multi-screen apps), unclosed streams
+  could exhaust file descriptors. Both now use `.use { it.readText() }` for deterministic cleanup.
+
+- **`SyntaxHighlightedCode` - reset horizontal scroll position on code change** -
+  `rememberScrollState()` had no key, so scroll position persisted when the `code` parameter
+  changed. A user who scrolled right on a long line would stay scrolled on the next code snippet.
+  The scroll state is now keyed on `code` so it resets to position 0 when new content is displayed.
+
+- **`HtmlToAnnotatedString` - remove redundant private `buildAnnotatedString` shadow** - A private
+  function reimplemented the standard `androidx.compose.ui.text.buildAnnotatedString` verbatim
+  with a misleading comment ("without Compose runtime"). The standard library function is already
+  available and is now used directly.
+
 ### Performance
 
 - **`SyntaxHighlightedCode` - stable lambda instances for slot defaults** - The `effectiveCopyButton` lambda and the default `languageLabel` lambda were allocated fresh on every recomposition, preventing the copy button and language label subtrees from being skipped by the Compose runtime. Both are now resolved via a sentinel pattern and wrapped in `remember`, keeping lambda instances stable across recompositions. This reduces unnecessary recomposition work in `LazyColumn` scenarios with many code blocks on screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this project will be documented in this file.
   could exhaust file descriptors. Both now use `.use { it.readText() }` for deterministic cleanup.
 
 - **`SyntaxHighlightedCode` - reset horizontal scroll position on code change** -
-  `rememberScrollState()` had no key, so scroll position persisted when the `code` parameter
-  changed. A user who scrolled right on a long line would stay scrolled on the next code snippet.
-  The scroll state is now keyed on `code` so it resets to position 0 when new content is displayed.
+  `rememberScrollState()` preserved scroll position when the `code` parameter changed. A user
+  who scrolled right on a long line would stay scrolled on the next code snippet. A
+  `LaunchedEffect(code)` now calls `scrollTo(0)` when code changes, resetting the position while
+  preserving state restoration across configuration changes (rememberScrollState is saveable).
 
 - **`HtmlToAnnotatedString` - remove redundant private `buildAnnotatedString` shadow** - A private
   function reimplemented the standard `androidx.compose.ui.text.buildAnnotatedString` verbatim

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -3,6 +3,7 @@ package dev.hossain.highlight.engine
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
@@ -303,10 +304,3 @@ internal data class TimedConvertBothResult(
     val htmlParseDuration: Duration,
     val treeWalkDuration: Duration,
 )
-
-// Extension to use buildAnnotatedString pattern without Compose runtime
-private fun buildAnnotatedString(block: AnnotatedString.Builder.() -> Unit): AnnotatedString {
-    val builder = AnnotatedString.Builder()
-    builder.block()
-    return builder.toAnnotatedString()
-}

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -43,7 +43,7 @@ object ThemeParser {
                 context.assets
                     .open(cssAssetPath)
                     .bufferedReader()
-                    .readText()
+                    .use { it.readText() }
             parse(css)
         } catch (e: Exception) {
             emptyMap()
@@ -64,7 +64,7 @@ object ThemeParser {
             context.assets
                 .open(cssAssetPath)
                 .bufferedReader()
-                .readText()
+                .use { it.readText() }
         return parse(css)
     }
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,7 +14,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
@@ -339,8 +339,10 @@ fun SyntaxHighlightedCode(
                 }
             }
 
-            // Code content with horizontal scroll
-            Box(modifier = Modifier.horizontalScroll(rememberScrollState())) {
+            // Code content with horizontal scroll. Scroll state is keyed on code so that
+            // the position resets to 0 when the code block displays new content.
+            val scrollState = remember(code) { ScrollState(0) }
+            Box(modifier = Modifier.horizontalScroll(scrollState)) {
                 val highlighted = highlightedState.value
                 val placeholderContent = placeholder
                 val shouldShowPlaceholder = highlighted == null && placeholderContent != null && !highlightFailed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,11 +13,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -339,9 +340,12 @@ fun SyntaxHighlightedCode(
                 }
             }
 
-            // Code content with horizontal scroll. Scroll state is keyed on code so that
-            // the position resets to 0 when the code block displays new content.
-            val scrollState = remember(code) { ScrollState(0) }
+            // Code content with horizontal scroll. Scroll position resets to 0 when code
+            // changes, but survives configuration changes via rememberScrollState (saveable).
+            val scrollState = rememberScrollState()
+            LaunchedEffect(code) {
+                scrollState.scrollTo(0)
+            }
             Box(modifier = Modifier.horizontalScroll(scrollState)) {
                 val highlighted = highlightedState.value
                 val placeholderContent = placeholder


### PR DESCRIPTION
…notatedString shadow

## Summary

  - **ThemeParser**: Close `InputStream` with `.use {}` in both `parse(Context, String)` and `parseAsset(Context, String)` to prevent file descriptor leaks under repeated theme loading
  - **SyntaxHighlightedCode**: Key scroll state on `code` so horizontal scroll resets to 0 when new content is displayed
  - **HtmlToAnnotatedString**: Remove redundant private `buildAnnotatedString` that reimplemented the standard `androidx.compose.ui.text.buildAnnotatedString` verbatim