### PR TITLE
docs: add docs/changelog.md sync instructions and update with last 5 releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,25 @@ npx markdownlint --fix CHANGELOG.md
 6. **No spaces inside code spans** — Code spans must not have spaces between backticks and content: `` `code` `` not `` ` code ` ``.
 7. **Run `markdownlint` before committing** — Always verify no violations remain: `npx markdownlint CHANGELOG.md`
 
+## Docs Changelog Sync
+
+**Keep `docs/changelog.md` in sync with root `CHANGELOG.md`.** The docs site file serves as a curated summary for visitors - it should always contain brief highlights of the **last 5 releases** only. After each release:
+
+1. Add a new `### X.Y.Z - Brief Title` section at the top of the "Recent highlights" block in `docs/changelog.md`
+2. Extract 3-5 key bullet points from the root `CHANGELOG.md` for that release (focus on user-facing features and major fixes)
+3. Keep descriptions brief (1-2 lines per item, no wrapped multi-line format)
+4. Remove the oldest release entry to maintain the "last 5 releases" limit
+5. No markdown linting required for `docs/changelog.md` — it's documentation, not a strict changelog
+
+Example format:
+```markdown
+### 0.25.0 - New theme support
+
+- Added 10 new built-in themes (Dracula, Solarized, etc.)
+- Fixed WebView crash on Android 12 devices
+- Improved theme parsing performance by 40%
+```
+
 ## Architecture
 
 The library has two layers - `engine/` (internal) and `ui/` (public):

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,39 +6,37 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
-### 0.22.0 - WebView and theme correctness fixes
+### 0.24.1 - Live editor state management fixes
 
-- CSS4 `rgb(R G B)` and `rgb(R G B / alpha)` space-separated syntax support in `ThemeParser`
-- `HighlightTheme` content-aware equality - `equals()` and `hashCode()` now include content identity, not just name
-- `unescapeJsString` surrogate pair handling for emoji and supplementary Unicode characters
-- `escapeForJs` now escapes null bytes and control characters (U+0000-U+001F)
-- WebView unavailability now surfaces as `WebViewInitFailed` instead of `JsExecutionFailed`
+- Fixed span color loss in `SyntaxHighlightedTextEditor` during mid-text edits via prefix/suffix analysis
+- Added `onHighlightComplete` callback to `SyntaxHighlightedTextEditor` for deterministic testing
+- New public helper `rememberSyntaxHighlightedEditorValue()` for custom editor layouts with syntax highlighting
 
-### 0.21.0 - Slot parameter rename and fallback colors
+### 0.24.0 - Live code editor support
 
-- `languageLabelContent` renamed to `languageLabel`; `copyButtonContent` renamed to `copyButton` (matches Material 3 slot naming conventions)
-- `CodeBlockStyle` gains `fallbackBackgroundColor` and `fallbackTextColor` - configurable fallbacks used when the active theme has no `.hljs` base rule
-- `SyntaxHighlightedCodeDefaults.fallbackBackgroundColor` and `fallbackTextColor` constants exposed
-- `placeholder` parameter added to `SyntaxHighlightedCode` - composable rendered while async highlighting is in progress
-- `onError` callback added to `SyntaxHighlightedCode`, `rememberHighlightedCode`, and `rememberHighlightedCodeBothThemes`
-- `HighlightEngine` now implements `java.io.Closeable` - `close()` delegates to `destroy()`
+- New `SyntaxHighlightedTextEditor` composable with live syntax highlighting as you type
+- 150 ms keystroke debounce with cursor and selection always preserved
+- New **Live Editor** demo tab in sample app showcasing 6 languages
+- Marked `@ExperimentalHighlightApi` for gradual API stabilization
 
-### 0.20.0 - Language discovery APIs
+### 0.23.0 - Screenshot regression testing
 
-- `HighlightLanguage.fromExtension(ext)` - maps file extensions to Highlight.js language identifiers without a WebView round-trip
-- `HighlightEngine.highlightAuto(code, theme)` - auto-detect language and highlight; returns `AutoHighlightResult` with `detectedLanguage`
-- `HighlightEngine.getLanguage(nameOrAlias)` - validate a language name and retrieve its metadata; returns `HighlightLanguageInfo` (name + aliases list)
-- `AutoHighlightResult` and `HighlightLanguageInfo` data classes added
+- 13 Roborazzi screenshot goldens covering themes, layout variants, languages, and error states
+- HTML token fixtures from bundled `highlight.min.js` for testing visual stability
+- `HighlightEngine.webViewForTest()` for cleaner test integration
+- Replaced regex CSS parser with recursive-descent implementation for robustness
 
-### 0.19.1 - Bug fixes
+### 0.22.1 - Resource leaks and performance
 
-- `CodeBlockStyle.copyButtonSize` now correctly scales the default copy button touch target and glyph
-- `SyntaxHighlightedCodeDefaults.CopyButton` `size` parameter now scales the `⧉` icon glyph proportionally
+- Fixed InputStream leak in `ThemeParser` CSS loading
+- Reset horizontal scroll on code change to prevent stale scroll state
+- Stabilized lambda instances for copy button and language label slots
 
-### 0.18.0 - Timing diagnostics
+### 0.22.0 - WebView and theme correctness
 
-- `HighlightTimings` data class with per-stage duration breakdown
-- `HighlightResult.timings` and `ThemedHighlightResult.timings` always populated
+- Surrogate pair handling for emoji and supplementary Unicode in highlighted output
+- Content-aware `HighlightTheme` equality - themes compared by content, not just name
+- `WebViewInitFailed` exception when WebView is unavailable (Android Go, MDM-disabled)
 
 ### 0.17.x - Theme parser improvements
 - Merged rules for same CSS selector (fixes `nord` and other multi-rule themes)


### PR DESCRIPTION
## Changes

- **Added** new 'Docs Changelog Sync' section to .github/copilot-instructions.md
  - Documents that docs/changelog.md should contain brief summaries of the last 5 releases only
  - Specifies 3-5 concise bullet points per release focusing on user-facing features
  - Clarifies update process and that no markdown linting is required for docs site

- **Updated** docs/changelog.md with latest releases
  - Replaced old entries with current top 5 releases: 0.24.1, 0.24.0, 0.23.0, 0.22.1, 0.22.0
  - Each entry has brief 1-2 line summaries with key features and fixes
  - Maintains reader-friendly format for documentation site visitors

## Related
This ensures the documentation site changelog remains in sync with the main CHANGELOG.md and provides clear guidance for future releases.