### PR TITLE
ci: scope Android build skip rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
   pull-requests: read
 
-# Skip the heavy Android build when only docs, assets, scripts, or repo config files change.
+# Skip the heavy Android build when only docs and non-Android files change.
 # A single always-running "Build & Test" job satisfies the required branch protection check
 # in all cases - it exits early with a success message for non-code changes.
 jobs:
@@ -30,17 +30,30 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           else
-            CHANGED=$(git diff --name-only HEAD^1 HEAD 2>/dev/null || git diff --name-only HEAD)
+            CHANGED=$(git diff --name-only ${{ github.event.before }}...${{ github.sha }} 2>/dev/null || git diff --name-only HEAD)
           fi
           echo "Changed files:"
           echo "$CHANGED"
           CODE_CHANGED=false
           while IFS= read -r file; do
-            if [[ "$file" == compose-highlight/* || \
-                  "$file" == sample/* || \
+            if [[ "$file" == compose-highlight/src/* || \
+                  "$file" == sample/src/* || \
+                  "$file" == buildSrc/* || \
                   "$file" == gradle/* || \
-                  "$file" == *.kts || \
+                  "$file" == "gradlew" || \
+                  "$file" == "gradlew.bat" || \
                   "$file" == "gradle.properties" || \
+                  "$file" == "settings.gradle" || \
+                  "$file" == "settings.gradle.kts" || \
+                  "$file" == "build.gradle" || \
+                  "$file" == "build.gradle.kts" || \
+                  "$file" == "compose-highlight/build.gradle.kts" || \
+                  "$file" == "sample/build.gradle.kts" || \
+                  "$file" == "gradle/libs.versions.toml" || \
+                  "$file" == "libs.versions.toml" || \
+                  "$file" == scripts/* || \
+                  "$file" == *.gradle || \
+                  "$file" == *.gradle.kts || \
                   "$file" == ".github/workflows/ci.yml" ]]; then
               CODE_CHANGED=true
               break


### PR DESCRIPTION
## Why
The CI workflow should run full Android build and test jobs only when Android-impacting files change.

## What changed
- Updated changed-files detection on push to use github.event.before...github.sha (handles multi-commit pushes).
- Narrowed run-full-CI paths to Android-impacting areas: compose-highlight/src/**, sample/src/**, buildSrc/**, gradle/**, Gradle wrapper and properties files, Gradle build files, and CI workflow file.
- Keeps the always-running Build and Test job behavior so required branch protection check is still satisfied when heavy steps are skipped.

## Result
Docs-only and other non-Android updates skip expensive Android CI steps, while build-relevant changes still run full verification.