### PR TITLE
Fixed docs site nav and switching sites

### DIFF
--- a/compose-highlight/dokka-theme/README.md
+++ b/compose-highlight/dokka-theme/README.md
@@ -260,10 +260,8 @@ prevents a race where Dokka's `platform-content-handler.js` could observe
 `.main-content` detached from the document during the fetch yield, throw,
 and abort `initializeFiltering()` — leaving the Members section hidden.
 
-**Auto-expand path to active page.** When rendering the nav tree, the script
-tracks which `<li>` ancestors contain the active page and pre-checks their
-toggle inputs. The user lands with a visible breadcrumb of context rather
-than having to drill down each time.
+**Fully expanded navigation.** All nested sidebar items are expanded by default so users
+can see the full API tree at a glance without manually drilling down.
 
 **Dokka's white SVG chevron.** `arrow-down.svg` is filled with
 `rgba(255,255,255,0.96)` because Dokka's stock theme is dark. On our light

--- a/compose-highlight/dokka-theme/dokka-zensical-chrome.js
+++ b/compose-highlight/dokka-theme/dokka-zensical-chrome.js
@@ -336,8 +336,7 @@
             <span class="md-ellipsis">Back to Docs</span>
         `;
         backItem.appendChild(backLink);
-        nav.appendChild(backItem);
-
+        navTree.insertBefore(backItem, navTree.firstChild);
         nav.appendChild(navTree);
         return sidebar;
     }

--- a/compose-highlight/dokka-theme/dokka-zensical-chrome.js
+++ b/compose-highlight/dokka-theme/dokka-zensical-chrome.js
@@ -305,7 +305,7 @@
             .trim();
     }
 
-    function buildPrimarySidebar(navTree) {
+    function buildPrimarySidebar(navTree, apiRoot) {
         const sidebar = document.createElement("div");
         sidebar.className = "md-sidebar md-sidebar--primary";
         sidebar.setAttribute("data-md-component", "sidebar");
@@ -318,7 +318,27 @@
                 </div>
             </div>
         `;
-        sidebar.querySelector(".md-nav--primary").appendChild(navTree);
+        const nav = sidebar.querySelector(".md-nav--primary");
+
+        // Inject "Back to Docs" link at the top of the sidebar
+        const backItem = document.createElement("li");
+        backItem.className = "md-nav__item";
+        const backLink = document.createElement("a");
+        backLink.href = apiRoot + "../index.html";
+        backLink.className = "md-nav__link";
+        backLink.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor"
+                 stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                 class="lucide lucide-arrow-left" viewBox="0 0 24 24"
+                 style="width:1.2em;height:1.2em;vertical-align:middle;margin-right:0.3em;">
+                <path d="M19 12H5M12 19l-7-7 7-7"/>
+            </svg>
+            <span class="md-ellipsis">Back to Docs</span>
+        `;
+        backItem.appendChild(backLink);
+        nav.appendChild(backItem);
+
+        nav.appendChild(navTree);
         return sidebar;
     }
 
@@ -445,7 +465,7 @@
                 const parser = new DOMParser();
                 const doc = parser.parseFromString(html, "text/html");
                 const navResult = renderNavTree(doc, apiRoot, location.href);
-                primarySidebar = buildPrimarySidebar(navResult.list);
+                primarySidebar = buildPrimarySidebar(navResult.list, apiRoot);
             }
         } catch (_) {
             // Silent: if navigation.html is unreachable, we just render without the left nav.

--- a/compose-highlight/dokka-theme/dokka-zensical-chrome.js
+++ b/compose-highlight/dokka-theme/dokka-zensical-chrome.js
@@ -286,9 +286,9 @@
             item.appendChild(nestedNav);
         }
 
-        // Auto-expand: if this item contains the active page, mark its toggle checked
-        // so the path to current page is open on first paint.
-        if (containsActive && expandToggle) {
+        // Auto-expand: expand all nested items by default so users can see the full
+        // navigation tree without manually drilling down.
+        if (expandToggle) {
             expandToggle.checked = true;
             ctx.openItems.add(item);
         }

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -194,7 +194,7 @@ fun rememberSyntaxHighlightedEditorValue(
 ): TextFieldValue
 ```
 
-The `onError` callback receives a typed [`HighlightException`](highlight-engine.md#highlightexception) on
+The `onError` callback receives a typed [`HighlightException`](highlight-engine.md) on
 failure. Possible subtypes: `Timeout`, `JsExecutionFailed`, `WebViewInitFailed`, `HtmlParseFailed`. The
 helper falls back to plain text regardless of whether the callback is set.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -45,7 +45,7 @@ nav = [
       "reference/highlight-language.md",
   ]},
   { "Changelog" = "changelog.md" },
-  # Requires: ./gradlew :compose-highlight:dokkaGenerate
+  # Requires: ./gradlew :compose-highlight:dokkaGeneratePublicationHtml
   { "Dokka API Docs" = "api/" },
 ]
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,15 +22,19 @@ repo_url         = "https://github.com/hossain-khan/android-compose-highlight"
 edit_uri         = "edit/main/docs/"
 extra_css        = ["stylesheets/shiki-kotlin.css"]
 
-[[project.extra_javascript]]
-path = "javascripts/shiki-kotlin.js"
-type = "module"
-async = true
 
 # ── Navigation ─────────────────────────────────────────────────────────────────
 nav = [
   { "Home"            = "index.md" },
   { "Getting Started" = "getting-started.md" },
+  { "Guides" = [
+      "guides/theming.md",
+      "guides/customization.md",
+      "guides/line-numbers.md",
+      "guides/performance.md",
+      "guides/engine-only.md",
+      "guides/language-selection.md",
+  ]},
   { "API Reference"   = [
       "reference/index.md",
       "reference/syntax-highlighted-code.md",
@@ -40,17 +44,15 @@ nav = [
       "reference/highlight-engine.md",
       "reference/highlight-language.md",
   ]},
-  { "Guides" = [
-      "guides/theming.md",
-      "guides/customization.md",
-      "guides/line-numbers.md",
-      "guides/performance.md",
-      "guides/engine-only.md",
-      "guides/language-selection.md",
-  ]},
   { "Changelog" = "changelog.md" },
-  { "Dokka API Docs" = "https://hossain-khan.github.io/android-compose-highlight/api/" },
+  # Requires: ./gradlew :compose-highlight:dokkaGenerate
+  { "Dokka API Docs" = "api/" },
 ]
+
+[[project.extra_javascript]]
+path = "javascripts/shiki-kotlin.js"
+type = "module"
+async = true
 
 # ── Theme ──────────────────────────────────────────────────────────────────────
 [project.theme]


### PR DESCRIPTION
This pull request makes several improvements to the Dokka API documentation theme and configuration, focusing on enhancing navigation usability, updating documentation links, and reorganizing configuration for clarity and maintainability.

**Navigation and Sidebar Improvements:**

* All sidebar navigation items in the Dokka API docs are now fully expanded by default, allowing users to see the complete API tree without manual drilling. [[1]](diffhunk://#diff-214599e35b8a07c1c5f61e48da9a17c75b4fc298ce6a428c30224ff4508471dfL263-R264)], [[2]](diffhunk://#diff-ad6b5e41a53a305de6999aaf63236af8d25e129b26a92b13925ae146042bb75cL289-R291)])
* A "Back to Docs" link has been added at the top of the API sidebar for easier navigation back to the main documentation. [[1]](diffhunk://#diff-ad6b5e41a53a305de6999aaf63236af8d25e129b26a92b13925ae146042bb75cL321-R341)], [[2]](diffhunk://#diff-ad6b5e41a53a305de6999aaf63236af8d25e129b26a92b13925ae146042bb75cL308-R308)], [[3]](diffhunk://#diff-ad6b5e41a53a305de6999aaf63236af8d25e129b26a92b13925ae146042bb75cL448-R468)])

**Documentation and Configuration Updates:**

* The `zensical.toml` configuration has been reorganized: the "Guides" section is now grouped together, and the Dokka API Docs link now points to a local `api/` directory instead of an external URL, making it easier to serve generated docs locally. [[1]](diffhunk://#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04L25-R37)], [[2]](diffhunk://#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04L43-R56)])
* The extra JavaScript configuration for syntax highlighting has been moved to the end of the file for better organization. [[1]](diffhunk://#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04L25-R37)], [[2]](diffhunk://#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04L43-R56)])
* A documentation link in `syntax-highlighted-text-editor.md` was fixed to point to the correct section for `HighlightException`. ([[docs/reference/syntax-highlighted-text-editor.mdL197-R197](diffhunk://#diff-d7c9f1c6c77dbb136698c07df2e9d76b3b775a6836623cb2ca5ca58b6ecfcfc3L197-R197)])