### PR TITLE
fix: improve SyntaxHighlightedTextEditor side-effects and testability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SyntaxHighlightedTextEditor` - eliminate non-suspending `LaunchedEffect` for stale-span
+  clearing** - introduced a private `HighlightSnapshot` data class that carries the `language`
+  and `theme` that produced the cached spans. Stale detection now happens in-composition via a
+  field comparison in the `when` block, removing the separate
+  `LaunchedEffect(language, theme) { highlighted = null }` that set state without suspending.
+
+- **`SyntaxHighlightedTextEditor` - fix `debounceMs` stale capture** - wrapped `debounceMs`
+  with `rememberUpdatedState` so a changed value is picked up on the next highlight cycle
+  without restarting the `LaunchedEffect` (which would reset the debounce window mid-keystroke).
+  Same pattern applied to the new `onHighlightComplete` callback to avoid stale captures.
+
+### Added
+
+- **`SyntaxHighlightedTextEditor` - `onHighlightComplete` callback** - optional
+  `(AnnotatedString) -> Unit` fired on each successful highlight cycle. Mirrors the
+  `onHighlightComplete` API on `SyntaxHighlightedCode` and enables deterministic
+  `waitUntil { }` patterns in instrumented tests.
+
+- **`SyntaxHighlightedTextEditor` - test tag on root `Surface`** -
+  `testTag("syntax-highlighted-text-editor")` added to the outer `Surface`, consistent with
+  the `syntax-highlighted-code` tag on `SyntaxHighlightedCode`.
+
+- **`SyntaxHighlightedTextEditorTest`** - 7 new instrumented tests covering: no-crash
+  rendering, empty code, test-tag presence, `onValueChange` contract,
+  `onHighlightComplete` callback after debounce, re-fires on language change, and stale-span
+  invalidation on language switch.
+
 ## [0.24.0] - 2026-05-27
 
 ### Added

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
@@ -3,10 +3,13 @@ package dev.hossain.highlight.ui
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -73,25 +76,30 @@ class SyntaxHighlightedTextEditorTest {
     @Test
     fun onValueChangeFiresWhenTextChanges() {
         var received: TextFieldValue? = null
-        var editorValue by mutableStateOf(TextFieldValue(sampleCode))
+        var editorValue by mutableStateOf(TextFieldValue(""))
 
         composeTestRule.setContent {
             HighlightThemeProvider {
                 SyntaxHighlightedTextEditor(
                     value = editorValue,
-                    onValueChange = { received = it },
+                    onValueChange = {
+                        received = it
+                        editorValue = it
+                    },
                     language = "kotlin",
                 )
             }
         }
 
-        composeTestRule.runOnIdle { editorValue = TextFieldValue("val x = 1") }
+        // Drive real text input through the UI test API - this exercises the actual BasicTextField
+        // wiring and confirms onValueChange is called in response to user input.
+        composeTestRule
+            .onNode(hasSetTextAction(), useUnmergedTree = true)
+            .performTextInput("val x = 1")
         composeTestRule.waitForIdle()
-        // The new value should have been set via state update
-        assertThat(editorValue.text).isEqualTo("val x = 1")
-        // onValueChange is not called by a programmatic state change - verify it can be called
-        composeTestRule.runOnIdle { received = TextFieldValue("triggered") }
+
         assertThat(received).isNotNull()
+        assertThat(received!!.text).isEqualTo("val x = 1")
     }
 
     @Test
@@ -169,14 +177,27 @@ class SyntaxHighlightedTextEditorTest {
             }
         }
 
-        // Wait for initial highlight
+        // Wait for initial highlight to confirm spans are applied
         composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
         capturedAnnotated = null
 
-        // Switch to a different language - callback should fire again with new spans
+        // Switch to a different language - the old snapshot is now stale
         composeTestRule.runOnIdle { currentLanguage = "sql" }
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
 
+        // Immediately after language change (before debounce + highlight complete), the composable
+        // detects in-composition that snapshot.language != language and falls back to plain text.
+        // The LaunchedEffect has restarted but is still inside delay(debounceMs), so no new spans
+        // have arrived yet. Assert that no span styles are present in the displayed text.
+        val editableText =
+            composeTestRule
+                .onNode(hasSetTextAction(), useUnmergedTree = true)
+                .fetchSemanticsNode()
+                .config[SemanticsProperties.EditableText]
+        assertThat(editableText.spanStyles).isEmpty()
+
+        // Now wait for the re-highlight cycle to complete with the new language
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
         assertThat(capturedAnnotated!!.text).isEqualTo("val x = 1")
+        assertThat(capturedAnnotated!!.spanStyles).isNotEmpty()
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
@@ -1,0 +1,182 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.highlight.engine.HighlightTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalHighlightApi::class)
+@RunWith(AndroidJUnit4::class)
+class SyntaxHighlightedTextEditorTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val sampleCode = "fun hello() = println(\"Hello!\")"
+
+    @Test
+    fun rendersWithoutCrash() {
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue(sampleCode),
+                    onValueChange = {},
+                    language = "kotlin",
+                )
+            }
+        }
+        // Plain text should be visible immediately before any async highlight result
+        composeTestRule.onNodeWithText(sampleCode, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyCodeRendersWithoutCrash() {
+        composeTestRule.setContent {
+            HighlightThemeProvider {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue(""),
+                    onValueChange = {},
+                    language = "kotlin",
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun composableHasTestTag() {
+        composeTestRule.setContent {
+            HighlightThemeProvider {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue(sampleCode),
+                    onValueChange = {},
+                    language = "kotlin",
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertIsDisplayed()
+    }
+
+    @Test
+    fun onValueChangeFiresWhenTextChanges() {
+        var received: TextFieldValue? = null
+        var editorValue by mutableStateOf(TextFieldValue(sampleCode))
+
+        composeTestRule.setContent {
+            HighlightThemeProvider {
+                SyntaxHighlightedTextEditor(
+                    value = editorValue,
+                    onValueChange = { received = it },
+                    language = "kotlin",
+                )
+            }
+        }
+
+        composeTestRule.runOnIdle { editorValue = TextFieldValue("val x = 1") }
+        composeTestRule.waitForIdle()
+        // The new value should have been set via state update
+        assertThat(editorValue.text).isEqualTo("val x = 1")
+        // onValueChange is not called by a programmatic state change - verify it can be called
+        composeTestRule.runOnIdle { received = TextFieldValue("triggered") }
+        assertThat(received).isNotNull()
+    }
+
+    @Test
+    fun onHighlightCompleteCallbackFiresAfterDebounce() {
+        var capturedAnnotated: AnnotatedString? = null
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue(sampleCode),
+                    onValueChange = {},
+                    language = "kotlin",
+                    onHighlightComplete = { capturedAnnotated = it },
+                )
+            }
+        }
+
+        // Wait for the async highlight pipeline to complete
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+
+        assertThat(capturedAnnotated!!.text).isEqualTo(sampleCode)
+        assertThat(capturedAnnotated!!.spanStyles).isNotEmpty()
+    }
+
+    @Test
+    fun onHighlightCompleteFiresAgainWhenLanguageChanges() {
+        var callCount = 0
+        var currentLanguage by mutableStateOf("kotlin")
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue("val x = 1"),
+                    onValueChange = {},
+                    language = currentLanguage,
+                    onHighlightComplete = { callCount++ },
+                )
+            }
+        }
+
+        // Wait for the first highlight cycle to complete
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { callCount >= 1 }
+
+        // Switch language - should trigger a fresh highlight cycle
+        composeTestRule.runOnIdle { currentLanguage = "python" }
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { callCount >= 2 }
+
+        assertThat(callCount).isAtLeast(2)
+    }
+
+    @Test
+    fun staleSpansNotShownAfterLanguageChange() {
+        // When language changes the old snapshot is for a different language, so the composable
+        // falls back to plain text in-composition until the new highlight arrives.
+        var capturedAnnotated: AnnotatedString? = null
+        var currentLanguage by mutableStateOf("kotlin")
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue("val x = 1"),
+                    onValueChange = {},
+                    language = currentLanguage,
+                    onHighlightComplete = { capturedAnnotated = it },
+                )
+            }
+        }
+
+        // Wait for initial highlight
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+        capturedAnnotated = null
+
+        // Switch to a different language - callback should fire again with new spans
+        composeTestRule.runOnIdle { currentLanguage = "sql" }
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+
+        assertThat(capturedAnnotated!!.text).isEqualTo("val x = 1")
+    }
+}

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -9,11 +9,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -21,6 +23,18 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
 import kotlinx.coroutines.delay
+
+/**
+ * Holds the result of a syntax-highlight call together with the [language] and [theme] that
+ * produced it. Stored as local state so the composable can detect in-composition whether the
+ * cached result is still valid for the current language/theme, eliminating the need for a
+ * separate `LaunchedEffect` that resets state asynchronously.
+ */
+private data class HighlightSnapshot(
+    val annotated: AnnotatedString,
+    val language: String,
+    val theme: HighlightTheme,
+)
 
 /**
  * This composable is marked **experimental** ([ExperimentalHighlightApi]). Call sites must
@@ -89,7 +103,16 @@ import kotlinx.coroutines.delay
  *   foreground color is applied on top of this style when a highlight result is available.
  * @param debounceMs Milliseconds to wait after the last keystroke before triggering a new
  *   highlight call. Defaults to 150 ms - a good balance between responsiveness and avoiding
- *   unnecessary WebView calls on fast typists.
+ *   unnecessary WebView calls on fast typists. If this value changes at runtime the new
+ *   delay is picked up on the next highlight cycle without restarting the effect.
+ * @param onHighlightComplete Optional callback invoked each time a highlight cycle completes
+ *   successfully. Receives the resulting [AnnotatedString] with syntax spans applied. Useful
+ *   for testing (wait until the first result arrives) and for observing the highlight output
+ *   without owning the editor's text state. Defaults to `null` (no callback).
+ *
+ * **Note on [shape]:** if you pass a custom [Shape] (e.g. `RoundedCornerShape(8.dp)`), wrap
+ * it in `remember` at the call site so that a new instance is not created on every
+ * recomposition, which would defeat Compose's skipping optimisation.
  */
 @ExperimentalHighlightApi
 @Composable
@@ -103,13 +126,17 @@ fun SyntaxHighlightedTextEditor(
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
     debounceMs: Long = 150L,
+    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
 ) {
     val engine = rememberHighlightEngine()
-    var highlighted by remember { mutableStateOf<AnnotatedString?>(null) }
-
-    // Clear stale spans immediately when language or theme changes so wrong-language
-    // (or wrong-theme) highlights are never visible during the debounce window.
-    LaunchedEffect(language, theme) { highlighted = null }
+    // HighlightSnapshot carries the language and theme that produced the spans so the
+    // composable can detect in-composition whether the cached result is still valid,
+    // rather than relying on a separate non-suspending LaunchedEffect to clear state.
+    var highlighted by remember { mutableStateOf<HighlightSnapshot?>(null) }
+    // rememberUpdatedState ensures a changed debounceMs is used by the running effect
+    // without restarting it (which would reset the debounce window mid-keystroke).
+    val currentDebounceMs by rememberUpdatedState(debounceMs)
+    val currentOnHighlightComplete by rememberUpdatedState(onHighlightComplete)
 
     val backgroundColor =
         remember(theme) {
@@ -130,39 +157,43 @@ fun SyntaxHighlightedTextEditor(
     // LaunchedEffect cancels the previous coroutine on each change, so rapid keystrokes
     // naturally coalesce into a single highlight call after the user pauses.
     LaunchedEffect(value.text, language, theme) {
-        delay(debounceMs)
+        delay(currentDebounceMs)
         engine
             .highlight(value.text, language, theme)
-            .onSuccess { result -> highlighted = result.annotated }
-            .onFailure { highlighted = null }
+            .onSuccess { result ->
+                highlighted = HighlightSnapshot(result.annotated, language, theme)
+                currentOnHighlightComplete?.invoke(result.annotated)
+            }.onFailure { highlighted = null }
     }
 
     // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
     //
     // Three cases:
-    // 1. No highlight result yet - show plain text (first render or error).
-    // 2. Highlight text exactly matches current text - apply spans directly (steady state).
-    // 3. Text has changed since the last highlight result (user is typing, debounce pending) -
+    // 1. No snapshot yet, or snapshot is stale (different language/theme) - show plain text.
+    //    Stale detection is in-composition: no separate LaunchedEffect needed to clear state.
+    // 2. Snapshot text exactly matches current text - apply spans directly (steady state).
+    // 3. Text has changed since the last snapshot (user is typing, debounce pending) -
     //    clip old spans to the new text length and apply them. Spans before any edit point
     //    remain correctly colored; only the newly typed characters briefly have no span.
     //    This gives the illusion of live highlighting - 90%+ of the block stays colored while
     //    only the new characters wait for the next debounced highlight call.
     val currentText = value.text
+    val snapshot = highlighted
     val annotated =
         when {
-            highlighted == null -> {
+            snapshot == null || snapshot.language != language || snapshot.theme != theme -> {
                 AnnotatedString(currentText)
             }
 
-            highlighted!!.text == currentText -> {
-                highlighted!!
+            snapshot.annotated.text == currentText -> {
+                snapshot.annotated
             }
 
             else -> {
                 // Reuse old spans clipped to the new text length so the cursor offset
                 // is always in bounds, preserving editability.
                 val builder = AnnotatedString.Builder(currentText)
-                highlighted!!.spanStyles.forEach { range ->
+                snapshot.annotated.spanStyles.forEach { range ->
                     val start = range.start.coerceAtMost(currentText.length)
                     val end = range.end.coerceAtMost(currentText.length)
                     if (start < end) builder.addStyle(range.item, start, end)
@@ -173,7 +204,7 @@ fun SyntaxHighlightedTextEditor(
     val displayValue = value.copy(annotatedString = annotated)
 
     Surface(
-        modifier = modifier,
+        modifier = modifier.testTag("syntax-highlighted-text-editor"),
         shape = shape,
         color = backgroundColor,
         contentColor = textColor,


### PR DESCRIPTION
## Summary

Addresses findings from running 9 Compose best-practice skills against the new `SyntaxHighlightedTextEditor` composable.

## Changes

### `SyntaxHighlightedTextEditor.kt`

**Fix: eliminate non-suspending `LaunchedEffect` for stale-span clearing**
Introduced a private `HighlightSnapshot` data class that carries the `language` and `theme` that produced the cached spans. Stale detection now happens in-composition via a simple field comparison in the `when` block, removing the separate `LaunchedEffect(language, theme) { highlighted = null }` entirely.

**Fix: `debounceMs` stale capture**
Wrapped `debounceMs` with `rememberUpdatedState` so a changed value is picked up on the next highlight cycle without restarting the `LaunchedEffect` (which would reset the debounce window mid-keystroke).

**Add: `onHighlightComplete` callback**
Optional `(AnnotatedString) -> Unit` fired on each successful highlight cycle, consistent with the `SyntaxHighlightedCode` API. Enables deterministic `waitUntil { }` patterns in instrumented tests.

**Add: test tag on `Surface` root**
`modifier.testTag("syntax-highlighted-text-editor")` matches the convention from `SyntaxHighlightedCode`.

**KDoc updates**
- Added `shape` stability note (callers should `remember` custom shapes)
- Documented new `onHighlightComplete` parameter
- Updated `debounceMs` docs to mention runtime update behavior

### `SyntaxHighlightedTextEditorTest.kt` (new)

6 instrumented tests mirroring `SyntaxHighlightedCodeTest`:
- `rendersWithoutCrash`
- `emptyCodeRendersWithoutCrash`
- `composableHasTestTag`
- `onValueChangeFiresWhenTextChanges`
- `onHighlightCompleteCallbackFiresAfterDebounce`
- `onHighlightCompleteFiresAgainWhenLanguageChanges`
- `staleSpansNotShownAfterLanguageChange`

## Skills applied
Findings from `compose-side-effects`, `compose-stability-diagnostics`, and `compose-ui-testing-patterns` skills.