### PR TITLE
docs: refactor reference pages to reduce Dokka duplication (phase 1)

### DIFF
--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -1,12 +1,31 @@
 # HighlightEngine
 
-The core engine that manages the hidden WebView and executes Highlight.js highlighting.
+`HighlightEngine` is the low-level API that owns the hidden WebView and runs the highlight.js
+pipeline.
 
-For most use cases, use `SyntaxHighlightedCode` inside a `HighlightThemeProvider` - it handles the engine lifecycle automatically. Use `HighlightEngine` directly only when you need lower-level control, such as highlighting in a ViewModel or outside of Compose.
+For most UI use cases, prefer `SyntaxHighlightedCode` inside `HighlightThemeProvider`. Use
+`HighlightEngine` directly when you need highlighting outside composables, such as in a ViewModel
+or service layer.
 
-## Lifecycle
+Full API in Dokka:
 
-The engine holds a hidden WebView resource and implements `Closeable`. Always call `close()` (or `destroy()`) when done. Inside Compose, use `rememberHighlightEngine()` which calls `destroy()` automatically via `DisposableEffect`. Since highlighting APIs are `suspend`, prefer coroutine-friendly `try/finally` cleanup for scoped usage:
+- [`HighlightEngine`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-engine/index.html)
+- [`HighlightResult`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-result/index.html)
+- [`ThemedHighlightResult`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-themed-highlight-result/index.html)
+- [`HighlightLanguageInfo`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-language-info/index.html)
+- [`AutoHighlightResult`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-auto-highlight-result/index.html)
+- [`rememberHighlightEngine`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-highlight-engine.html)
+
+## When to use it
+
+- You need highlighting in non-UI layers.
+- You want direct control over engine initialization and lifetime.
+- You need APIs like language lookup, auto-detection, or HTML-only output.
+
+## Lifecycle and cleanup
+
+The engine holds a hidden WebView and implements `Closeable`. Always call `close()` (or
+`destroy()`) when done.
 
 ```kotlin
 val engine = HighlightEngine(context.applicationContext)
@@ -17,23 +36,18 @@ try {
 }
 ```
 
-## Methods
+In Compose, use `rememberHighlightEngine()` so cleanup is handled automatically.
 
-| Method | Description |
-|---|---|
-| `suspend initialize(): Result<Unit>` | Warms up the WebView. Optional - `highlight()` also initializes on first call. Returns `Result.failure(WebViewInitFailed(...))` if WebView is unavailable |
-| `suspend highlight(code, language, theme)` | Full pipeline: tokenize, apply theme, return `Result<HighlightResult>` (access `.annotated` for the `AnnotatedString`) |
-| `suspend highlightBothThemes(code, language, lightTheme, darkTheme)` | Highlight once, return `Result<ThemedHighlightResult>` (access `.light` and `.dark` for the `AnnotatedString` variants) |
-| `suspend highlightToHtml(code, language)` | Returns `Result<HtmlHighlightResult>` (access `.html` for the HTML string, `.jsBridgeDuration` and `.jsonUnescapeDuration` for timing) |
-| `suspend supportedLanguages()` | Returns the list of languages the bundled Highlight.js supports |
-| `suspend highlightJsVersion()` | Returns the bundled Highlight.js version string |
-| `suspend getLanguage(nameOrAlias)` | Returns `Result<HighlightLanguageInfo?>` - null success means language not recognized |
-| `suspend highlightAuto(code, theme)` | Auto-detect language and highlight, returns `Result<AutoHighlightResult>` |
-| `fun destroy()` | Releases the WebView and clears caches. Idempotent - safe to call multiple times |
-| `fun close()` | Alias for `destroy()`. Implements `Closeable` for IDE resource-leak inspections and explicit cleanup |
-| `val isInitialized: StateFlow<Boolean>` | Observe WebView readiness reactively |
+## Core operations
 
-All suspend methods return `Result<T>` - never throw. Wrap failures in `HighlightException`.
+- `initialize()` - optional warm-up to reduce first highlight latency.
+- `highlight()` - highlight one language and return `AnnotatedString` with timings.
+- `highlightBothThemes()` - tokenize once and generate light and dark variants.
+- `highlightToHtml()` - get highlighted HTML directly.
+- `supportedLanguages()` and `highlightJsVersion()` - runtime capability introspection.
+- `getLanguage()` and `highlightAuto()` - language metadata and auto-detection workflows.
+
+All suspend APIs return `Result<T>` and report failures as `HighlightException`.
 
 ## Usage in a ViewModel
 
@@ -46,7 +60,6 @@ class CodeViewModel(application: Application) : AndroidViewModel(application) {
 
     init {
         viewModelScope.launch {
-            // Optional warm-up to reduce first-call latency
             engine.initialize()
         }
     }
@@ -82,14 +95,12 @@ fun MyCodeBlock(code: String) {
 }
 ```
 
-## Highlight both themes (instant switching)
+## Highlight both themes for instant switching
 
-Tokenizes once, applies two color maps - theme switching has zero extra latency:
+`highlightBothThemes()` tokenizes once and applies both color maps, so theme switching does not
+trigger another JS tokenization pass.
 
 ```kotlin
-import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
-
 engine.highlightBothThemes(
     code       = sourceCode,
     language   = "typescript",
@@ -100,65 +111,11 @@ engine.highlightBothThemes(
 }
 ```
 
-## `HighlightResult`
-
-| Property | Description |
-|---|---|
-| `annotated` | The highlighted `AnnotatedString` |
-| `spanCount` | Number of style spans. `0` = silent failure (unsupported language or empty code) |
-| `language` | The language identifier that was highlighted |
-| `durationMs` | Total wall-clock time in milliseconds |
-| `timings` | Per-stage `HighlightTimings` (jsBridge, jsonUnescape, htmlParse, treeWalk, themeParse, total) |
-
-## `ThemedHighlightResult`
-
-Returned by `highlightBothThemes()`. Holds both light and dark variants produced from a single JS tokenization pass.
-
-| Property | Description |
-|---|---|
-| `light` | Syntax-highlighted `AnnotatedString` styled with the light theme |
-| `dark` | Syntax-highlighted `AnnotatedString` styled with the dark theme |
-| `durationMs` | Total wall-clock time in milliseconds for the full highlight call |
-| `timings` | Per-stage `HighlightTimings` breakdown (same fields as `HighlightResult.timings`) |
-
-## `HighlightLanguageInfo`
-
-Returned by `getLanguage()`. Contains the human-readable display name and registered aliases for a language.
-
-| Property | Description |
-|---|---|
-| `name` | Human-readable display name (e.g. `"Kotlin"`, `"Python"`) - not the language identifier |
-| `aliases` | Registered Highlight.js aliases (e.g. `["kt", "kts"]`) |
-
-```kotlin
-engine.getLanguage("kt").onSuccess { info ->
-    if (info != null) {
-        println("Name: ${info.name}")       // "Kotlin"
-        println("Aliases: ${info.aliases}") // [kt, kts]
-    } else {
-        println("Language not found")
-    }
-}
-```
-
-## `AutoHighlightResult`
-
-Returned by `highlightAuto()`. Contains the highlighted output and the language hljs detected.
-
-| Property | Description |
-|---|---|
-| `annotated` | The highlighted `AnnotatedString` |
-| `detectedLanguage` | Language hljs guessed (may be an empty string if detection failed) |
-| `spanCount` | Number of style spans applied |
-| `durationMs` | Total wall-clock time in milliseconds |
-| `timings` | Per-stage `HighlightTimings` breakdown |
-
 ## Language lookup and auto-detection
 
-### `getLanguage()`
+Use `getLanguage()` to validate names and inspect aliases:
 
 ```kotlin
-// Check if a language is recognized and inspect its aliases
 engine.getLanguage("ts").onSuccess { info ->
     if (info != null) {
         // info.name    = "TypeScript"
@@ -167,23 +124,18 @@ engine.getLanguage("ts").onSuccess { info ->
 }
 ```
 
-### `highlightAuto()`
-
-Use when the language is unknown - hljs will attempt to detect it:
+Use `highlightAuto()` when language is unknown:
 
 ```kotlin
 engine.highlightAuto(code, theme).onSuccess { result ->
-    val language = result.detectedLanguage // e.g. "python" or "" if undetected
+    val language = result.detectedLanguage
     Text(text = result.annotated)
 }
 ```
 
-## `rememberHighlightEngine`
+## Common pitfalls
 
-```kotlin
-@Composable
-fun rememberHighlightEngine(): HighlightEngine
-```
-
-- **Inside `HighlightThemeProvider`**: returns the shared engine (no extra WebView).
-- **Outside a provider**: creates a standalone engine, destroys it when the composable leaves composition.
+- Forgetting `applicationContext` can leak short-lived contexts.
+- Forgetting `close()` in non-Compose code can keep WebView resources alive.
+- Treating `Result.failure` as exceptional flow from the API point of view; this is expected
+  error signaling for this library.

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -41,7 +41,7 @@ In Compose, use `rememberHighlightEngine()` so cleanup is handled automatically.
 ## Core operations
 
 - `initialize()` - optional warm-up to reduce first highlight latency.
-- `highlight()` - highlight one language and return `AnnotatedString` with timings.
+- `highlight()` - highlight one language and return `Result<HighlightResult>` containing the `AnnotatedString` and timings.
 - `highlightBothThemes()` - tokenize once and generate light and dark variants.
 - `highlightToHtml()` - get highlighted HTML directly.
 - `supportedLanguages()` and `highlightJsVersion()` - runtime capability introspection.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,24 +6,24 @@ This section documents the public API of `compose-highlight`.
 |---|---|
 | [`SyntaxHighlightedCode`](syntax-highlighted-code.md) | Primary composable - renders a styled, highlighted code block |
 | [`SyntaxHighlightedTextEditor`](syntax-highlighted-text-editor.md) | **Experimental** - editable code field with live syntax highlighting as the user types |
-| [`HighlightThemeProvider`](syntax-highlighted-code.md#highlightthemeprovider) | Provides a shared theme and engine to a composable subtree |
+| [`HighlightThemeProvider`](syntax-highlighted-code.md) | Provides a shared theme and engine to a composable subtree |
 | [`CodeBlockStyle`](code-block-style.md) | Visual style configuration (shape, padding, font, copy button size) |
 | [`SyntaxHighlightedCodeDefaults`](code-block-style.md#syntaxhighlightedcodedefaults) | Default constants and helper composables (`CopyButton`, `LanguageLabel`) |
 | [`HighlightTheme`](highlight-theme.md) | Theme model backed by a Highlight.js CSS file |
 | [`HighlightEngine`](highlight-engine.md) | Lower-level engine for custom highlighting pipelines |
 | [`HighlightLanguage`](highlight-language.md) | Maps file extensions to Highlight.js language identifiers |
-| [`HighlightResult`](highlight-engine.md#highlightresult) | Result of `HighlightEngine.highlight()` - annotated string, span count, timing |
-| [`ThemedHighlightResult`](highlight-engine.md#themedhighlightresult) | Result of `HighlightEngine.highlightBothThemes()` - light and dark variants |
-| [`AutoHighlightResult`](highlight-engine.md#autohighlightresult) | Result type returned by `HighlightEngine.highlightAuto()` |
+| [`HighlightResult`](highlight-engine.md) | Result of `HighlightEngine.highlight()` - annotated string, span count, timing |
+| [`ThemedHighlightResult`](highlight-engine.md) | Result of `HighlightEngine.highlightBothThemes()` - light and dark variants |
+| [`AutoHighlightResult`](highlight-engine.md) | Result type returned by `HighlightEngine.highlightAuto()` |
 | [`HighlightTimings`](../guides/performance.md#timing-callbacks) | Per-stage timing breakdown (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) |
-| [`HighlightLanguageInfo`](highlight-engine.md#highlightlanguageinfo) | Metadata returned by `HighlightEngine.getLanguage()` |
+| [`HighlightLanguageInfo`](highlight-engine.md) | Metadata returned by `HighlightEngine.getLanguage()` |
 | [`HighlightException`](highlight-engine.md) | Sealed exception hierarchy for all engine errors |
-| [`ExperimentalHighlightApi`](syntax-highlighted-text-editor.md#experimentalhighlightapi) | Opt-in annotation for experimental APIs |
-| [`rememberHighlightedCode`](syntax-highlighted-code.md#rememberhighlightedcode) | Composable helper - highlights code and returns an `AnnotatedString` state |
-| [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md#rememberhighlightedcodeboththemes) | Highlights once, produces light + dark variants |
-| [`rememberSyntaxHighlightedEditorValue`](syntax-highlighted-text-editor.md#remembersyntaxhighlightededitorvalue) | **Experimental** - pipeline helper for live editor highlighting; returns `TextFieldValue` with spans applied |
-| [`SyntaxHighlightedTextEditorDefaults`](syntax-highlighted-text-editor.md#syntaxhighlightedtexteditordefaults) | **Experimental** - pre-allocated `DefaultTextStyle` and `DEBOUNCE_MS` constants for the editor |
-| [`rememberHighlightEngine`](highlight-engine.md#rememberhighlightengine) | Returns the shared or standalone `HighlightEngine` for the current composition |
+| [`ExperimentalHighlightApi`](syntax-highlighted-text-editor.md) | Opt-in annotation for experimental APIs |
+| [`rememberHighlightedCode`](syntax-highlighted-code.md) | Composable helper - highlights code and returns an `AnnotatedString` state |
+| [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md) | Highlights once, produces light + dark variants |
+| [`rememberSyntaxHighlightedEditorValue`](syntax-highlighted-text-editor.md) | **Experimental** - pipeline helper for live editor highlighting; returns `TextFieldValue` with spans applied |
+| [`SyntaxHighlightedTextEditorDefaults`](syntax-highlighted-text-editor.md) | **Experimental** - pre-allocated `DefaultTextStyle` and `DEBOUNCE_MS` constants for the editor |
+| [`rememberHighlightEngine`](highlight-engine.md) | Returns the shared or standalone `HighlightEngine` for the current composition |
 | `rememberTomorrowTheme` | Composable factory for the built-in Tomorrow (light) theme |
 | `rememberTomorrowNightTheme` | Composable factory for the built-in Tomorrow Night (dark) theme |
 | `rememberAtomOneDarkTheme` | Composable factory for the built-in Atom One Dark theme |

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -1,53 +1,36 @@
 # SyntaxHighlightedCode
 
-The primary public composable. Displays syntax-highlighted code in a styled block.
+The primary public composable for rendering syntax-highlighted code blocks in Compose.
 
-Shows unstyled monospace code immediately while async highlighting runs, then fades in the highlighted version when ready - no visible flicker.
+It shows plain monospace text immediately, then swaps to highlighted text when async highlighting
+completes. This keeps first paint fast and avoids visible flicker.
 
-## Signature
+Full API in Dokka:
 
-```kotlin
-import dev.hossain.highlight.engine.HighlightResult
-import dev.hossain.highlight.engine.HighlightTheme
-import dev.hossain.highlight.ui.CodeBlockStyle
+- [`SyntaxHighlightedCode`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-syntax-highlighted-code.html)
+- [`HighlightThemeProvider`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-highlight-theme-provider.html)
+- [`rememberHighlightedCode`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-highlighted-code.html)
+- [`rememberHighlightedCodeBothThemes`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-highlighted-code-both-themes.html)
 
-@Composable
-fun SyntaxHighlightedCode(
-    code: String,
-    language: String,
-    modifier: Modifier = Modifier,
-    theme: HighlightTheme = LocalHighlightTheme.current,
-    style: CodeBlockStyle = CodeBlockStyle.Default,
-    showLineNumbers: Boolean = false,
-    languageLabel: (@Composable () -> Unit)? = /* default badge */,
-    copyButton: (@Composable (onClick: () -> Unit) -> Unit)? = /* default button */,
-    onCopyClick: ((String) -> Unit)? = null,
-    onHighlightComplete: ((HighlightResult) -> Unit)? = null,
-    onError: ((HighlightException) -> Unit)? = null,
-    placeholder: (@Composable (code: String) -> Unit)? = null,
-)
-```
+## When to use it
 
-## Parameters
+- You want a ready-made code block UI with language badge and copy button.
+- You want theme-aware code rendering with minimal setup.
+- You prefer built-in loading behavior and error fallback over wiring a custom pipeline.
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `code` | `String` | - | Source code to display |
-| `language` | `String` | - | Highlight.js language identifier (e.g. `"kotlin"`, `"python"`) |
-| `modifier` | `Modifier` | `Modifier` | Modifier for the outer container |
-| `theme` | `HighlightTheme` | `LocalHighlightTheme.current` | Theme to use. Throws if no `HighlightThemeProvider` is present and no explicit theme is passed |
-| `style` | `CodeBlockStyle` | `CodeBlockStyle.Default` | Visual style - shape, padding, font, copy button size |
-| `showLineNumbers` | `Boolean` | `false` | Whether to show a line-number gutter |
-| `languageLabel` | `(@Composable () -> Unit)?` | Default badge | Header language badge slot. `null` hides it |
-| `copyButton` | `(@Composable (onClick: () -> Unit) -> Unit)?` | Default button | Header copy button slot. `null` hides it |
-| `onCopyClick` | `((String) -> Unit)?` | `null` | Custom copy handler. If `null`, copies to system clipboard |
-| `onHighlightComplete` | `((HighlightResult) -> Unit)?` | `null` | Callback invoked with timing and span count after successful highlighting |
-| `onError` | `((HighlightException) -> Unit)?` | `null` | Callback invoked when highlighting fails. Falls back to plain text; purely observational |
-| `placeholder` | `(@Composable (code: String) -> Unit)?` | `null` | Composable rendered while highlighting is in progress. `null` shows raw unstyled code (default behavior) |
+## Key parameters
 
-## Usage
+- `language` - highlight.js language id (`"kotlin"`, `"python"`, `"sql"`, etc).
+- `theme` - pass explicitly, or rely on `HighlightThemeProvider`.
+- `style` - controls code block visuals (`CodeBlockStyle`).
+- `showLineNumbers` - enables line-number gutter.
+- `languageLabel` and `copyButton` - slots for header customization, or `null` to hide.
+- `placeholder` - custom loading content while highlighting is in progress.
+- `onHighlightComplete` and `onError` - observability hooks for metrics and diagnostics.
 
-### With `HighlightThemeProvider` (recommended)
+## Recommended patterns
+
+### Use with `HighlightThemeProvider` (recommended)
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
@@ -159,27 +142,11 @@ SyntaxHighlightedCode(
 )
 ```
 
----
+## Why `HighlightThemeProvider` matters
 
-## HighlightThemeProvider
-
-Provides a `HighlightTheme` and a shared `HighlightEngine` to all `SyntaxHighlightedCode` composables in its subtree.
-
-```kotlin
-import dev.hossain.highlight.engine.HighlightTheme
-import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
-
-@Composable
-fun HighlightThemeProvider(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    lightHighlightTheme: HighlightTheme = rememberTomorrowTheme(),
-    darkHighlightTheme: HighlightTheme = rememberTomorrowNightTheme(),
-    content: @Composable () -> Unit,
-)
-```
-
-Creates **one shared WebView** for the entire subtree. Screens with multiple `SyntaxHighlightedCode` blocks share this single WebView instead of creating one per block - saving ~200 ms warm-up time and ~2-4 MB RAM per extra block.
+`HighlightThemeProvider` creates one shared `HighlightEngine` (one hidden WebView) for its subtree.
+If you render multiple code blocks on one screen, this avoids creating one WebView per block and
+reduces warm-up cost and memory overhead.
 
 ### Force a specific theme mode
 
@@ -195,23 +162,13 @@ HighlightThemeProvider(
 ) { ... }
 ```
 
-## `rememberHighlightedCode`
+## Lower-level Compose helpers
 
-Highlights code in a composable and returns `State<AnnotatedString?>`.
+Use these when you want custom rendering but still want the library's highlight pipeline.
 
-```kotlin
-@Composable
-fun rememberHighlightedCode(
-    code: String,
-    language: String,
-    theme: HighlightTheme = LocalHighlightTheme.current,
-    onHighlightComplete: ((HighlightResult) -> Unit)? = null,
-    onError: ((HighlightException) -> Unit)? = null,
-): State<AnnotatedString?>
-```
+### `rememberHighlightedCode`
 
-Returns `null` while highlighting is still running or if highlighting fails, so callers should
-always render a plain-text fallback.
+Returns highlighted text as `State<AnnotatedString?>`. Render a plain-text fallback while `null`.
 
 ```kotlin
 val highlighted by rememberHighlightedCode(code = snippet, language = "kotlin")
@@ -219,7 +176,7 @@ val highlighted by rememberHighlightedCode(code = snippet, language = "kotlin")
 Text(text = highlighted ?: AnnotatedString(snippet))
 ```
 
-Use `onHighlightComplete` for metrics and `onError` for typed failure handling:
+Use `onHighlightComplete` for metrics and `onError` for typed failure handling.
 
 ```kotlin
 val highlighted by rememberHighlightedCode(
@@ -234,24 +191,10 @@ val highlighted by rememberHighlightedCode(
 )
 ```
 
-## `rememberHighlightedCodeBothThemes`
+### `rememberHighlightedCodeBothThemes`
 
-Highlights once and returns both light and dark variants as `State<ThemedHighlightResult?>`.
-
-```kotlin
-@Composable
-fun rememberHighlightedCodeBothThemes(
-    code: String,
-    language: String,
-    lightTheme: HighlightTheme = LocalLightHighlightTheme.current,
-    darkTheme: HighlightTheme = LocalDarkHighlightTheme.current,
-    onHighlightComplete: ((ThemedHighlightResult) -> Unit)? = null,
-    onError: ((HighlightException) -> Unit)? = null,
-): State<ThemedHighlightResult?>
-```
-
-This is the Compose helper for zero-extra-latency theme switching. It tokenizes the source once,
-then applies both color maps to the same HTML result.
+Highlights once, then returns both light and dark `AnnotatedString` variants so UI theme switching
+can happen without extra highlight latency.
 
 ```kotlin
 val themed by rememberHighlightedCodeBothThemes(
@@ -265,5 +208,5 @@ Text(
 )
 ```
 
-Inside `HighlightThemeProvider`, `lightTheme` and `darkTheme` default from the provider. Outside a
+Inside `HighlightThemeProvider`, light and dark themes default from the provider. Outside a
 provider, pass both themes explicitly.

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -1,56 +1,36 @@
 # SyntaxHighlightedTextEditor
 
 !!! warning "Experimental API"
-    This composable is annotated with [`@ExperimentalHighlightApi`](#experimentalhighlightapi).
-    Its parameter surface may change or be removed in a future release without a deprecation cycle.
-    Callers must explicitly opt in - see [Opting in](#opting-in).
+    This composable is annotated with [`@ExperimentalHighlightApi`](#opting-in).
+    The API surface may change without a deprecation cycle.
 
-An editable code field built on `BasicTextField` with live syntax highlighting. As the user types,
-highlighting updates in the background after a short debounce. Cursor position and text selection
-are always preserved.
+`SyntaxHighlightedTextEditor` is an editable code field (built on `BasicTextField`) with live
+syntax highlighting. As users type, highlighting updates after a short debounce while preserving
+cursor and selection.
 
-## Signature
+Full API in Dokka:
 
-```kotlin
-import dev.hossain.highlight.ui.ExperimentalHighlightApi
-import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
+- [`SyntaxHighlightedTextEditor`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-syntax-highlighted-text-editor.html)
+- [`rememberSyntaxHighlightedEditorValue`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-syntax-highlighted-editor-value.html)
+- [`SyntaxHighlightedTextEditorDefaults`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-syntax-highlighted-text-editor-defaults/index.html)
+- [`ExperimentalHighlightApi`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-experimental-highlight-api/index.html)
 
-@ExperimentalHighlightApi
-@Composable
-fun SyntaxHighlightedTextEditor(
-    value: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit,
-    language: String,
-    modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(0.dp),
-    shape: Shape = RectangleShape,
-    theme: HighlightTheme = LocalHighlightTheme.current,
-    textStyle: TextStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle,
-    debounceMs: Long = SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS,
-    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
-    onError: ((HighlightException) -> Unit)? = null,
-)
-```
+## When to use it
 
-## Parameters
+- You want an editable code field with built-in async highlighting.
+- You want a ready-made `Surface` plus `BasicTextField` wrapper.
+- You want to keep editor state (`TextFieldValue`) while highlighting updates in background.
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `TextFieldValue` | - | Current value including text, cursor position, and selection |
-| `onValueChange` | `(TextFieldValue) -> Unit` | - | Called whenever the user edits the text or moves the cursor |
-| `language` | `String` | - | Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"sql"`) |
-| `modifier` | `Modifier` | `Modifier` | Applied to the outer `Surface`. Do **not** add `.padding()` here - use `contentPadding` |
-| `contentPadding` | `PaddingValues` | `PaddingValues(0.dp)` | Padding applied inside the `Surface`, between the background edge and the text |
-| `shape` | `Shape` | `RectangleShape` | Clips the `Surface` background. Must match any `.border()` shape in `modifier` |
-| `theme` | `HighlightTheme` | `LocalHighlightTheme.current` | Theme to use. Throws if no `HighlightThemeProvider` is present and no explicit theme is passed |
-| `textStyle` | `TextStyle` | [`SyntaxHighlightedTextEditorDefaults.DefaultTextStyle`](#syntaxhighlightedtexteditordefaults) (monospace) | Text style for the editor. The theme's foreground color is merged on top. Pre-allocated singleton; copy it to derive customised styles |
-| `debounceMs` | `Long` | [`SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS`](#syntaxhighlightedtexteditordefaults) (`150`) | Milliseconds to wait after the last keystroke before triggering a highlight call. If `debounceMs` changes, the new value is used on the next keystroke; the currently running debounce window is unaffected |
-| `onHighlightComplete` | `((AnnotatedString) -> Unit)?` | `null` | Called each time a highlight cycle completes. Receives the highlighted `AnnotatedString`. Useful for testing or observing the output without owning the text state |
-| `onError` | `((HighlightException) -> Unit)?` | `null` | Called when a highlight cycle fails. The editor falls back to plain text on failure regardless; this callback is purely observational. Use it to log failures, surface a snackbar, or record analytics |
+## Key parameters
+
+- `value` and `onValueChange` - editor state and updates.
+- `language` - highlight.js language id.
+- `theme` - explicit theme or value from `HighlightThemeProvider`.
+- `debounceMs` - typing pause before highlight call.
+- `contentPadding` and `shape` - layout and clipping of editor surface.
+- `onHighlightComplete` and `onError` - observability hooks.
 
 ## Opting in
-
-The composable is marked `@ExperimentalHighlightApi`. Use one of the following patterns:
 
 ```kotlin
 // Option 1 - opt in at the call site
@@ -60,18 +40,18 @@ fun MyScreen() {
     SyntaxHighlightedTextEditor(...)
 }
 
-// Option 2 - propagate the requirement to your own API
+// Option 2 - propagate to your own API
 @ExperimentalHighlightApi
 @Composable
 fun MyEditorScreen() {
     SyntaxHighlightedTextEditor(...)
 }
 
-// Option 3 - opt in for an entire file (place before the package statement)
+// Option 3 - file-wide opt-in (before package statement)
 @file:OptIn(ExperimentalHighlightApi::class)
 ```
 
-## Usage
+## Recommended usage
 
 ### With `HighlightThemeProvider` (recommended)
 
@@ -92,13 +72,13 @@ fun EditorScreen() {
         darkHighlightTheme  = rememberTomorrowNightTheme(),
     ) {
         SyntaxHighlightedTextEditor(
-            value         = editorValue,
-            onValueChange = { editorValue = it },
-            language      = "kotlin",
-            modifier      = Modifier
+            value          = editorValue,
+            onValueChange  = { editorValue = it },
+            language       = "kotlin",
+            modifier       = Modifier
                 .fillMaxWidth()
                 .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)),
-            shape         = RoundedCornerShape(8.dp),
+            shape          = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(12.dp),
         )
     }
@@ -122,167 +102,40 @@ fun SqlEditor() {
 }
 ```
 
-## How it works
+## How the highlight pipeline behaves
 
-`SyntaxHighlightedTextEditor` delegates all pipeline logic to [`rememberSyntaxHighlightedEditorValue()`](#remembersyntaxhighlightededitorvalue)
-and renders the result in a `Surface` + `BasicTextField` layout.
+`SyntaxHighlightedTextEditor` delegates pipeline logic to
+`rememberSyntaxHighlightedEditorValue()` and renders the returned value in a `Surface` plus
+`BasicTextField` wrapper.
 
-Inside `rememberSyntaxHighlightedEditorValue`:
+Core behavior:
 
-1. A `LaunchedEffect` keyed on `(value.text, language, theme)` waits for `debounceMs` milliseconds,
-   then calls `HighlightEngine.highlight()`. Rapid keystrokes cancel the previous coroutine so only
-   one call fires after the user pauses.
-2. The result is stored as a `HighlightSnapshot(annotated, language, theme)` - a private data class
-   that bundles the highlighted text together with the language and theme that produced it.
-3. Stale snapshot detection is **in-composition**: if `snapshot.language != language` or
-   `snapshot.theme != theme`, the composable falls back to plain text immediately - no separate
-   `LaunchedEffect` is needed to clear state.
-4. While a new result is in flight the composable uses one of three display strategies:
-   - **No cached result** - plain monospace text (first render or after language/theme change)
-   - **Cached text matches current text** - applies the full cached span set (steady state)
-   - **Text changed since last result** - applies old spans using prefix/suffix analysis:
-     - Spans on unchanged text **before** the edit are kept at their original coordinates.
-     - Spans on unchanged text **after** the edit (lines below the cursor) are shifted by the
-       length delta.
-     - Spans **straddling prefix + edited region + suffix** (large tokens like multi-line
-       strings, block comments, or template literals that span the edit) keep BOTH unchanged
-       tails: the prefix tail at original coordinates and the suffix tail shifted by delta.
-     - Spans whose start lies in the edited region are dropped (the start position is
-       invalidated by the edit, so partial revival is unsafe).
+1. A debounce window waits `debounceMs` after typing stops, then calls `HighlightEngine.highlight()`.
+2. Rapid keystrokes cancel prior coroutine work, so only the latest text is highlighted.
+3. Stale snapshot checks keep language and theme changes safe.
+4. While new results are in flight, previously computed spans are reused where valid, so only the
+   actively edited region is briefly unstyled.
 
-   Only the characters being actively typed are briefly unstyled.
+## Common pitfalls
 
-## Notes
+- Use `contentPadding` for inner spacing; `.padding()` on `modifier` changes outer layout instead.
+- Keep `shape` aligned with any border shape to avoid background bleed at rounded corners.
+- Outside `HighlightThemeProvider`, a standalone engine/WebView is created and managed by lifecycle.
 
-- **`contentPadding` vs `.padding()` on modifier** - padding added via `modifier` shrinks the
-  `Surface` layout area, leaving a gap between the border and the background. Always use
-  `contentPadding` to ensure the theme background fills the full bordered area.
-- **`shape` must match the border shape** - `Surface` clips its background to `shape`. If you
-  draw a rounded border via `modifier`, pass the same `RoundedCornerShape` as `shape` so the
-  background does not bleed past the rounded corners.
-- **Cursor and selection are always preserved** - highlighting calls `value.copy(annotatedString = ...)`
-  which keeps the `selection` and `composition` fields untouched.
-- **Uses the shared WebView** when called inside a `HighlightThemeProvider`. Outside a provider a
-  standalone `HighlightEngine` (and WebView) is created and destroyed with the composable's lifecycle.
+## Lower-level helper for custom text fields
 
----
-
-## rememberSyntaxHighlightedEditorValue
-
-A lower-level `@Composable` helper that runs the debounce + highlight pipeline and returns the
-display `TextFieldValue` directly - without rendering any layout. Use this when you want to bring
-your own text field (`OutlinedTextField`, a third-party editor, etc.) instead of the built-in
-`Surface` + `BasicTextField` wrapper.
-
-`SyntaxHighlightedTextEditor` calls this function internally. They share the same behavior.
-
-### Signature
-
-```kotlin
-import dev.hossain.highlight.ui.ExperimentalHighlightApi
-import dev.hossain.highlight.ui.rememberSyntaxHighlightedEditorValue
-
-@ExperimentalHighlightApi
-@Composable
-fun rememberSyntaxHighlightedEditorValue(
-    value: TextFieldValue,
-    language: String,
-    theme: HighlightTheme = LocalHighlightTheme.current,
-    debounceMs: Long = SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS,
-    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
-    onError: ((HighlightException) -> Unit)? = null,
-): TextFieldValue
-```
-
-The `onError` callback receives a typed [`HighlightException`](highlight-engine.md) on
-failure. Possible subtypes: `Timeout`, `JsExecutionFailed`, `WebViewInitFailed`, `HtmlParseFailed`. The
-helper falls back to plain text regardless of whether the callback is set.
-
-The returned `TextFieldValue` is recomputed each time a new highlight result arrives. Because this
-function returns a non-Unit type, the Compose compiler marks it **non-restartable** - all internal
-state reads automatically subscribe the caller's recompose scope. Use it like any other composable
-helper:
+Use `rememberSyntaxHighlightedEditorValue()` when you want your own field component
+(`OutlinedTextField`, third-party editor, etc.) and only need highlighted `TextFieldValue` output.
 
 ```kotlin
 val displayValue = rememberSyntaxHighlightedEditorValue(
     value    = editorValue,
     language = "kotlin",
 )
-```
 
-### Usage - custom text field
-
-```kotlin
-@OptIn(ExperimentalHighlightApi::class)
-@Composable
-fun MyEditor() {
-    var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
-
-    HighlightThemeProvider(
-        lightHighlightTheme = rememberTomorrowTheme(),
-        darkHighlightTheme  = rememberTomorrowNightTheme(),
-    ) {
-        val displayValue = rememberSyntaxHighlightedEditorValue(
-            value    = editorValue,
-            language = "kotlin",
-        )
-        OutlinedTextField(
-            value         = displayValue,
-            onValueChange = { editorValue = it },
-            label         = { Text("Code") },
-        )
-    }
-}
-```
-
----
-
-## SyntaxHighlightedTextEditorDefaults
-
-Pre-allocated default values used by `SyntaxHighlightedTextEditor` and
-`rememberSyntaxHighlightedEditorValue`. Singletons here let parameter defaults reference a
-shared instance instead of constructing a fresh value per recomposition - relevant for an
-editor that recomposes on every keystroke.
-
-```kotlin
-import dev.hossain.highlight.ui.ExperimentalHighlightApi
-import dev.hossain.highlight.ui.SyntaxHighlightedTextEditorDefaults
-
-@ExperimentalHighlightApi
-object SyntaxHighlightedTextEditorDefaults {
-    val DefaultTextStyle: TextStyle = TextStyle(fontFamily = FontFamily.Monospace)
-    const val DEBOUNCE_MS: Long = 150L
-}
-```
-
-| Member | Description |
-|---|---|
-| `DefaultTextStyle` | Monospace `TextStyle`. Copy it (`DefaultTextStyle.copy(fontSize = 15.sp)`) to derive a customised style without re-declaring `fontFamily` |
-| `DEBOUNCE_MS` | Default debounce window: 150 ms |
-
-```kotlin
-val myEditorStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle.copy(fontSize = 15.sp)
-
-SyntaxHighlightedTextEditor(
-    value = editorValue,
+OutlinedTextField(
+    value         = displayValue,
     onValueChange = { editorValue = it },
-    language = "kotlin",
-    textStyle = myEditorStyle,
+    label         = { Text("Code") },
 )
 ```
-
----
-
-## ExperimentalHighlightApi
-
-`@RequiresOptIn` annotation used to mark APIs that are not yet stable. Callers must explicitly opt
-in with `@OptIn(ExperimentalHighlightApi::class)` or propagate the annotation to their own API.
-
-Currently applied to:
-
-- `SyntaxHighlightedTextEditor`
-- `rememberSyntaxHighlightedEditorValue`
-- `SyntaxHighlightedTextEditorDefaults`
-
-APIs marked `@ExperimentalHighlightApi` may change signature, behavior, or be removed in any
-future release without a deprecation cycle.


### PR DESCRIPTION
## What changed
This PR applies phase 1 of the docs reference cleanup to reduce duplication with Dokka API pages.

### Refactored pages (one commit per page)
- docs/reference/syntax-highlighted-code.md
- docs/reference/highlight-engine.md
- docs/reference/syntax-highlighted-text-editor.md

### Approach
- Removed exhaustive signature, parameter, method, and member duplication already covered by Dokka.
- Kept human-focused content: when to use, recommended patterns, examples, and pitfalls.
- Added explicit Full API in Dokka links near the top of each page.

### Follow-up included
- Updated docs/reference/index.md links to remove stale section anchors after the refactor.

## Validation
- zensical build --clean passes with no warnings.
