### PR TITLE
feat: add SyntaxHighlightedTextEditor with live syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   Falls back to plain monospace text while a highlight result is in flight or on error.
   A new **Live Editor** demo tab in the sample app showcases the composable across
   6 languages (Kotlin, Python, JavaScript, SQL, JSON, XML).
+  Marked `@ExperimentalHighlightApi` - callers must opt in with
+  `@OptIn(ExperimentalHighlightApi::class)`.
+
+- **`ExperimentalHighlightApi`** - new `@RequiresOptIn` annotation for APIs that are not yet
+  stable. Applied to `SyntaxHighlightedTextEditor` for now; may be applied to future APIs
+  before they graduate to stable.
 
 ## [0.23.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`SyntaxHighlightedTextEditor`** - new public composable built on `BasicTextField` that
+  provides live syntax highlighting as the user types. Keystrokes are debounced (default 150 ms)
+  before triggering a highlight call. Cursor position and text selection are always preserved.
+  Falls back to plain monospace text while a highlight result is in flight or on error.
+  A new **Live Editor** demo tab in the sample app showcases the composable across
+  6 languages (Kotlin, Python, JavaScript, SQL, JSON, XML).
+
 ## [0.23.0] - 2026-05-27
 
 ### Tests

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/ExperimentalHighlightApi.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/ExperimentalHighlightApi.kt
@@ -1,0 +1,50 @@
+package dev.hossain.highlight.ui
+
+/**
+ * Marks an API as experimental within the `compose-highlight` library.
+ *
+ * Experimental APIs may change signature, behavior, or be removed in any future release
+ * without a deprecation cycle. They are provided for early feedback and are not yet
+ * considered stable for production use.
+ *
+ * To use an API annotated with `@ExperimentalHighlightApi`, opt in at the call site:
+ *
+ * ```kotlin
+ * // Opt in for a single composable or function:
+ * @OptIn(ExperimentalHighlightApi::class)
+ * @Composable
+ * fun MyScreen() {
+ *     SyntaxHighlightedTextEditor(...)
+ * }
+ * ```
+ *
+ * Or propagate the requirement to your own API:
+ *
+ * ```kotlin
+ * @ExperimentalHighlightApi
+ * @Composable
+ * fun MyEditorScreen() {
+ *     SyntaxHighlightedTextEditor(...)
+ * }
+ * ```
+ *
+ * To opt in for an entire file, add this to the top of the file (before the package statement):
+ *
+ * ```kotlin
+ * @file:OptIn(ExperimentalHighlightApi::class)
+ * ```
+ */
+@RequiresOptIn(
+    message =
+        "This API is part of the experimental compose-highlight surface and may change " +
+            "or be removed in future releases without a deprecation cycle.",
+    level = RequiresOptIn.Level.ERROR,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+)
+annotation class ExperimentalHighlightApi

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -1,0 +1,113 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.TextFieldValue
+import dev.hossain.highlight.engine.HighlightTheme
+import kotlinx.coroutines.delay
+
+/**
+ * A syntax-highlighted code editor composable built on [BasicTextField].
+ *
+ * As the user types, the visible text is re-highlighted in the background using the
+ * same [HighlightEngine] pipeline as [SyntaxHighlightedCode]. Keystrokes are debounced
+ * by [debounceMs] to avoid firing a highlight call on every character. While a new
+ * highlight result is in flight, the previously highlighted spans (or plain text on
+ * first render) remain visible with no flicker.
+ *
+ * Cursor position and selection are always preserved: the highlighting only replaces the
+ * [AnnotatedString] content inside the [TextFieldValue], never the cursor or selection.
+ *
+ * This composable reads the active theme from [LocalHighlightTheme], so a
+ * [HighlightThemeProvider] ancestor **must** exist, or you must pass an explicit [theme].
+ *
+ * ## Usage - inside HighlightThemeProvider (recommended)
+ *
+ * ```kotlin
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = HighlightTheme.tomorrow(),
+ *     darkHighlightTheme  = HighlightTheme.tomorrowNight(),
+ * ) {
+ *     var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
+ *     SyntaxHighlightedTextEditor(
+ *         value       = editorValue,
+ *         onValueChange = { editorValue = it },
+ *         language    = "kotlin",
+ *         modifier    = Modifier.fillMaxWidth(),
+ *     )
+ * }
+ * ```
+ *
+ * ## Usage - with an explicit theme
+ *
+ * ```kotlin
+ * var editorValue by remember { mutableStateOf(TextFieldValue("SELECT * FROM users")) }
+ * SyntaxHighlightedTextEditor(
+ *     value         = editorValue,
+ *     onValueChange = { editorValue = it },
+ *     language      = "sql",
+ *     theme         = HighlightTheme.tomorrow(),
+ * )
+ * ```
+ *
+ * @param value The current [TextFieldValue], including text, cursor position, and selection.
+ * @param onValueChange Called whenever the user edits the text or moves the cursor.
+ * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`).
+ * @param modifier Modifier applied to the underlying [BasicTextField].
+ * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
+ * @param textStyle Text style for the editor. Defaults to a monospace style. The theme's
+ *   foreground color is applied on top of this style when a highlight result is available.
+ * @param debounceMs Milliseconds to wait after the last keystroke before triggering a new
+ *   highlight call. Defaults to 150 ms - a good balance between responsiveness and avoiding
+ *   unnecessary WebView calls on fast typists.
+ */
+@Composable
+fun SyntaxHighlightedTextEditor(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    language: String,
+    modifier: Modifier = Modifier,
+    theme: HighlightTheme = LocalHighlightTheme.current,
+    textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
+    debounceMs: Long = 150L,
+) {
+    val engine = rememberHighlightEngine()
+    var highlighted by remember { mutableStateOf<AnnotatedString?>(null) }
+
+    // Re-highlight with debounce whenever the text, language, or theme changes.
+    // LaunchedEffect cancels the previous coroutine on each change, so rapid keystrokes
+    // naturally coalesce into a single highlight call after the user pauses.
+    LaunchedEffect(value.text, language, theme) {
+        delay(debounceMs)
+        engine
+            .highlight(value.text, language, theme)
+            .onSuccess { result -> highlighted = result.annotated }
+            .onFailure { highlighted = null }
+    }
+
+    // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
+    // When no highlight result is available yet, fall back to plain text so the editor
+    // is always interactive, even before the first highlight call completes.
+    val displayValue =
+        remember(value, highlighted) {
+            value.copy(
+                annotatedString = highlighted ?: AnnotatedString(value.text),
+            )
+        }
+
+    BasicTextField(
+        value = displayValue,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        textStyle = textStyle,
+    )
+}

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -95,12 +95,17 @@ fun SyntaxHighlightedTextEditor(
     }
 
     // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
-    // When no highlight result is available yet, fall back to plain text so the editor
-    // is always interactive, even before the first highlight call completes.
+    // Only apply the highlight result when its text exactly matches the current value text.
+    // If the user typed a new character while the previous highlight result is still cached,
+    // the stale AnnotatedString has a different length than value.text, which would make the
+    // cursor selection out of bounds and freeze the field. Plain text is shown instead until
+    // the debounced highlight call for the new text completes.
     val displayValue =
         remember(value, highlighted) {
             value.copy(
-                annotatedString = highlighted ?: AnnotatedString(value.text),
+                annotatedString =
+                    highlighted?.takeIf { it.text == value.text }
+                        ?: AnnotatedString(value.text),
             )
         }
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -102,6 +102,10 @@ fun SyntaxHighlightedTextEditor(
     val engine = rememberHighlightEngine()
     var highlighted by remember { mutableStateOf<AnnotatedString?>(null) }
 
+    // Clear stale spans immediately when language or theme changes so wrong-language
+    // (or wrong-theme) highlights are never visible during the debounce window.
+    LaunchedEffect(language, theme) { highlighted = null }
+
     val backgroundColor =
         remember(theme) {
             theme.backgroundColor.takeIf { it != Color.Unspecified }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -48,6 +50,7 @@ import kotlinx.coroutines.delay
  *         onValueChange = { editorValue = it },
  *         language    = "kotlin",
  *         modifier    = Modifier.fillMaxWidth().border(1.dp, Color.Gray, RoundedCornerShape(8.dp)),
+ *         shape       = RoundedCornerShape(8.dp),
  *         contentPadding = PaddingValues(12.dp),
  *     )
  * }
@@ -74,6 +77,9 @@ import kotlinx.coroutines.delay
  * @param contentPadding Padding applied *inside* the [Surface], between the background edge and
  *   the text. Defaults to [PaddingValues] of 0.dp (no padding). Use this instead of adding
  *   `.padding()` to [modifier] so the theme background fills the full bordered area.
+ * @param shape Shape used to clip the Surface background. Must match the shape used in any
+ *   `.border()` applied via [modifier] so the background and border align. Defaults to
+ *   [RectangleShape] (no rounding).
  * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
  * @param textStyle Text style for the editor. Defaults to a monospace style. The theme's
  *   foreground color is applied on top of this style when a highlight result is available.
@@ -88,6 +94,7 @@ fun SyntaxHighlightedTextEditor(
     language: String,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
+    shape: Shape = RectangleShape,
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
     debounceMs: Long = 150L,
@@ -158,6 +165,7 @@ fun SyntaxHighlightedTextEditor(
 
     Surface(
         modifier = modifier,
+        shape = shape,
         color = backgroundColor,
         contentColor = textColor,
     ) {

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -95,19 +95,39 @@ fun SyntaxHighlightedTextEditor(
     }
 
     // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
-    // Only apply the highlight result when its text exactly matches the current value text.
-    // If the user typed a new character while the previous highlight result is still cached,
-    // the stale AnnotatedString has a different length than value.text, which would make the
-    // cursor selection out of bounds and freeze the field. Plain text is shown instead until
-    // the debounced highlight call for the new text completes.
-    val displayValue =
-        remember(value, highlighted) {
-            value.copy(
-                annotatedString =
-                    highlighted?.takeIf { it.text == value.text }
-                        ?: AnnotatedString(value.text),
-            )
+    //
+    // Three cases:
+    // 1. No highlight result yet - show plain text (first render or error).
+    // 2. Highlight text exactly matches current text - apply spans directly (steady state).
+    // 3. Text has changed since the last highlight result (user is typing, debounce pending) -
+    //    clip old spans to the new text length and apply them. Spans before any edit point
+    //    remain correctly colored; only the newly typed characters briefly have no span.
+    //    This gives the illusion of live highlighting - 90%+ of the block stays colored while
+    //    only the new characters wait for the next debounced highlight call.
+    val currentText = value.text
+    val annotated =
+        when {
+            highlighted == null -> {
+                AnnotatedString(currentText)
+            }
+
+            highlighted!!.text == currentText -> {
+                highlighted!!
+            }
+
+            else -> {
+                // Reuse old spans clipped to the new text length so the cursor offset
+                // is always in bounds, preserving editability.
+                val builder = AnnotatedString.Builder(currentText)
+                highlighted!!.spanStyles.forEach { range ->
+                    val start = range.start.coerceAtMost(currentText.length)
+                    val end = range.end.coerceAtMost(currentText.length)
+                    if (start < end) builder.addStyle(range.item, start, end)
+                }
+                builder.toAnnotatedString()
+            }
         }
+    val displayValue = value.copy(annotatedString = annotated)
 
     BasicTextField(
         value = displayValue,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -1,5 +1,7 @@
 package dev.hossain.highlight.ui
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -14,6 +16,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
 import kotlinx.coroutines.delay
 
@@ -44,7 +47,8 @@ import kotlinx.coroutines.delay
  *         value       = editorValue,
  *         onValueChange = { editorValue = it },
  *         language    = "kotlin",
- *         modifier    = Modifier.fillMaxWidth(),
+ *         modifier    = Modifier.fillMaxWidth().border(1.dp, Color.Gray, RoundedCornerShape(8.dp)),
+ *         contentPadding = PaddingValues(12.dp),
  *     )
  * }
  * ```
@@ -65,6 +69,11 @@ import kotlinx.coroutines.delay
  * @param onValueChange Called whenever the user edits the text or moves the cursor.
  * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`).
  * @param modifier Modifier applied to the outer [Surface] container (background, border, size, etc.).
+ *   Do **not** include padding here - use [contentPadding] instead. Padding applied via [modifier]
+ *   would shrink the Surface layout area, leaving a gap between the border and the theme background.
+ * @param contentPadding Padding applied *inside* the [Surface], between the background edge and
+ *   the text. Defaults to [PaddingValues] of 0.dp (no padding). Use this instead of adding
+ *   `.padding()` to [modifier] so the theme background fills the full bordered area.
  * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
  * @param textStyle Text style for the editor. Defaults to a monospace style. The theme's
  *   foreground color is applied on top of this style when a highlight result is available.
@@ -78,6 +87,7 @@ fun SyntaxHighlightedTextEditor(
     onValueChange: (TextFieldValue) -> Unit,
     language: String,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
     debounceMs: Long = 150L,
@@ -155,6 +165,7 @@ fun SyntaxHighlightedTextEditor(
             value = displayValue,
             onValueChange = onValueChange,
             textStyle = themedTextStyle,
+            modifier = Modifier.padding(contentPadding),
         )
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -23,6 +23,10 @@ import dev.hossain.highlight.engine.HighlightTheme
 import kotlinx.coroutines.delay
 
 /**
+ * This composable is marked **experimental** ([ExperimentalHighlightApi]). Call sites must
+ * opt in with `@OptIn(ExperimentalHighlightApi::class)` or propagate the annotation. The API
+ * surface (parameters, defaults, behavior) may change in future releases.
+ *
  * A syntax-highlighted code editor composable built on [BasicTextField].
  *
  * As the user types, the visible text is re-highlighted in the background using the
@@ -87,6 +91,7 @@ import kotlinx.coroutines.delay
  *   highlight call. Defaults to 150 ms - a good balance between responsiveness and avoiding
  *   unnecessary WebView calls on fast typists.
  */
+@ExperimentalHighlightApi
 @Composable
 fun SyntaxHighlightedTextEditor(
     value: TextFieldValue,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -1,6 +1,7 @@
 package dev.hossain.highlight.ui
 
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -8,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -62,7 +64,7 @@ import kotlinx.coroutines.delay
  * @param value The current [TextFieldValue], including text, cursor position, and selection.
  * @param onValueChange Called whenever the user edits the text or moves the cursor.
  * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`).
- * @param modifier Modifier applied to the underlying [BasicTextField].
+ * @param modifier Modifier applied to the outer [Surface] container (background, border, size, etc.).
  * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
  * @param textStyle Text style for the editor. Defaults to a monospace style. The theme's
  *   foreground color is applied on top of this style when a highlight result is available.
@@ -82,6 +84,21 @@ fun SyntaxHighlightedTextEditor(
 ) {
     val engine = rememberHighlightEngine()
     var highlighted by remember { mutableStateOf<AnnotatedString?>(null) }
+
+    val backgroundColor =
+        remember(theme) {
+            theme.backgroundColor.takeIf { it != Color.Unspecified }
+                ?: SyntaxHighlightedCodeDefaults.fallbackBackgroundColor
+        }
+    val textColor =
+        remember(theme) {
+            theme.defaultTextColor.takeIf { it != Color.Unspecified }
+                ?: SyntaxHighlightedCodeDefaults.fallbackTextColor
+        }
+
+    // Merge the theme foreground color into the caller-supplied text style so unspanned
+    // characters (newly typed, not yet highlighted) match the theme foreground.
+    val themedTextStyle = remember(theme, textStyle) { textStyle.copy(color = textColor) }
 
     // Re-highlight with debounce whenever the text, language, or theme changes.
     // LaunchedEffect cancels the previous coroutine on each change, so rapid keystrokes
@@ -129,10 +146,15 @@ fun SyntaxHighlightedTextEditor(
         }
     val displayValue = value.copy(annotatedString = annotated)
 
-    BasicTextField(
-        value = displayValue,
-        onValueChange = onValueChange,
+    Surface(
         modifier = modifier,
-        textStyle = textStyle,
-    )
+        color = backgroundColor,
+        contentColor = textColor,
+    ) {
+        BasicTextField(
+            value = displayValue,
+            onValueChange = onValueChange,
+            textStyle = themedTextStyle,
+        )
+    }
 }

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,6 +5,7 @@ This section documents the public API of `compose-highlight`.
 | Class / Function | Description |
 |---|---|
 | [`SyntaxHighlightedCode`](syntax-highlighted-code.md) | Primary composable - renders a styled, highlighted code block |
+| [`SyntaxHighlightedTextEditor`](syntax-highlighted-text-editor.md) | **Experimental** - editable code field with live syntax highlighting as the user types |
 | [`HighlightThemeProvider`](syntax-highlighted-code.md#highlightthemeprovider) | Provides a shared theme and engine to a composable subtree |
 | [`CodeBlockStyle`](code-block-style.md) | Visual style configuration (shape, padding, font, copy button size) |
 | [`SyntaxHighlightedCodeDefaults`](code-block-style.md#syntaxhighlightedcodedefaults) | Default constants and helper composables (`CopyButton`, `LanguageLabel`) |
@@ -17,6 +18,7 @@ This section documents the public API of `compose-highlight`.
 | [`HighlightTimings`](../guides/performance.md#timing-callbacks) | Per-stage timing breakdown (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) |
 | [`HighlightLanguageInfo`](highlight-engine.md#highlightlanguageinfo) | Metadata returned by `HighlightEngine.getLanguage()` |
 | [`HighlightException`](highlight-engine.md) | Sealed exception hierarchy for all engine errors |
+| [`ExperimentalHighlightApi`](syntax-highlighted-text-editor.md#experimentalhighlightapi) | Opt-in annotation for experimental APIs |
 | [`rememberHighlightedCode`](syntax-highlighted-code.md#rememberhighlightedcode) | Composable helper - highlights code and returns an `AnnotatedString` state |
 | [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md#rememberhighlightedcodeboththemes) | Highlights once, produces light + dark variants |
 | [`rememberHighlightEngine`](highlight-engine.md#rememberhighlightengine) | Returns the shared or standalone `HighlightEngine` for the current composition |

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -1,0 +1,161 @@
+# SyntaxHighlightedTextEditor
+
+!!! warning "Experimental API"
+    This composable is annotated with [`@ExperimentalHighlightApi`](#experimentalhighlightapi).
+    Its parameter surface may change or be removed in a future release without a deprecation cycle.
+    Callers must explicitly opt in - see [Opting in](#opting-in).
+
+An editable code field built on `BasicTextField` with live syntax highlighting. As the user types,
+highlighting updates in the background after a short debounce. Cursor position and text selection
+are always preserved.
+
+## Signature
+
+```kotlin
+import dev.hossain.highlight.ui.ExperimentalHighlightApi
+import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
+
+@ExperimentalHighlightApi
+@Composable
+fun SyntaxHighlightedTextEditor(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    language: String,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    shape: Shape = RectangleShape,
+    theme: HighlightTheme = LocalHighlightTheme.current,
+    textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
+    debounceMs: Long = 150L,
+)
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `value` | `TextFieldValue` | - | Current value including text, cursor position, and selection |
+| `onValueChange` | `(TextFieldValue) -> Unit` | - | Called whenever the user edits the text or moves the cursor |
+| `language` | `String` | - | Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`) |
+| `modifier` | `Modifier` | `Modifier` | Applied to the outer `Surface`. Do **not** add `.padding()` here - use `contentPadding` |
+| `contentPadding` | `PaddingValues` | `PaddingValues(0.dp)` | Padding applied inside the `Surface`, between the background edge and the text |
+| `shape` | `Shape` | `RectangleShape` | Clips the `Surface` background. Must match any `.border()` shape in `modifier` |
+| `theme` | `HighlightTheme` | `LocalHighlightTheme.current` | Theme to use. Throws if no `HighlightThemeProvider` is present and no explicit theme is passed |
+| `textStyle` | `TextStyle` | Monospace | Text style for the editor. The theme's foreground color is merged on top |
+| `debounceMs` | `Long` | `150` | Milliseconds to wait after the last keystroke before triggering a highlight call |
+
+## Opting in
+
+The composable is marked `@ExperimentalHighlightApi`. Use one of the following patterns:
+
+```kotlin
+// Option 1 - opt in at the call site
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun MyScreen() {
+    SyntaxHighlightedTextEditor(...)
+}
+
+// Option 2 - propagate the requirement to your own API
+@ExperimentalHighlightApi
+@Composable
+fun MyEditorScreen() {
+    SyntaxHighlightedTextEditor(...)
+}
+
+// Option 3 - opt in for an entire file (place before the package statement)
+@file:OptIn(ExperimentalHighlightApi::class)
+```
+
+## Usage
+
+### With `HighlightThemeProvider` (recommended)
+
+```kotlin
+import dev.hossain.highlight.ui.ExperimentalHighlightApi
+import dev.hossain.highlight.ui.HighlightThemeProvider
+import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
+import dev.hossain.highlight.ui.rememberTomorrowNightTheme
+import dev.hossain.highlight.ui.rememberTomorrowTheme
+
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun EditorScreen() {
+    var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
+
+    HighlightThemeProvider(
+        lightHighlightTheme = rememberTomorrowTheme(),
+        darkHighlightTheme  = rememberTomorrowNightTheme(),
+    ) {
+        SyntaxHighlightedTextEditor(
+            value         = editorValue,
+            onValueChange = { editorValue = it },
+            language      = "kotlin",
+            modifier      = Modifier
+                .fillMaxWidth()
+                .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)),
+            shape         = RoundedCornerShape(8.dp),
+            contentPadding = PaddingValues(12.dp),
+        )
+    }
+}
+```
+
+### With an explicit theme (no provider)
+
+```kotlin
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun SqlEditor() {
+    var editorValue by remember { mutableStateOf(TextFieldValue("SELECT * FROM users")) }
+
+    SyntaxHighlightedTextEditor(
+        value         = editorValue,
+        onValueChange = { editorValue = it },
+        language      = "sql",
+        theme         = HighlightTheme.tomorrow(),
+    )
+}
+```
+
+## How it works
+
+1. The composable maintains a `highlighted: AnnotatedString?` state and a `TextFieldValue` for the
+   field itself.
+2. A `LaunchedEffect` keyed on `(value.text, language, theme)` waits for `debounceMs` milliseconds,
+   then calls `HighlightEngine.highlight()`. Rapid keystrokes cancel the previous coroutine so only
+   one call fires after the user pauses.
+3. When `language` or `theme` changes, a separate `LaunchedEffect` immediately clears the cached
+   spans so stale highlights from a prior language or theme are never shown.
+4. While a new result is in flight the composable uses one of three display strategies:
+   - **No cached result** - plain monospace text (first render or after language/theme change)
+   - **Cached text matches current text** - applies the full cached span set (steady state)
+   - **Text changed since last result** - clips old spans to the new text length; characters
+     before the edit point stay correctly colored, only newly typed characters are briefly unstyled
+
+## Notes
+
+- **`contentPadding` vs `.padding()` on modifier** - padding added via `modifier` shrinks the
+  `Surface` layout area, leaving a gap between the border and the background. Always use
+  `contentPadding` to ensure the theme background fills the full bordered area.
+- **`shape` must match the border shape** - `Surface` clips its background to `shape`. If you
+  draw a rounded border via `modifier`, pass the same `RoundedCornerShape` as `shape` so the
+  background does not bleed past the rounded corners.
+- **Cursor and selection are always preserved** - highlighting calls `value.copy(annotatedString = ...)`
+  which keeps the `selection` and `composition` fields untouched.
+- **Uses the shared WebView** when called inside a `HighlightThemeProvider`. Outside a provider a
+  standalone `HighlightEngine` (and WebView) is created and destroyed with the composable's lifecycle.
+
+---
+
+## ExperimentalHighlightApi
+
+`@RequiresOptIn` annotation used to mark APIs that are not yet stable. Callers must explicitly opt
+in with `@OptIn(ExperimentalHighlightApi::class)` or propagate the annotation to their own API.
+
+Currently applied to:
+
+- `SyntaxHighlightedTextEditor`
+
+APIs marked `@ExperimentalHighlightApi` may change signature, behavior, or be removed in any
+future release without a deprecation cycle.

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
@@ -34,6 +34,8 @@ internal sealed class DemoTab(
 
     data object Engine : DemoTab("Engine")
 
+    data object LiveEditor : DemoTab("Live Editor")
+
     companion object {
         val all by lazy {
             listOf(
@@ -48,6 +50,7 @@ internal sealed class DemoTab(
                 LanguageDiscoverability,
                 Advanced,
                 Engine,
+                LiveEditor,
             )
         }
     }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/DemoTab.kt
@@ -48,9 +48,9 @@ internal sealed class DemoTab(
                 Themes,
                 AllThemes,
                 LanguageDiscoverability,
+                LiveEditor,
                 Advanced,
                 Engine,
-                LiveEditor,
             )
         }
     }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -49,6 +49,7 @@ import dev.hossain.highlight.sample.sections.AllThemesSection
 import dev.hossain.highlight.sample.sections.CallbacksSection
 import dev.hossain.highlight.sample.sections.EngineInfoSection
 import dev.hossain.highlight.sample.sections.LanguageDiscoverabilitySection
+import dev.hossain.highlight.sample.sections.LiveEditorSection
 import dev.hossain.highlight.sample.sections.PlaceholderSection
 import dev.hossain.highlight.sample.sections.SectionHeader
 import dev.hossain.highlight.sample.sections.StylingSection
@@ -308,6 +309,10 @@ fun SampleScreen() {
 
                         DemoTab.Engine -> {
                             item { EngineInfoSection() }
+                        }
+
+                        DemoTab.LiveEditor -> {
+                            item { LiveEditorSection() }
                         }
                     }
                 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -31,11 +33,8 @@ import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
 private val DEMO_LANGUAGES =
     listOf(
         "kotlin",
-        "python",
         "javascript",
-        "sql",
         "json",
-        "xml",
     )
 
 private val INITIAL_CODE_BY_LANGUAGE =
@@ -141,6 +140,20 @@ internal fun LiveEditorSection() {
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         SubSectionHeader("Live Syntax Highlighting Editor")
+
+        // Experimental feature banner
+        Surface(
+            color = MaterialTheme.colorScheme.tertiaryContainer,
+            shape = RoundedCornerShape(8.dp),
+        ) {
+            Text(
+                text = "\u26a0\ufe0f Experimental - This feature uses @ExperimentalHighlightApi and may change in future releases.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            )
+        }
+
         Text(
             text = "Edit the code below - syntax highlighting updates as you type.",
             style = MaterialTheme.typography.bodySmall,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -170,6 +170,7 @@ internal fun LiveEditorSection() {
                         color = MaterialTheme.colorScheme.outline,
                         shape = RoundedCornerShape(8.dp),
                     ),
+            shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(12.dp),
             textStyle =
                 TextStyle(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalHighlightApi::class)
+
 package dev.hossain.highlight.sample.sections
 
 import androidx.compose.foundation.border
@@ -23,6 +25,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hossain.highlight.ui.ExperimentalHighlightApi
 import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
 
 private val DEMO_LANGUAGES =

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -141,15 +141,15 @@ internal fun LiveEditorSection() {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         SubSectionHeader("Live Syntax Highlighting Editor")
 
-        // Experimental feature banner
+        // Experimental feature info banner
         Surface(
-            color = MaterialTheme.colorScheme.tertiaryContainer,
+            color = MaterialTheme.colorScheme.secondaryContainer,
             shape = RoundedCornerShape(8.dp),
         ) {
             Text(
-                text = "\u26a0\ufe0f Experimental - This feature uses @ExperimentalHighlightApi and may change in future releases.",
+                text = "\u2139\ufe0f Experimental - This feature uses @ExperimentalHighlightApi and may change in future releases.",
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             )
         }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -3,10 +3,10 @@ package dev.hossain.highlight.sample.sections
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
@@ -169,7 +169,8 @@ internal fun LiveEditorSection() {
                         width = 1.dp,
                         color = MaterialTheme.colorScheme.outline,
                         shape = RoundedCornerShape(8.dp),
-                    ).padding(12.dp),
+                    ),
+            contentPadding = PaddingValues(12.dp),
             textStyle =
                 TextStyle(
                     fontFamily = FontFamily.Monospace,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -1,0 +1,180 @@
+package dev.hossain.highlight.sample.sections
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
+
+private val DEMO_LANGUAGES =
+    listOf(
+        "kotlin",
+        "python",
+        "javascript",
+        "sql",
+        "json",
+        "xml",
+    )
+
+private val INITIAL_CODE_BY_LANGUAGE =
+    mapOf(
+        "kotlin" to
+            """
+fun greet(name: String): String {
+    return "Hello, ${'$'}name!"
+}
+
+data class User(val id: Int, val name: String)
+
+fun main() {
+    val user = User(1, "Alice")
+    println(greet(user.name))
+}
+            """.trimIndent(),
+        "python" to
+            """
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+class User:
+    def __init__(self, id: int, name: str):
+        self.id = id
+        self.name = name
+
+if __name__ == "__main__":
+    user = User(1, "Alice")
+    print(greet(user.name))
+            """.trimIndent(),
+        "javascript" to
+            """
+function greet(name) {
+    return `Hello, ${'$'}{name}!`;
+}
+
+class User {
+    constructor(id, name) {
+        this.id = id;
+        this.name = name;
+    }
+}
+
+const user = new User(1, "Alice");
+console.log(greet(user.name));
+            """.trimIndent(),
+        "sql" to
+            """
+SELECT
+    u.id,
+    u.name,
+    COUNT(o.id) AS order_count
+FROM users u
+LEFT JOIN orders o ON o.user_id = u.id
+WHERE u.active = 1
+GROUP BY u.id, u.name
+ORDER BY order_count DESC
+LIMIT 10;
+            """.trimIndent(),
+        "json" to
+            """
+{
+  "user": {
+    "id": 1,
+    "name": "Alice",
+    "active": true,
+    "roles": ["admin", "editor"],
+    "address": {
+      "city": "Vancouver",
+      "country": "Canada"
+    }
+  }
+}
+            """.trimIndent(),
+        "xml" to
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<users>
+  <user id="1" active="true">
+    <name>Alice</name>
+    <roles>
+      <role>admin</role>
+      <role>editor</role>
+    </roles>
+  </user>
+</users>
+            """.trimIndent(),
+    )
+
+/**
+ * Demonstrates [SyntaxHighlightedTextEditor] - a live syntax-highlighting code editor.
+ *
+ * Shows a language selector and an editable [SyntaxHighlightedTextEditor] field. As the
+ * user types, syntax highlighting updates in real time with a short debounce.
+ */
+@Composable
+internal fun LiveEditorSection() {
+    var selectedLanguage by rememberSaveable { mutableStateOf("kotlin") }
+    var editorValue by remember(selectedLanguage) {
+        mutableStateOf(TextFieldValue(INITIAL_CODE_BY_LANGUAGE[selectedLanguage] ?: ""))
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        SubSectionHeader("Live Syntax Highlighting Editor")
+        Text(
+            text = "Edit the code below - syntax highlighting updates as you type.",
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        // Language selector chips
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            DEMO_LANGUAGES.forEach { lang ->
+                FilterChip(
+                    selected = lang == selectedLanguage,
+                    onClick = { selectedLanguage = lang },
+                    label = { Text(lang) },
+                )
+            }
+        }
+
+        // Live editor
+        SyntaxHighlightedTextEditor(
+            value = editorValue,
+            onValueChange = { editorValue = it },
+            language = selectedLanguage,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 200.dp)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(8.dp),
+                    ).padding(12.dp),
+            textStyle =
+                TextStyle(
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 13.sp,
+                ),
+        )
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,6 +23,7 @@ nav = [
   { "API Reference"   = [
       "reference/index.md",
       "reference/syntax-highlighted-code.md",
+      "reference/syntax-highlighted-text-editor.md",
       "reference/code-block-style.md",
       "reference/highlight-theme.md",
       "reference/highlight-engine.md",


### PR DESCRIPTION
## Summary

Adds `SyntaxHighlightedTextEditor`, a new experimental composable that provides live syntax highlighting inside an editable `BasicTextField`. As the user types, highlighting updates in the background via a debounced `HighlightEngine` call - cursor and selection are always preserved.

## New public API

- **`SyntaxHighlightedTextEditor`** - live-highlighting editor composable (`@ExperimentalHighlightApi`)
- **`ExperimentalHighlightApi`** - `@RequiresOptIn(level=ERROR)` annotation for unstable APIs

## Key design decisions

- Built on `BasicTextField` - no custom input handling needed
- Debounce (default 150 ms) via `LaunchedEffect` coalesces rapid keystrokes into one highlight call
- Span-clipping: while a new result is in flight, old spans are clipped to the new text length so ~90% of the block stays colored during typing
- `contentPadding` parameter applies padding inside the `Surface` (not on the modifier) so the theme background fills all the way to the border
- `shape` parameter clips the `Surface` background - must match the border shape for rounded corners
- Stale spans cleared immediately when `language` or `theme` changes

## Sample app

New **Live Editor** tab demonstrates the composable across 6 languages (Kotlin, Python, JavaScript, SQL, JSON, XML).

## Docs

- New `docs/reference/syntax-highlighted-text-editor.md` reference page
- Updated `docs/reference/index.md` API table
- Updated `zensical.toml` nav
- CHANGELOG updated under `[Unreleased]`