### PR TITLE
fix: Sync Dokka palette toggle with Zensical root key

### DIFF
--- a/compose-highlight/dokka-theme/README.md
+++ b/compose-highlight/dokka-theme/README.md
@@ -157,24 +157,15 @@ updated.
 **LocalStorage palette key shape:**
 
 ```
-key   = `${apiRoot.pathname}.__palette`     // e.g. "/android-compose-highlight/api/.__palette"
+key   = `${siteRoot.pathname}.__palette`  // e.g. "/android-compose-highlight/.__palette"
 value = JSON.stringify({
     color: { media: "none", scheme: "default"|"slate", primary: "indigo", accent: "indigo" }
 })
 ```
 
-`apiRoot` is computed by stripping `images/dokka-zensical-chrome.js` from the
-script's own `src` attribute (Dokka emits relative URLs that vary with page
-depth). The script reads/writes only this api-root key — separate from
-Material's own per-directory scoping on `/`. See "Scoping" below.
-
-**Scoping note:** Material's own init script per-pathname-scopes the palette
-key (a flip on `/foo/` doesn't carry to `/bar/`). The chrome script
-deliberately deviates: it anchors the key to `/api/`'s root, so the toggle is
-sticky throughout the API reference regardless of which class detail page the
-user is on. The Zensical site at `/` continues to use Material's own
-per-directory scope, so a flip on `/` does NOT carry into `/api/` — users
-toggle once per site.
+`siteRoot` is computed by stripping `/api/` from the Dokka api root, so the palette key
+matches the Zensical site root. Both sites now share the same localStorage key — a toggle on
+`/` carries into `/api/` and vice versa.
 
 ## Out of scope
 

--- a/compose-highlight/dokka-theme/dokka-zensical-chrome.js
+++ b/compose-highlight/dokka-theme/dokka-zensical-chrome.js
@@ -26,17 +26,13 @@
         return "";
     }
 
-    // Compute the localStorage key the Material palette script uses, but anchored to /api/'s
-    // root (not the current page's directory). Material itself per-pathname-scopes this key,
-    // which would mean dark mode resets every time the user navigates between /api/<package>/
-    // and /api/<package>/<class>/. Anchoring to /api/'s root keeps the toggle sticky
-    // throughout the API reference. The Zensical site at / continues to use its own
-    // per-directory scope (we don't touch that), so a flip on / won't carry into /api/ —
-    // users toggle once per site, which is acceptable.
-    function paletteStorageKey(apiRoot) {
+    // Compute the localStorage key the Material palette script uses, anchored to the
+    // Zensical site root (not /api/). This keeps the palette toggle synced between the
+    // Zensical docs at / and the Dokka API reference at /api/.
+    function sharedPaletteStorageKey(apiRoot) {
         try {
             const apiScope = new URL(apiRoot || ".", location);
-            let pathname = apiScope.pathname;
+            let pathname = apiScope.pathname.replace(/\/api\/?$/, "/");
             if (!pathname.endsWith("/")) pathname = pathname + "/";
             return pathname + MD_PALETTE_LS_KEY_SUFFIX;
         } catch (_) {
@@ -46,7 +42,7 @@
 
     function readStoredPalette(apiRoot) {
         try {
-            const raw = localStorage.getItem(paletteStorageKey(apiRoot));
+            const raw = localStorage.getItem(sharedPaletteStorageKey(apiRoot));
             if (!raw) return null;
             return JSON.parse(raw);
         } catch (_) {
@@ -64,7 +60,7 @@
             },
         };
         try {
-            localStorage.setItem(paletteStorageKey(apiRoot), JSON.stringify(value));
+            localStorage.setItem(sharedPaletteStorageKey(apiRoot), JSON.stringify(value));
         } catch (_) {
             // localStorage may be unavailable (Safari private mode etc); silently ignore.
         }


### PR DESCRIPTION
## Summary

Syncs the dark/light mode toggle between the Zensical docs site (`/`) and the Dokka API reference (`/api/`).

## Problem

Before this change, Dokka's palette toggle used its own localStorage key scoped to `/api/.__palette`, while Zensical used a separate key at `/.__palette`. This meant:

- Toggling dark mode on the docs site had no effect on `/api/` pages
- Users had to toggle dark mode twice when navigating between the two sites

## Solution

Changed Dokka's `sharedPaletteStorageKey()` to strip the `/api/` suffix from the pathname, so both sites read/write the same localStorage key. Now a toggle on either site carries over to the other.

## Files Changed

- `compose-highlight/dokka-theme/dokka-zensical-chrome.js` — Renamed `paletteStorageKey` → `sharedPaletteStorageKey`, added `/api/` path stripping
- `compose-highlight/dokka-theme/README.md` — Updated docs to reflect shared key behavior