### PR TITLE
chore: prepare release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-27
+
 ### Added
 
 - **`SyntaxHighlightedTextEditor`** - new public composable built on `BasicTextField` that

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.23.0")
+    implementation("dev.hossain:compose-highlight:0.24.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.23.0
+VERSION_NAME=0.24.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 27
-        versionName = "0.23.0"
+        versionCode = 28
+        versionName = "0.24.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Release 0.24.0

### Added
- `SyntaxHighlightedTextEditor` - experimental live syntax-highlighting code editor built on `BasicTextField`
- `ExperimentalHighlightApi` - `@RequiresOptIn` annotation for unstable APIs

**Dependency:** `dev.hossain:compose-highlight:0.24.0`