### PR TITLE
feat: extract rememberSyntaxHighlightedEditorValue() helper from SyntaxHighlightedTextEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ All notable changes to this project will be documented in this file.
   `onHighlightComplete` callback after debounce, re-fires on language change, and stale-span
   invalidation on language switch.
 
+- **`rememberSyntaxHighlightedEditorValue()`** - new public `@Composable` helper that extracts
+  the debounce + engine pipeline from `SyntaxHighlightedTextEditor` into a standalone function
+  mirroring the existing `rememberHighlightedCode` pattern. Returns `State<TextFieldValue>`
+  with syntax spans applied and cursor/selection preserved. Enables callers to bring their own
+  layout (`OutlinedTextField`, third-party editor, etc.) without forking the composable.
+  `SyntaxHighlightedTextEditor` now delegates to this helper and acts as a thin layout shell.
+
 ## [0.24.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 
 - **`rememberSyntaxHighlightedEditorValue()`** - new public `@Composable` helper that extracts
   the debounce + engine pipeline from `SyntaxHighlightedTextEditor` into a standalone function
-  mirroring the existing `rememberHighlightedCode` pattern. Returns `State<TextFieldValue>`
+  mirroring the existing `rememberHighlightedCode` pattern. Returns `TextFieldValue` directly
   with syntax spans applied and cursor/selection preserved. Enables callers to bring their own
   layout (`OutlinedTextField`, third-party editor, etc.) without forking the composable.
   `SyntaxHighlightedTextEditor` now delegates to this helper and acts as a thin layout shell.

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
@@ -1,0 +1,158 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.highlight.engine.HighlightTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for [rememberSyntaxHighlightedEditorValue] exercising the helper
+ * in isolation - without a [Surface] or [BasicTextField] in the tree.
+ */
+@OptIn(ExperimentalHighlightApi::class)
+@RunWith(AndroidJUnit4::class)
+class RememberSyntaxHighlightedEditorValueTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val sampleCode = "fun hello() = println(\"Hello!\")"
+
+    @Test
+    fun returnsPlainTextWithNoSpansBeforeHighlightArrives() {
+        // Capture the value returned synchronously in the first composition frame, before
+        // the async highlight pipeline has had a chance to produce a result.
+        var capturedValue: TextFieldValue? = null
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                capturedValue =
+                    rememberSyntaxHighlightedEditorValue(
+                        value = TextFieldValue(sampleCode),
+                        language = "kotlin",
+                    )
+            }
+        }
+
+        // After the first composition frame the text must be present but no highlight spans
+        // have been written yet (the LaunchedEffect hasn't started, let alone completed).
+        composeTestRule.runOnIdle {
+            assertThat(capturedValue).isNotNull()
+            assertThat(capturedValue!!.text).isEqualTo(sampleCode)
+            assertThat(capturedValue!!.annotatedString.spanStyles).isEmpty()
+        }
+    }
+
+    @Test
+    fun returnsHighlightedSpansAfterDebounce() {
+        var capturedValue: TextFieldValue? = null
+        var highlightCallbackFired = false
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                capturedValue =
+                    rememberSyntaxHighlightedEditorValue(
+                        value = TextFieldValue(sampleCode),
+                        language = "kotlin",
+                        onHighlightComplete = { highlightCallbackFired = true },
+                    )
+            }
+        }
+
+        // Wait for the async highlight pipeline (debounce + WebView + recomposition) to finish.
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { highlightCallbackFired }
+
+        // After the highlight cycle completes, the returned TextFieldValue must carry spans
+        // and preserve the original text content.
+        composeTestRule.runOnIdle {
+            assertThat(capturedValue!!.text).isEqualTo(sampleCode)
+            assertThat(capturedValue!!.annotatedString.spanStyles).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun preservesCursorPositionInReturnedValue() {
+        // The highlight pipeline must not move the cursor. Cursor position lives in the
+        // TextFieldValue selection field; copying annotatedString must leave it untouched.
+        val cursorOffset = 5
+        val inputValue = TextFieldValue(text = sampleCode, selection = TextRange(cursorOffset))
+        var capturedValue: TextFieldValue? = null
+        var highlightDone = false
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                capturedValue =
+                    rememberSyntaxHighlightedEditorValue(
+                        value = inputValue,
+                        language = "kotlin",
+                        onHighlightComplete = { highlightDone = true },
+                    )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { highlightDone }
+
+        composeTestRule.runOnIdle {
+            assertThat(capturedValue!!.selection).isEqualTo(TextRange(cursorOffset))
+        }
+    }
+
+    @Test
+    fun returnsPlainTextImmediatelyAfterLanguageChange() {
+        // When the language changes, the cached snapshot is stale. The composable must detect
+        // this in-composition (snapshot.language != language) and fall back to plain text
+        // immediately - before the new highlight cycle has completed.
+        var capturedAnnotated: AnnotatedString? = null
+        var currentLanguage by mutableStateOf("kotlin")
+        var capturedValue: TextFieldValue? = null
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                capturedValue =
+                    rememberSyntaxHighlightedEditorValue(
+                        value = TextFieldValue("val x = 1"),
+                        language = currentLanguage,
+                        onHighlightComplete = { capturedAnnotated = it },
+                    )
+            }
+        }
+
+        // Wait for the initial highlight to confirm spans exist
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+        capturedAnnotated = null
+
+        // Switch language - the snapshot is now stale, stale detection is in-composition
+        composeTestRule.runOnIdle { currentLanguage = "sql" }
+
+        // Immediately after the recomposition (before new highlight arrives), spans should
+        // be absent because the snapshot is for "kotlin", not "sql".
+        composeTestRule.runOnIdle {
+            assertThat(capturedValue!!.annotatedString.spanStyles).isEmpty()
+        }
+
+        // Confirm the new highlight cycle eventually fires with the new language
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+        assertThat(capturedAnnotated!!.text).isEqualTo("val x = 1")
+        assertThat(capturedAnnotated!!.spanStyles).isNotEmpty()
+    }
+}

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
@@ -4,17 +4,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.TextFieldValue
 import dev.hossain.highlight.engine.HighlightEngine
 import dev.hossain.highlight.engine.HighlightException
 import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.engine.ThemedHighlightResult
+import kotlinx.coroutines.delay
 
 /**
  * Creates and remembers a [HighlightEngine] scoped to the composition.
@@ -250,4 +254,135 @@ fun rememberHighlightedCodeBothThemes(
     }
 
     return state
+}
+
+/**
+ * Holds the result of a syntax-highlight call together with the [language] and [theme] that
+ * produced it. Stored as local state so the composable can detect in-composition whether the
+ * cached result is still valid for the current language/theme, eliminating the need for a
+ * separate `LaunchedEffect` that resets state asynchronously.
+ */
+private data class HighlightSnapshot(
+    val annotated: AnnotatedString,
+    val language: String,
+    val theme: HighlightTheme,
+)
+
+/**
+ * Runs the debounce + syntax-highlight pipeline for a live code editor and returns the
+ * display [TextFieldValue] ready to pass directly to `BasicTextField` (or any other text
+ * field that accepts [TextFieldValue]).
+ *
+ * This is the lower-level counterpart to [SyntaxHighlightedTextEditor]: it owns the engine
+ * call, the debounce window, and the span-clipping logic, but does **not** render anything.
+ * Callers drive their own layout, which makes it easy to:
+ * - wrap an `OutlinedTextField` or a third-party editor with syntax highlighting
+ * - test the highlight pipeline in isolation without a `Surface`/`BasicTextField` in the tree
+ *
+ * The returned [State] is updated each time a new highlight result arrives. Between updates
+ * the previous spans are preserved and clipped to the current text length, so the editor
+ * never flickers or loses color while the user is typing.
+ *
+ * ## Usage - standalone (with BasicTextField)
+ *
+ * ```kotlin
+ * var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
+ *
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = HighlightTheme.tomorrow(),
+ *     darkHighlightTheme  = HighlightTheme.tomorrowNight(),
+ * ) {
+ *     val displayValue by rememberSyntaxHighlightedEditorValue(
+ *         value    = editorValue,
+ *         language = "kotlin",
+ *     )
+ *     BasicTextField(
+ *         value         = displayValue,
+ *         onValueChange = { editorValue = it },
+ *     )
+ * }
+ * ```
+ *
+ * ## Usage - with SyntaxHighlightedTextEditor (preferred for most cases)
+ *
+ * For the common case of a themed, bordered editor use [SyntaxHighlightedTextEditor] directly.
+ * It calls this function internally and adds the `Surface` + padding + test-tag wrapper.
+ *
+ * @param value The current [TextFieldValue], including text, cursor position, and selection.
+ * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`).
+ * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
+ * @param debounceMs Milliseconds to wait after the last keystroke before triggering a new
+ *   highlight call. Defaults to 150 ms. If this value changes at runtime the new delay is
+ *   picked up on the next highlight cycle without restarting the effect.
+ * @param onHighlightComplete Optional callback invoked each time a highlight cycle completes
+ *   successfully. Receives the resulting [AnnotatedString] with syntax spans applied. Useful
+ *   for testing (wait until the first result arrives) and for observing the highlight output
+ *   without owning the editor's text state.
+ * @return A [State] holding a [TextFieldValue] with syntax-highlight spans applied, preserving
+ *   the original cursor position and selection. Falls back to plain text while a highlight
+ *   result is in flight, on error, or when the language/theme has just changed.
+ */
+@ExperimentalHighlightApi
+@Composable
+fun rememberSyntaxHighlightedEditorValue(
+    value: TextFieldValue,
+    language: String,
+    theme: HighlightTheme = LocalHighlightTheme.current,
+    debounceMs: Long = 150L,
+    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
+): State<TextFieldValue> {
+    val engine = rememberHighlightEngine()
+    var highlighted by remember { mutableStateOf<HighlightSnapshot?>(null) }
+    // rememberUpdatedState ensures a changed debounceMs or callback is used by the running
+    // effect without restarting it (restarting would reset the debounce window mid-keystroke).
+    val currentDebounceMs by rememberUpdatedState(debounceMs)
+    val currentOnHighlightComplete by rememberUpdatedState(onHighlightComplete)
+
+    // Re-highlight with debounce whenever the text, language, or theme changes.
+    // LaunchedEffect cancels the previous coroutine on each change, so rapid keystrokes
+    // naturally coalesce into a single highlight call after the user pauses.
+    LaunchedEffect(value.text, language, theme) {
+        delay(currentDebounceMs)
+        engine
+            .highlight(value.text, language, theme)
+            .onSuccess { result ->
+                highlighted = HighlightSnapshot(result.annotated, language, theme)
+                currentOnHighlightComplete?.invoke(result.annotated)
+            }.onFailure { highlighted = null }
+    }
+
+    // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
+    //
+    // Three cases:
+    // 1. No snapshot yet, or snapshot is stale (different language/theme) - show plain text.
+    //    Stale detection is in-composition: no separate LaunchedEffect needed to clear state.
+    // 2. Snapshot text exactly matches current text - apply spans directly (steady state).
+    // 3. Text has changed since the last snapshot (user is typing, debounce pending) -
+    //    clip old spans to the new text length and apply them. Spans before any edit point
+    //    remain correctly colored; only the newly typed characters briefly have no span.
+    //    This gives the illusion of live highlighting while the debounce window is open.
+    val currentText = value.text
+    val snapshot = highlighted
+    val annotated =
+        when {
+            snapshot == null || snapshot.language != language || snapshot.theme != theme -> {
+                AnnotatedString(currentText)
+            }
+
+            snapshot.annotated.text == currentText -> {
+                snapshot.annotated
+            }
+
+            else -> {
+                val builder = AnnotatedString.Builder(currentText)
+                snapshot.annotated.spanStyles.forEach { range ->
+                    val start = range.start.coerceAtMost(currentText.length)
+                    val end = range.end.coerceAtMost(currentText.length)
+                    if (start < end) builder.addStyle(range.item, start, end)
+                }
+                builder.toAnnotatedString()
+            }
+        }
+
+    return remember(value, annotated) { mutableStateOf(value.copy(annotatedString = annotated)) }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
@@ -318,9 +318,12 @@ private data class HighlightSnapshot(
  *   successfully. Receives the resulting [AnnotatedString] with syntax spans applied. Useful
  *   for testing (wait until the first result arrives) and for observing the highlight output
  *   without owning the editor's text state.
- * @return A [State] holding a [TextFieldValue] with syntax-highlight spans applied, preserving
+ * @return The [TextFieldValue] with syntax-highlight spans applied, preserving
  *   the original cursor position and selection. Falls back to plain text while a highlight
- *   result is in flight, on error, or when the language/theme has just changed.
+ *   result is in flight, on error, or when the language/theme has just changed. Because this
+ *   function is a non-restartable composable (returns a non-Unit type), all internal [State]
+ *   reads (including the highlight snapshot) automatically subscribe the caller's recompose
+ *   scope — callers should use it like any other composable helper (`val x = rememberXxx()`).
  */
 @ExperimentalHighlightApi
 @Composable
@@ -330,7 +333,7 @@ fun rememberSyntaxHighlightedEditorValue(
     theme: HighlightTheme = LocalHighlightTheme.current,
     debounceMs: Long = 150L,
     onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
-): State<TextFieldValue> {
+): TextFieldValue {
     val engine = rememberHighlightEngine()
     var highlighted by remember { mutableStateOf<HighlightSnapshot?>(null) }
     // rememberUpdatedState ensures a changed debounceMs or callback is used by the running
@@ -384,5 +387,5 @@ fun rememberSyntaxHighlightedEditorValue(
             }
         }
 
-    return remember(value, annotated) { mutableStateOf(value.copy(annotatedString = annotated)) }
+    return value.copy(annotatedString = annotated)
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHelpers.kt
@@ -279,9 +279,9 @@ private data class HighlightSnapshot(
  * - wrap an `OutlinedTextField` or a third-party editor with syntax highlighting
  * - test the highlight pipeline in isolation without a `Surface`/`BasicTextField` in the tree
  *
- * The returned [State] is updated each time a new highlight result arrives. Between updates
- * the previous spans are preserved and clipped to the current text length, so the editor
- * never flickers or loses color while the user is typing.
+ * The returned [TextFieldValue] is recomputed each time a new highlight result arrives.
+ * Between updates the previous spans are preserved and clipped to the current text length,
+ * so the editor never flickers or loses color while the user is typing.
  *
  * ## Usage - standalone (with BasicTextField)
  *
@@ -292,7 +292,7 @@ private data class HighlightSnapshot(
  *     lightHighlightTheme = HighlightTheme.tomorrow(),
  *     darkHighlightTheme  = HighlightTheme.tomorrowNight(),
  * ) {
- *     val displayValue by rememberSyntaxHighlightedEditorValue(
+ *     val displayValue = rememberSyntaxHighlightedEditorValue(
  *         value    = editorValue,
  *         language = "kotlin",
  *     )
@@ -323,7 +323,7 @@ private data class HighlightSnapshot(
  *   result is in flight, on error, or when the language/theme has just changed. Because this
  *   function is a non-restartable composable (returns a non-Unit type), all internal [State]
  *   reads (including the highlight snapshot) automatically subscribe the caller's recompose
- *   scope — callers should use it like any other composable helper (`val x = rememberXxx()`).
+ *   scope - callers should use it like any other composable helper (`val x = rememberXxx()`).
  */
 @ExperimentalHighlightApi
 @Composable

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -114,13 +113,14 @@ fun SyntaxHighlightedTextEditor(
     debounceMs: Long = 150L,
     onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
 ) {
-    val displayValue by rememberSyntaxHighlightedEditorValue(
-        value = value,
-        language = language,
-        theme = theme,
-        debounceMs = debounceMs,
-        onHighlightComplete = onHighlightComplete,
-    )
+    val displayValue =
+        rememberSyntaxHighlightedEditorValue(
+            value = value,
+            language = language,
+            theme = theme,
+            debounceMs = debounceMs,
+            onHighlightComplete = onHighlightComplete,
+        )
 
     val backgroundColor =
         remember(theme) {

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -5,12 +5,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -22,19 +18,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
-import kotlinx.coroutines.delay
-
-/**
- * Holds the result of a syntax-highlight call together with the [language] and [theme] that
- * produced it. Stored as local state so the composable can detect in-composition whether the
- * cached result is still valid for the current language/theme, eliminating the need for a
- * separate `LaunchedEffect` that resets state asynchronously.
- */
-private data class HighlightSnapshot(
-    val annotated: AnnotatedString,
-    val language: String,
-    val theme: HighlightTheme,
-)
 
 /**
  * This composable is marked **experimental** ([ExperimentalHighlightApi]). Call sites must
@@ -54,6 +37,9 @@ private data class HighlightSnapshot(
  *
  * This composable reads the active theme from [LocalHighlightTheme], so a
  * [HighlightThemeProvider] ancestor **must** exist, or you must pass an explicit [theme].
+ *
+ * For custom layout or third-party text fields, use [rememberSyntaxHighlightedEditorValue]
+ * directly to obtain the highlighted [TextFieldValue] without the `Surface` wrapper.
  *
  * ## Usage - inside HighlightThemeProvider (recommended)
  *
@@ -128,15 +114,13 @@ fun SyntaxHighlightedTextEditor(
     debounceMs: Long = 150L,
     onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
 ) {
-    val engine = rememberHighlightEngine()
-    // HighlightSnapshot carries the language and theme that produced the spans so the
-    // composable can detect in-composition whether the cached result is still valid,
-    // rather than relying on a separate non-suspending LaunchedEffect to clear state.
-    var highlighted by remember { mutableStateOf<HighlightSnapshot?>(null) }
-    // rememberUpdatedState ensures a changed debounceMs is used by the running effect
-    // without restarting it (which would reset the debounce window mid-keystroke).
-    val currentDebounceMs by rememberUpdatedState(debounceMs)
-    val currentOnHighlightComplete by rememberUpdatedState(onHighlightComplete)
+    val displayValue by rememberSyntaxHighlightedEditorValue(
+        value = value,
+        language = language,
+        theme = theme,
+        debounceMs = debounceMs,
+        onHighlightComplete = onHighlightComplete,
+    )
 
     val backgroundColor =
         remember(theme) {
@@ -148,60 +132,7 @@ fun SyntaxHighlightedTextEditor(
             theme.defaultTextColor.takeIf { it != Color.Unspecified }
                 ?: SyntaxHighlightedCodeDefaults.fallbackTextColor
         }
-
-    // Merge the theme foreground color into the caller-supplied text style so unspanned
-    // characters (newly typed, not yet highlighted) match the theme foreground.
     val themedTextStyle = remember(theme, textStyle) { textStyle.copy(color = textColor) }
-
-    // Re-highlight with debounce whenever the text, language, or theme changes.
-    // LaunchedEffect cancels the previous coroutine on each change, so rapid keystrokes
-    // naturally coalesce into a single highlight call after the user pauses.
-    LaunchedEffect(value.text, language, theme) {
-        delay(currentDebounceMs)
-        engine
-            .highlight(value.text, language, theme)
-            .onSuccess { result ->
-                highlighted = HighlightSnapshot(result.annotated, language, theme)
-                currentOnHighlightComplete?.invoke(result.annotated)
-            }.onFailure { highlighted = null }
-    }
-
-    // Merge highlight spans into the TextFieldValue while preserving cursor and selection.
-    //
-    // Three cases:
-    // 1. No snapshot yet, or snapshot is stale (different language/theme) - show plain text.
-    //    Stale detection is in-composition: no separate LaunchedEffect needed to clear state.
-    // 2. Snapshot text exactly matches current text - apply spans directly (steady state).
-    // 3. Text has changed since the last snapshot (user is typing, debounce pending) -
-    //    clip old spans to the new text length and apply them. Spans before any edit point
-    //    remain correctly colored; only the newly typed characters briefly have no span.
-    //    This gives the illusion of live highlighting - 90%+ of the block stays colored while
-    //    only the new characters wait for the next debounced highlight call.
-    val currentText = value.text
-    val snapshot = highlighted
-    val annotated =
-        when {
-            snapshot == null || snapshot.language != language || snapshot.theme != theme -> {
-                AnnotatedString(currentText)
-            }
-
-            snapshot.annotated.text == currentText -> {
-                snapshot.annotated
-            }
-
-            else -> {
-                // Reuse old spans clipped to the new text length so the cursor offset
-                // is always in bounds, preserving editability.
-                val builder = AnnotatedString.Builder(currentText)
-                snapshot.annotated.spanStyles.forEach { range ->
-                    val start = range.start.coerceAtMost(currentText.length)
-                    val end = range.end.coerceAtMost(currentText.length)
-                    if (start < end) builder.addStyle(range.item, start, end)
-                }
-                builder.toAnnotatedString()
-            }
-        }
-    val displayValue = value.copy(annotatedString = annotated)
 
     Surface(
         modifier = modifier.testTag("syntax-highlighted-text-editor"),

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@ This section documents the public API of `compose-highlight`.
 | [`ExperimentalHighlightApi`](syntax-highlighted-text-editor.md#experimentalhighlightapi) | Opt-in annotation for experimental APIs |
 | [`rememberHighlightedCode`](syntax-highlighted-code.md#rememberhighlightedcode) | Composable helper - highlights code and returns an `AnnotatedString` state |
 | [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md#rememberhighlightedcodeboththemes) | Highlights once, produces light + dark variants |
+| [`rememberSyntaxHighlightedEditorValue`](syntax-highlighted-text-editor.md#remembersyntaxhighlightededitorvalue) | **Experimental** - pipeline helper for live editor highlighting; returns `TextFieldValue` with spans applied |
 | [`rememberHighlightEngine`](highlight-engine.md#rememberhighlightengine) | Returns the shared or standalone `HighlightEngine` for the current composition |
 | `rememberTomorrowTheme` | Composable factory for the built-in Tomorrow (light) theme |
 | `rememberTomorrowNightTheme` | Composable factory for the built-in Tomorrow Night (dark) theme |

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -27,6 +27,7 @@ fun SyntaxHighlightedTextEditor(
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace),
     debounceMs: Long = 150L,
+    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
 )
 ```
 
@@ -43,6 +44,7 @@ fun SyntaxHighlightedTextEditor(
 | `theme` | `HighlightTheme` | `LocalHighlightTheme.current` | Theme to use. Throws if no `HighlightThemeProvider` is present and no explicit theme is passed |
 | `textStyle` | `TextStyle` | Monospace | Text style for the editor. The theme's foreground color is merged on top |
 | `debounceMs` | `Long` | `150` | Milliseconds to wait after the last keystroke before triggering a highlight call |
+| `onHighlightComplete` | `((AnnotatedString) -> Unit)?` | `null` | Called each time a highlight cycle completes. Receives the highlighted `AnnotatedString`. Useful for testing or observing the output without owning the text state |
 
 ## Opting in
 
@@ -120,13 +122,19 @@ fun SqlEditor() {
 
 ## How it works
 
-1. The composable maintains a `highlighted: AnnotatedString?` state and a `TextFieldValue` for the
-   field itself.
-2. A `LaunchedEffect` keyed on `(value.text, language, theme)` waits for `debounceMs` milliseconds,
+`SyntaxHighlightedTextEditor` delegates all pipeline logic to [`rememberSyntaxHighlightedEditorValue()`](#remembersyntaxhighlightededitorvalue)
+and renders the result in a `Surface` + `BasicTextField` layout.
+
+Inside `rememberSyntaxHighlightedEditorValue`:
+
+1. A `LaunchedEffect` keyed on `(value.text, language, theme)` waits for `debounceMs` milliseconds,
    then calls `HighlightEngine.highlight()`. Rapid keystrokes cancel the previous coroutine so only
    one call fires after the user pauses.
-3. When `language` or `theme` changes, a separate `LaunchedEffect` immediately clears the cached
-   spans so stale highlights from a prior language or theme are never shown.
+2. The result is stored as a `HighlightSnapshot(annotated, language, theme)` - a private data class
+   that bundles the highlighted text together with the language and theme that produced it.
+3. Stale snapshot detection is **in-composition**: if `snapshot.language != language` or
+   `snapshot.theme != theme`, the composable falls back to plain text immediately - no separate
+   `LaunchedEffect` is needed to clear state.
 4. While a new result is in flight the composable uses one of three display strategies:
    - **No cached result** - plain monospace text (first render or after language/theme change)
    - **Cached text matches current text** - applies the full cached span set (steady state)
@@ -148,6 +156,71 @@ fun SqlEditor() {
 
 ---
 
+## rememberSyntaxHighlightedEditorValue
+
+A lower-level `@Composable` helper that runs the debounce + highlight pipeline and returns the
+display `TextFieldValue` directly - without rendering any layout. Use this when you want to bring
+your own text field (`OutlinedTextField`, a third-party editor, etc.) instead of the built-in
+`Surface` + `BasicTextField` wrapper.
+
+`SyntaxHighlightedTextEditor` calls this function internally. They share the same behavior.
+
+### Signature
+
+```kotlin
+import dev.hossain.highlight.ui.ExperimentalHighlightApi
+import dev.hossain.highlight.ui.rememberSyntaxHighlightedEditorValue
+
+@ExperimentalHighlightApi
+@Composable
+fun rememberSyntaxHighlightedEditorValue(
+    value: TextFieldValue,
+    language: String,
+    theme: HighlightTheme = LocalHighlightTheme.current,
+    debounceMs: Long = 150L,
+    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
+): TextFieldValue
+```
+
+The returned `TextFieldValue` is recomputed each time a new highlight result arrives. Because this
+function returns a non-Unit type, the Compose compiler marks it **non-restartable** - all internal
+state reads automatically subscribe the caller's recompose scope. Use it like any other composable
+helper:
+
+```kotlin
+val displayValue = rememberSyntaxHighlightedEditorValue(
+    value    = editorValue,
+    language = "kotlin",
+)
+```
+
+### Usage - custom text field
+
+```kotlin
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun MyEditor() {
+    var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
+
+    HighlightThemeProvider(
+        lightHighlightTheme = rememberTomorrowTheme(),
+        darkHighlightTheme  = rememberTomorrowNightTheme(),
+    ) {
+        val displayValue = rememberSyntaxHighlightedEditorValue(
+            value    = editorValue,
+            language = "kotlin",
+        )
+        OutlinedTextField(
+            value         = displayValue,
+            onValueChange = { editorValue = it },
+            label         = { Text("Code") },
+        )
+    }
+}
+```
+
+---
+
 ## ExperimentalHighlightApi
 
 `@RequiresOptIn` annotation used to mark APIs that are not yet stable. Callers must explicitly opt
@@ -156,6 +229,7 @@ in with `@OptIn(ExperimentalHighlightApi::class)` or propagate the annotation to
 Currently applied to:
 
 - `SyntaxHighlightedTextEditor`
+- `rememberSyntaxHighlightedEditorValue`
 
 APIs marked `@ExperimentalHighlightApi` may change signature, behavior, or be removed in any
 future release without a deprecation cycle.


### PR DESCRIPTION
## Summary

Extracts the debounce + highlight pipeline out of `SyntaxHighlightedTextEditor` into a standalone `@Composable` function `rememberSyntaxHighlightedEditorValue()`, mirroring the existing `rememberHighlightedCode()` pattern in `RememberHelpers.kt`.

## Changes

### `RememberHelpers.kt`
- Added private `HighlightSnapshot` data class (moved from `SyntaxHighlightedTextEditor.kt`)
- Added `rememberSyntaxHighlightedEditorValue()` - the pipeline extracted from `SyntaxHighlightedTextEditor`
  - Returns `TextFieldValue` directly (not `State<TextFieldValue>`) - see note below
  - Contains all debounce, engine, span-clipping logic

### `SyntaxHighlightedTextEditor.kt`
- Reduced to a ~30-line thin layout shell: calls `rememberSyntaxHighlightedEditorValue()`, then renders `Surface { BasicTextField }`

## Why return `TextFieldValue` not `State<TextFieldValue>`

Because `rememberSyntaxHighlightedEditorValue` returns a non-Unit type, the Compose compiler marks it **non-restartable**. All internal State reads (the `highlighted` snapshot) bubble up to the nearest restartable ancestor automatically - no `State<T>` wrapper needed.

Using `remember(value, annotated) { mutableStateOf(...) }` would have created a new `MutableState` on every recomposition where `annotated` changed (every keystroke), and `AnnotatedString.equals()` is O(n spans). Returning `value.copy(annotatedString = annotated)` directly is both simpler and correct.

## Why it's worth doing

- **Testability**: tests can call `rememberSyntaxHighlightedEditorValue()` directly in a `@Composable` rule without needing a `Surface`/`BasicTextField` in the tree
- **Reusability**: callers can use a custom text field and just feed it the returned `TextFieldValue`
- **Consistency**: aligns with the `rememberHighlightedCode` / `rememberHighlightedCodeBothThemes` pattern