### PR TITLE
fix: configure setuptools to exclude packages in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ dependencies = [
 dev = [
     "zensical==0.0.43",
 ]
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
## Problem

CI docs workflow fails with error:
```
error: Multiple top-level packages discovered in a flat-layout: ['sample', 'gradle', 'keystore', 'buildSrc', 'resources'].
```

Setuptools tries to discover Python packages in the Android/Gradle project directories when running `pip install .`

## Solution

Add `[tool.setuptools]` section with empty `packages = []` to explicitly tell setuptools:
- Do not attempt automatic package discovery
- This is NOT a Python package to be built/distributed
- Just install the dependencies defined in `[project]` section

This allows `pip install .` to work cleanly without attempting a wheel build in a multi-language monorepo.