### PR TITLE
chore: Add AGENTS.md symlink to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,3 +222,61 @@ dev.hossain:compose-highlight:<version>
 
 **Writing style - never use the em dash `-` character** in commit messages, code comments, KDoc, CHANGELOG entries, or any other text. Use a regular hyphen/minus `-` instead.
 
+## Docs site
+
+The documentation site at https://hossain-khan.github.io/android-compose-highlight/ is built with two tools:
+
+- **Zensical** (v0.0.43) - Static site generator for the main docs (Markdown in `docs/`). Configured via `zensical.toml`.
+- **Dokka** - Generates the Kotlin API reference under `docs/api/`, rethemed to match the Zensical chrome via `compose-highlight/dokka-theme/`.
+
+**Local preview:**
+```bash
+# Zensical docs site (main docs)
+zensical serve
+# Open http://localhost:8000
+
+# Dokka API reference (must serve over HTTP, not file://)
+./gradlew :compose-highlight:dokkaGenerate
+cd docs && python3 -m http.server 8765
+# Open http://localhost:8765/api/index.html
+```
+
+**Dokka retheme** (`compose-highlight/dokka-theme/`):
+- `dokka-zensical-chrome.js` - Injects Material-style header, sidebar, and footer around Dokka's content. Includes a "Back to Docs" link in the sidebar pointing to `../index.html`. All sidebar items are expanded by default.
+- `zensical-overrides.css` - Overrides Dokka's CSS variables to match Zensical's light/dark schemes.
+- `zensical-assets/` - Frozen copies of Zensical's Material CSS bundles (pinned by hash).
+- The palette toggle is synced between Zensical (`/`) and Dokka (`/api/`) via a shared localStorage key.
+
+**CI workflow** (`.github/workflows/docs.yml`): Generates Dokka API docs, builds Zensical site, deploys `site/` to GitHub Pages.
+
+**Updating Zensical CSS assets:** When Zensical is upgraded, copy the new hashed CSS files from `site/assets/stylesheets/modern/` into `compose-highlight/dokka-theme/zensical-assets/` and update the references in `compose-highlight/build.gradle.kts`. See `compose-highlight/dokka-theme/README.md` for the full refresh procedure.
+
+## Docs site
+
+The documentation site at https://hossain-khan.github.io/android-compose-highlight/ is built with two tools:
+
+- **Zensical** (v0.0.43) - Static site generator for the main docs (Markdown in `docs/`). Configured via `zensical.toml`.
+- **Dokka** - Generates the Kotlin API reference under `docs/api/`, rethemed to match the Zensical chrome via `compose-highlight/dokka-theme/`.
+
+**Local preview:**
+```bash
+# Zensical docs site (main docs)
+zensical serve
+# Open http://localhost:8000
+
+# Dokka API reference (must serve over HTTP, not file://)
+./gradlew :compose-highlight:dokkaGenerate
+cd docs && python3 -m http.server 8765
+# Open http://localhost:8765/api/index.html
+```
+
+**Dokka retheme** (`compose-highlight/dokka-theme/`):
+- `dokka-zensical-chrome.js` - Injects Material-style header, sidebar, and footer around Dokka's content. Includes a "Back to Docs" link in the sidebar pointing to `../index.html`. All sidebar items are expanded by default.
+- `zensical-overrides.css` - Overrides Dokka's CSS variables to match Zensical's light/dark schemes.
+- `zensical-assets/` - Frozen copies of Zensical's Material CSS bundles (pinned by hash).
+- The palette toggle is synced between Zensical (`/`) and Dokka (`/api/`) via a shared localStorage key.
+
+**CI workflow** (`.github/workflows/docs.yml`): Generates Dokka API docs, builds Zensical site, deploys `site/` to GitHub Pages.
+
+**Updating Zensical CSS assets:** When Zensical is upgraded, copy the new hashed CSS files from `site/assets/stylesheets/modern/` into `compose-highlight/dokka-theme/zensical-assets/` and update the references in `compose-highlight/build.gradle.kts`. See `compose-highlight/dokka-theme/README.md` for the full refresh procedure.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/compose-highlight/dokka-theme/README.md
+++ b/compose-highlight/dokka-theme/README.md
@@ -164,7 +164,7 @@ value = JSON.stringify({
 ```
 
 `siteRoot` is computed by stripping `/api/` from the Dokka api root, so the palette key
-matches the Zensical site root. Both sites now share the same localStorage key — a toggle on
+matches the Zensical site root. Both sites now share the same localStorage key - a toggle on
 `/` carries into `/api/` and vice versa.
 
 ## Out of scope


### PR DESCRIPTION
Symlinks AGENTS.md to .github/copilot-instructions.md so AI agents (Claude Code, Cursor, etc.) can find project instructions at the standard location.