### PR TITLE
chore: add pyproject.toml and pin zensical version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,10 +166,11 @@ Do not commit if any of these fail.
 ./scripts/prepare-release.sh <new-version>
 # Example: ./scripts/prepare-release.sh 0.18.0
 ```
-This script updates all four required files in one step:
+This script updates all five required files in one step:
 - `gradle.properties` - `VERSION_NAME`
 - `README.md` - dependency snippet
 - `sample/build.gradle.kts` - `versionName` and auto-incremented `versionCode`
+- `pyproject.toml` - `version` (keeps docs dependencies in sync with library release)
 - `CHANGELOG.md` - `[Unreleased]` renamed to `[X.Y.Z] - YYYY-MM-DD`
 
 Never update these files manually one-by-one - always use the script to avoid missing files.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Install Zensical
-        run: pip install zensical
+      - name: Install dependencies
+        run: pip install .
 
       - name: Build docs site
         run: zensical build --clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **Upgraded Zensical to 0.0.43** - latest documentation site generator with improved link
+  validation edge cases (dollar signs, GitHub callouts, TOC markers), BOM stripping for
+  UTF-8 files, and theme directory watching improvements.
+
 ## [0.24.1] - 2026-05-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "android-compose-highlight-docs"
+description = "Documentation site for Compose Highlight for Android"
+version = "0.24.1"
+dependencies = [
+    # https://github.com/zensical/zensical/releases
+    # https://pypi.org/project/zensical/
+    "zensical==0.0.43",
+]
+
+[project.optional-dependencies]
+dev = [
+    "zensical==0.0.43",
+]

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -9,6 +9,7 @@
 #   - gradle.properties        (VERSION_NAME)
 #   - README.md                (dependency snippet)
 #   - sample/build.gradle.kts  (versionName, versionCode auto-incremented)
+#   - pyproject.toml           (version)
 #   - CHANGELOG.md             ([Unreleased] renamed to [<version>] - <date>)
 #
 # After running, verify the diff with `git diff`, then:
@@ -68,6 +69,10 @@ echo "- sample/build.gradle.kts versionCode: $CURRENT_CODE -> $NEW_CODE"
 # 5. CHANGELOG.md - rename [Unreleased] to versioned entry
 sed -i '' "s/## \[Unreleased\]/## [Unreleased]\n\n## [$NEW_VERSION] - $DATE/" "$REPO_ROOT/CHANGELOG.md"
 echo "- CHANGELOG.md [Unreleased] -> [$NEW_VERSION] - $DATE"
+
+# 6. pyproject.toml - version
+sed -i '' "s/version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" "$REPO_ROOT/pyproject.toml"
+echo "- pyproject.toml version updated"
 
 echo ""
 echo "Done. Verify with: git diff"


### PR DESCRIPTION
## Changes

- **Created pyproject.toml** with PEP 621 standard configuration
  - Replaces implicit floating dependency on latest Zensical
  - Follows modern Python best practices

- **Pinned zensical==0.0.43** as explicit dependency
  - Ensures reproducible builds across all environments
  - Prevents silent version changes between runs

- **Updated docs workflow** to use `pip install .`
  - Now installs dependencies from pyproject.toml
  - Same versions used in local dev and CI

## Benefits

✅ Reproducible builds - consistent versions everywhere
✅ Explicit dependency management - easy to track and update
✅ Modern Python standard (PEP 621) - future-proof configuration
✅ Single source of truth - one place to update dependencies