### PR TITLE
docs: sync theming docs with current implementation

### DIFF
--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -15,7 +15,7 @@ Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) are
 
 - No `Context` required
 - No runtime CSS parsing
-- Color maps are read from precompiled `GeneratedThemes` constants
+- Color maps are read from precompiled color maps bundled with the library
 
 ## Automatic light/dark switching
 

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -1,6 +1,6 @@
 # Theming
 
-`compose-highlight` ships four Highlight.js themes out of the box. Themes are backed by CSS files bundled in the library's assets and lazily parsed at first use.
+`compose-highlight` ships four Highlight.js themes out of the box. Those built-ins are precompiled into Kotlin constants at build time, so they do not parse CSS at runtime.
 
 ## Built-in themes
 
@@ -10,6 +10,12 @@
 | Tomorrow Night | Dark | `rememberTomorrowNightTheme()` |
 | Atom One Dark | Dark | `rememberAtomOneDarkTheme()` |
 | Atom One Light | Light | `rememberAtomOneLightTheme()` |
+
+Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) are fast-path themes:
+
+- No `Context` required
+- No runtime CSS parsing
+- Color maps are read from precompiled `GeneratedThemes` constants
 
 ## Automatic light/dark switching
 
@@ -59,6 +65,8 @@ val theme = HighlightTheme.fromAsset(
 )
 HighlightThemeProvider(darkHighlightTheme = theme) { ... }
 ```
+
+`fromAsset()` is lazy. CSS parsing happens on first use (`theme.colorMap`), not at factory-call time.
 
 !!! note
     `HighlightTheme.fromAsset()` normalizes the passed `Context` to `applicationContext` internally.
@@ -123,7 +131,7 @@ import dev.hossain.highlight.ui.rememberHighlightEngine
 
 val engine = rememberHighlightEngine()
 val fallback = remember(code) { AnnotatedString(code) }
-val (lightAnnotated, darkAnnotated) by produceState(fallback to fallback, code) {
+val themedPair by produceState(fallback to fallback, code) {
     engine.highlightBothThemes(
         code       = code,
         language   = "kotlin",
@@ -131,6 +139,7 @@ val (lightAnnotated, darkAnnotated) by produceState(fallback to fallback, code) 
         darkTheme  = darkTheme,
     ).onSuccess { value = it.light to it.dark }
 }
+val (lightAnnotated, darkAnnotated) = themedPair
 // Switch between lightAnnotated and darkAnnotated instantly
 ```
 

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -6,6 +6,7 @@ Theme initialization depends on how the theme is created:
 
 - Built-ins (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) use precompiled color maps and do not parse CSS at runtime.
 - CSS-backed themes (`fromAsset`, `fromCss`) are lazy and parse CSS on first `colorMap` access.
+- Color-map themes (`fromColorMap`) use the provided map and do not parse CSS.
 
 ## Built-in themes
 

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -1,8 +1,11 @@
 # HighlightTheme
 
-Represents a syntax highlighting theme backed by a Highlight.js CSS file.
+Represents a syntax highlighting theme used by the engine to map `hljs-*` tokens to Compose `SpanStyle`s.
 
-The color map is lazily initialized and cached - CSS parsing happens at most once per theme instance.
+Theme initialization depends on how the theme is created:
+
+- Built-ins (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) use precompiled color maps and do not parse CSS at runtime.
+- CSS-backed themes (`fromAsset`, `fromCss`) are lazy and parse CSS on first `colorMap` access.
 
 ## Built-in themes
 
@@ -13,7 +16,7 @@ The color map is lazily initialized and cached - CSS parsing happens at most onc
 | `HighlightTheme.atomOneDark()` | Dark | `rememberAtomOneDarkTheme()` |
 | `HighlightTheme.atomOneLight()` | Light | `rememberAtomOneLightTheme()` |
 
-Always use the `remember*` helpers inside composables so the CSS is not re-parsed on every recomposition:
+Use the `remember*` helpers inside composables to keep stable theme instances across recompositions:
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider


### PR DESCRIPTION
## What changed
- update theming guide to reflect precompiled built-in themes (no runtime CSS parse, no Context needed)
- clarify fromAsset() lazy parsing behavior
- update HighlightTheme reference to describe built-in vs CSS-backed initialization paths
- fix invalid delegated destructuring snippet in theming guide (produceState usage)

## Why
Docs had drifted from current implementation and one snippet was not valid Kotlin syntax.

## Files
- docs/guides/theming.md
- docs/reference/highlight-theme.md
