### PR TITLE
docs: add zensical setup instructions to zensical.toml

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -20,6 +20,12 @@ docs_dir         = "docs"
 repo_name        = "hossain-khan/android-compose-highlight"
 repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
+# extra_css        = ["stylesheets/shiki-kotlin.css"]
+
+# [[project.extra_javascript]]
+# path = "javascripts/shiki-kotlin.js"
+# type = "module"
+# async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -20,12 +20,12 @@ docs_dir         = "docs"
 repo_name        = "hossain-khan/android-compose-highlight"
 repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
-# extra_css        = ["stylesheets/shiki-kotlin.css"]
+extra_css        = ["stylesheets/shiki-kotlin.css"]
 
-# [[project.extra_javascript]]
-# path = "javascripts/shiki-kotlin.js"
-# type = "module"
-# async = true
+[[project.extra_javascript]]
+path = "javascripts/shiki-kotlin.js"
+type = "module"
+async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -20,12 +20,6 @@ docs_dir         = "docs"
 repo_name        = "hossain-khan/android-compose-highlight"
 repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
-# extra_css        = ["stylesheets/shiki-kotlin.css"]
-
-# [[project.extra_javascript]]
-# path = "javascripts/shiki-kotlin.js"
-# type = "module"
-# async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,4 +1,15 @@
-# ── Site metadata ──────────────────────────────────────────────────────────────
+# ── Zensical Documentation Site ────────────────────────────────────────────────────
+#
+# Setup Instructions (first time only):
+#   python3 -m venv .venv
+#   source .venv/bin/activate
+#   pip install zensical
+#
+# Local Preview:
+#   zensical serve
+#   Then open http://localhost:8000
+#
+# ── Site metadata ──────────────────────────────────────────────────────────────────
 [project]
 site_name        = "Highlight"
 site_description = "Jetpack Compose syntax highlighting library powered by Highlight.js"
@@ -9,12 +20,12 @@ docs_dir         = "docs"
 repo_name        = "hossain-khan/android-compose-highlight"
 repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
-extra_css        = ["stylesheets/shiki-kotlin.css"]
+# extra_css        = ["stylesheets/shiki-kotlin.css"]
 
-[[project.extra_javascript]]
-path = "javascripts/shiki-kotlin.js"
-type = "module"
-async = true
+# [[project.extra_javascript]]
+# path = "javascripts/shiki-kotlin.js"
+# type = "module"
+# async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [


### PR DESCRIPTION
Adds setup and preview instructions as a comment block at the top of zensical.toml, keeping all zensical-related documentation co-located in one place.