### PR TITLE
fix: consolidate duplicate section headings and enable MD024 rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,14 +44,19 @@ npx markdownlint --fix CHANGELOG.md
 ## CHANGELOG.md Markdown Formatting
 
 **Markdown linting usage:**
-- This repository currently documents running `markdownlint` directly against `CHANGELOG.md`: `npx markdownlint CHANGELOG.md`
-- No repository markdownlint config file is referenced in these instructions, so do not assume a `.markdownlintrc` is present
+- Run `npx markdownlint CHANGELOG.md` to validate all formatting rules before committing
+- The repository includes `.markdownlintrc` configuration that enforces changelog-specific rules
+
+**.markdownlintrc configuration:**
+- `MD013`: Line length limit of 120 characters (vs. default 80) to accommodate detailed technical changelog entries
+- `MD024`: `siblings_only: true` - Prevents duplicate section headings (e.g., multiple `### Fixed`) within the same release version. Allows the same heading across different versions, which is normal for changelogs
 
 **CHANGELOG.md formatting rules:**
-1. **Blank lines around section headings** - Every heading (`### Fixed`, `### Added`, `### Changed`, `### Performance`, `### Infrastructure`, etc.) should be surrounded by blank lines (one before, one after).
-2. **Blank lines around code fences** - All code blocks (triple backticks) should be surrounded by blank lines.
-3. **Line length** - Keep lines reasonably wrapped for readability; long bullet items should wrap to multiple indented lines instead of becoming hard to review.
-4. **Long bullet wrapping pattern** - Convert long single-line items like:
+1. **No duplicate headings within a version** — Each release (`## [X.Y.Z]`) should have at most one of each section heading type (`### Fixed`, `### Added`, `### Changed`, etc.). If your changes span multiple categories, consolidate them under a single section heading with multiple bullet items. This rule is enforced by MD024 with `siblings_only: true`.
+2. **Blank lines around section headings** — Every heading (`### Fixed`, `### Added`, `### Changed`, `### Performance`, `### Infrastructure`, etc.) should be surrounded by blank lines (one before, one after).
+3. **Blank lines around code fences** — All code blocks (triple backticks) should be surrounded by blank lines.
+4. **Line length** — Keep lines reasonably wrapped for readability; long bullet items should wrap to multiple indented lines instead of becoming hard to review. The 120-character limit allows technical explanations to stay together without excessive wrapping.
+5. **Long bullet wrapping pattern** — Convert long single-line items like:
 
    ```
    - **Item** - [500+ char explanation with multiple concepts]
@@ -65,8 +70,8 @@ npx markdownlint --fix CHANGELOG.md
      [Explanation line 3 indented by 2 spaces]
    ```
 
-5. **No spaces inside code spans** - Code spans must not have spaces between backticks and content: `` `code` `` not `` ` code ` ``.
-6. **Run `markdownlint` before committing** - Always verify no violations remain: `npx markdownlint CHANGELOG.md`
+6. **No spaces inside code spans** — Code spans must not have spaces between backticks and content: `` `code` `` not `` ` code ` ``.
+7. **Run `markdownlint` before committing** — Always verify no violations remain: `npx markdownlint CHANGELOG.md`
 
 ## Architecture
 

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,4 +1,4 @@
 {
   "MD013": { "line_length": 120 },
-  "MD024": false
+  "MD024": { "siblings_only": true }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,11 @@ All notable changes to this project will be documented in this file.
   )
   ```
 
+- Added jsoup keep rules to `consumer-rules.pro` so consuming apps with R8 minification
+  enabled do not encounter runtime crashes (`ClassNotFoundException`, `NoSuchMethodError`)
+  from stripped or obfuscated jsoup classes. Rules cover `org.jsoup.Jsoup`,
+  `org.jsoup.parser.**`, `org.jsoup.nodes.**`, and `org.jsoup.select.**`.
+
 ### Performance
 
 - `HtmlToAnnotatedString.convertTimed()` and theme color map resolution now run on
@@ -218,13 +223,6 @@ All notable changes to this project will be documented in this file.
   on `Dispatchers.Main` as required by Android.
 - `highlightAuto()` now releases the serializing mutex before the CPU-intensive HTML
   parsing step, allowing other highlight calls to proceed sooner.
-
-### Fixed
-
-- Added jsoup keep rules to `consumer-rules.pro` so consuming apps with R8 minification
-  enabled do not encounter runtime crashes (`ClassNotFoundException`, `NoSuchMethodError`)
-  from stripped or obfuscated jsoup classes. Rules cover `org.jsoup.Jsoup`,
-  `org.jsoup.parser.**`, `org.jsoup.nodes.**`, and `org.jsoup.select.**`.
 
 ## [0.20.0] - 2026-05-20
 
@@ -671,6 +669,34 @@ All notable changes to this project will be documented in this file.
 - **`rememberHighlightedCode` timing is now measured inside the engine** — `durationMs` in
   `HighlightResult` reflects pure highlight time (JS round-trip + HTML parse), not
   coroutine-scheduling overhead.
+- **`CodeBlockStyle` gains a `textStyle: TextStyle` property** — font family, font size,
+  and line height are now configured via `CodeBlockStyle.textStyle` (defaulting to
+  `SyntaxHighlightedCodeDefaults.codeTextStyle`: monospace, 13 sp, 20 sp line height).
+- **`SyntaxHighlightedCode`: removed `fontFamily`, `fontSize`, `lineHeight` parameters**
+  — these three top-level parameters are replaced by `CodeBlockStyle.textStyle`.
+  Consolidating typography into `CodeBlockStyle` follows established Compose library
+  patterns (e.g. Material 3, Haze) where all visual style is expressed through a single
+  style object.
+
+  **Migration:** replace individual parameters with `style = CodeBlockStyle(textStyle = ...)`:
+
+  ```kotlin
+  // Before
+  SyntaxHighlightedCode(code = snippet, language = "kotlin", fontSize = 15.sp,
+                        lineHeight = 24.sp)
+
+  // After
+  SyntaxHighlightedCode(
+      code     = snippet,
+      language = "kotlin",
+      style    = CodeBlockStyle(
+          textStyle = SyntaxHighlightedCodeDefaults.codeTextStyle.copy(
+              fontSize   = 15.sp,
+              lineHeight = 24.sp,
+          ),
+      ),
+  )
+  ```
 
 ### Removed
 
@@ -801,6 +827,15 @@ All notable changes to this project will be documented in this file.
     (Material 3 color map)
   - **Advanced**: `rememberHighlightedCodeBothThemes()` — pre-highlights for both light
     and dark in one JS call for instant theme switching
+- JVM unit tests for `HighlightTheme`: `fromCss`, `fromColorMap`, lazy `colorMap`,
+  `backgroundColor`, `defaultTextColor`, `equals`/`hashCode`/`toString`, and
+  defensive-copy behavior
+- JVM unit tests for all `HighlightException` variants: message content, cause
+  preservation, and the `TIMEOUT_SECONDS` constant
+- Additional `ThemeParser` tests: `rgb()` color format, `background-color` property,
+  `font-weight: 700`, 8-digit hex colors, and descendant-selector skipping
+- Additional `HtmlToAnnotatedString` tests: non-span element wrapping, HTML entity
+  decoding, and base-style application
 
 ### Changed
 
@@ -812,18 +847,6 @@ All notable changes to this project will be documented in this file.
   - `startUpWebView()` and `WebViewStartUpConfig` APIs graduated to stable.
   - `NavigationListener` / `WebViewCompat.addNavigationListener()` graduated to stable.
   - `minSdk` for the webkit library increased to 24 (matches this library's `minSdk`).
-
-### Added
-
-- JVM unit tests for `HighlightTheme`: `fromCss`, `fromColorMap`, lazy `colorMap`,
-  `backgroundColor`, `defaultTextColor`, `equals`/`hashCode`/`toString`, and
-  defensive-copy behavior
-- JVM unit tests for all `HighlightException` variants: message content, cause
-  preservation, and the `TIMEOUT_SECONDS` constant
-- Additional `ThemeParser` tests: `rgb()` color format, `background-color` property,
-  `font-weight: 700`, 8-digit hex colors, and descendant-selector skipping
-- Additional `HtmlToAnnotatedString` tests: non-span element wrapping, HTML entity
-  decoding, and base-style application
 
 ### Fixed
 
@@ -842,9 +865,6 @@ All notable changes to this project will be documented in this file.
   pass. The old approach applied `\n` → newline before `\\` → `\`, which incorrectly
   converted `\n` (a literal backslash + 'n' in JSON) to a newline instead of `\n`. The
   new implementation also adds support for `\r` → CR and `\/` → `/` escape sequences.
-
-### Changed
-
 - **`HighlightThemeProvider`: shared engine for the whole subtree** — the provider now
   creates one `HighlightEngine` (one hidden WebView) for its entire subtree and provides
   it via an internal `LocalHighlightEngine` CompositionLocal. Previously, every


### PR DESCRIPTION
Consolidated all duplicate section headings within release versions and enabled the MD024 markdown linting rule to prevent future duplicates.

**Changes:**
- v0.6.0: Merged two Added sections
- v0.21.0: Merged two Fixed sections  
- Updated .markdownlintrc with MD024: siblings_only configuration
- Updated copilot-instructions.md with markdown formatting rules