### PR TITLE
docs: reduce Dokka duplication in reference pages (phase 2)

### DIFF
--- a/docs/reference/code-block-style.md
+++ b/docs/reference/code-block-style.md
@@ -1,44 +1,30 @@
 # CodeBlockStyle
 
-Visual style configuration for `SyntaxHighlightedCode`.
+`CodeBlockStyle` controls the visual presentation of `SyntaxHighlightedCode`.
 
-## Properties
+Full API in Dokka:
 
-| Property | Type | Default | Description |
-|---|---|---|---|
-| `shape` | `Shape` | `RoundedCornerShape(8.dp)` | Shape applied to the outer container |
-| `padding` | `PaddingValues` | `PaddingValues(16.dp)` | Inner padding between container edge and code content |
-| `headerPadding` | `PaddingValues` | `PaddingValues(horizontal=16.dp, vertical=8.dp)` | Padding for the header row (language badge + copy button) |
-| `lineNumberColor` | `Color` | `Color.Unspecified` | Line number gutter text color. Unspecified = theme foreground at 40% opacity |
-| `lineNumberWidth` | `Dp` | `32.dp` | Width reserved for the line number gutter |
-| `copyButtonSize` | `Dp` | `32.dp` | Width and height of the copy button touch target |
-| `textStyle` | `TextStyle` | See below | Font family, size, line height for the code text |
-| `fallbackBackgroundColor` | `Color` | `Color(0xFF1E1E1E)` | Background color used when the active theme has no `.hljs { background: ... }` rule |
-| `fallbackTextColor` | `Color` | `Color(0xFFCCCCCC)` | Text color used when the active theme has no `.hljs { color: ... }` rule |
+- [`CodeBlockStyle`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-code-block-style/index.html)
+- [`SyntaxHighlightedCodeDefaults`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/-syntax-highlighted-code-defaults/index.html)
 
-The default `textStyle` is `SyntaxHighlightedCodeDefaults.codeTextStyle`: monospace font, 13 sp size, 20 sp line height.
+## When to customize it
 
-!!! note
-    The theme's foreground color is applied on top of `textStyle.color` at render time - any explicit `color` you set here is overridden by the active `HighlightTheme`.
+- You need denser or more spacious code blocks for your layout.
+- You want to align border radius, padding, and header density with your design system.
+- You need line-number and copy-button sizing adjustments for accessibility or compact UI.
 
 ## Presets
 
 ```kotlin
 import dev.hossain.highlight.ui.CodeBlockStyle
 
-// Standard - rounded corners, 16 dp padding
 CodeBlockStyle.Default
-
-// Compact - reduced padding for space-constrained layouts
 CodeBlockStyle.Compact
 ```
 
-## Custom style
+## Typical custom style
 
 ```kotlin
-import dev.hossain.highlight.ui.CodeBlockStyle
-import dev.hossain.highlight.ui.SyntaxHighlightedCode
-
 val myStyle = CodeBlockStyle(
     shape           = RoundedCornerShape(4.dp),
     padding         = PaddingValues(8.dp),
@@ -46,16 +32,13 @@ val myStyle = CodeBlockStyle(
     lineNumberWidth = 40.dp,
     copyButtonSize  = 24.dp,
 )
+
 SyntaxHighlightedCode(code = snippet, language = "bash", style = myStyle)
 ```
 
-## Custom typography
+## Typography customization
 
 ```kotlin
-import dev.hossain.highlight.ui.CodeBlockStyle
-import dev.hossain.highlight.ui.SyntaxHighlightedCode
-import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
-
 SyntaxHighlightedCode(
     code     = snippet,
     language = "kotlin",
@@ -69,77 +52,20 @@ SyntaxHighlightedCode(
 )
 ```
 
-## Copy button size
+!!! note
+    The active `HighlightTheme` applies foreground color at render time. Explicit
+    `textStyle.color` is overridden by theme color.
+
+## Recomposition guidance
+
+Wrap inline style creation in `remember` to avoid creating new style objects every recomposition.
 
 ```kotlin
-import dev.hossain.highlight.ui.CodeBlockStyle
-import dev.hossain.highlight.ui.SyntaxHighlightedCode
-
-SyntaxHighlightedCode(
-    code  = snippet,
-    language = "kotlin",
-    style = CodeBlockStyle(copyButtonSize = 48.dp),
-)
-```
-
-Wrap inline styles in `remember` to avoid unnecessary recompositions:
-
-```kotlin
-import dev.hossain.highlight.ui.CodeBlockStyle
-
 val myStyle = remember { CodeBlockStyle(padding = PaddingValues(8.dp)) }
 ```
 
----
+## Common pitfalls
 
-## SyntaxHighlightedCodeDefaults
-
-Object providing default constants and helper composables.
-
-| Member | Description |
-|---|---|
-| `codeTextStyle` | Default `TextStyle`: monospace, 13 sp, 20 sp line height |
-| `shape` | Default shape: `RoundedCornerShape(8.dp)` |
-| `padding` | Default padding: `PaddingValues(16.dp)` |
-| `headerPadding` | Default header padding: `PaddingValues(horizontal=16.dp, vertical=8.dp)` |
-| `lineNumberWidth` | Default gutter width: `32.dp` |
-| `copyButtonSize` | Default copy button size: `32.dp` |
-| `fallbackBackgroundColor` | Default fallback background: `Color(0xFF1E1E1E)` (dark). Used when the active theme has no `.hljs { background }` rule |
-| `fallbackTextColor` | Default fallback text color: `Color(0xFFCCCCCC)` (light gray). Used when the active theme has no `.hljs { color }` rule |
-| `CopyButton(onClick, tint, contentDescription, size)` | Default copy button composable (renders `⧉` icon) |
-| `LanguageLabel(language, color, fontSize)` | Default language badge composable |
-
-### Using `CopyButton` with custom accessibility label
-
-```kotlin
-import dev.hossain.highlight.ui.SyntaxHighlightedCode
-import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
-
-SyntaxHighlightedCode(
-    code = snippet,
-    language = "kotlin",
-    copyButton = { onClick ->
-        SyntaxHighlightedCodeDefaults.CopyButton(
-            onClick            = onClick,
-            contentDescription = stringResource(R.string.copy_code_label),
-        )
-    },
-)
-```
-
-### Toggling the language label at runtime
-
-```kotlin
-import dev.hossain.highlight.ui.SyntaxHighlightedCode
-import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
-
-var showLabel by remember { mutableStateOf(true) }
-
-SyntaxHighlightedCode(
-    code = snippet,
-    language = "kotlin",
-    languageLabel = if (showLabel) {
-        { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
-    } else null,
-)
-```
+- Overriding `textStyle.color` and expecting it to win over theme foreground.
+- Using too-small `copyButtonSize` and reducing touch target usability.
+- Mismatched `shape` and outer container decoration, causing clipped or inconsistent edges.

--- a/docs/reference/highlight-language.md
+++ b/docs/reference/highlight-language.md
@@ -1,18 +1,26 @@
 # HighlightLanguage
 
-A pure-Kotlin helper that maps file extensions to Highlight.js language identifiers.
+`HighlightLanguage` is a pure Kotlin helper that maps file extensions to highlight.js language
+identifiers.
 
-This is a **convenience helper only**. The `language` parameter on `SyntaxHighlightedCode` and `HighlightEngine.highlight()` is still a plain `String` - you can always pass any Highlight.js language name directly. `HighlightLanguage` just makes it easier to resolve the right name from a file extension.
+It is a convenience API. `SyntaxHighlightedCode` and `HighlightEngine.highlight()` still accept a
+plain `String` language id, so you can always pass supported highlight.js names directly.
 
-## `fromExtension()`
+Full API in Dokka:
 
-```kotlin
-fun fromExtension(extension: String): String?
-```
+- [`HighlightLanguage`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-language/index.html)
 
-Returns the Highlight.js language identifier for the given file extension (without a leading dot), or `null` if the extension is not recognized.
+## When to use it
 
-The lookup is case-insensitive and locale-safe (uses `Locale.ROOT`).
+- You have filenames or file extensions and need a best-effort language id.
+- You want locale-safe, case-insensitive extension lookup.
+- You want a simple fallback to `plaintext` for unknown extensions.
+
+## Core behavior
+
+- `fromExtension(extension)` returns a highlight.js language id or `null`.
+- Lookup is case-insensitive and locale-safe (`Locale.ROOT`).
+- Pass extension without a leading dot.
 
 ```kotlin
 HighlightLanguage.fromExtension("kt")   // "kotlin"
@@ -21,12 +29,11 @@ HighlightLanguage.fromExtension("py")   // "python"
 HighlightLanguage.fromExtension("xyz")  // null
 ```
 
-## Usage - resolve language from a filename
+## Recommended usage pattern
 
 ```kotlin
 val file = File("MainActivity.kt")
-val extension = file.extension          // "kt"
-val language = HighlightLanguage.fromExtension(extension) ?: "plaintext"
+val language = HighlightLanguage.fromExtension(file.extension) ?: "plaintext"
 
 SyntaxHighlightedCode(
     code     = file.readText(),
@@ -34,86 +41,14 @@ SyntaxHighlightedCode(
 )
 ```
 
-## Supported extensions
+## Practical guidance
 
-Extensions are grouped by language family below.
+- Prefer mapping by extension only when language is not known from other metadata.
+- For user-selected languages, pass the chosen id directly.
+- For unknown or mixed content, consider `HighlightEngine.highlightAuto()` instead.
 
-| Extensions | Language |
-|---|---|
-| `kt`, `kts` | kotlin |
-| `java` | java |
-| `py`, `pyw`, `pyi` | python |
-| `js`, `mjs`, `cjs`, `jsx` | javascript |
-| `ts`, `mts`, `cts`, `tsx` | typescript |
-| `c`, `h` | c |
-| `cpp`, `cc`, `cxx`, `hpp`, `hh` | cpp |
-| `cs` | csharp |
-| `rs` | rust |
-| `go` | go |
-| `swift` | swift |
-| `rb`, `rbw` | ruby |
-| `php`, `phtml` | php |
-| `scala` | scala |
-| `groovy` | groovy |
-| `gradle` | gradle |
-| `dart` | dart |
-| `ex`, `exs` | elixir |
-| `erl`, `hrl` | erlang |
-| `hs`, `lhs` | haskell |
-| `fs`, `fsi`, `fsx` | fsharp |
-| `ml`, `mli` | ocaml |
-| `clj`, `cljs`, `cljc` | clojure |
-| `lua` | lua |
-| `r` | r |
-| `m`, `mm` | objectivec |
-| `pl`, `pm` | perl |
-| `sh`, `bash`, `zsh` | bash |
-| `ps1`, `psm1`, `psd1` | powershell |
-| `sql` | sql |
-| `html`, `htm` | html |
-| `xhtml`, `xml`, `svg`, `xsl` | xml |
-| `css` | css |
-| `scss` | scss |
-| `less` | less |
-| `json`, `jsonc` | json |
-| `yaml`, `yml` | yaml |
-| `toml` | toml |
-| `md`, `markdown` | markdown |
-| `dockerfile` | dockerfile |
-| `makefile`, `mk` | makefile |
-| `tex`, `latex` | latex |
-| `diff`, `patch` | diff |
-| `ini`, `cfg`, `conf` | ini |
-| `properties` | properties |
-| `vim` | vim |
-| `cmake` | cmake |
-| `proto` | protobuf |
-| `glsl` | glsl |
-| `bat`, `cmd` | dos |
-| `asm`, `s` | x86asm |
-| `graphql`, `gql` | graphql |
-| `txt` | plaintext |
-| `jl` | julia |
-| `nim`, `nims` | nim |
-| `vb` | vbnet |
-| `vbs` | vbscript |
-| `coffee` | coffeescript |
-| `wat` | wasm |
-| `haml` | haml |
-| `hbs`, `handlebars` | handlebars |
-| `styl` | stylus |
-| `cr` | crystal |
-| `elm` | elm |
-| `hx` | haxe |
-| `scm`, `ss` | scheme |
-| `qml` | qml |
-| `d` | d |
-| `f`, `f90`, `f95`, `for` | fortran |
-| `awk` | awk |
-| `tcl`, `tk` | tcl |
-| `lisp`, `lsp` | lisp |
-| `applescript`, `scpt` | applescript |
-| `nix` | nix |
-| `nginx` | nginx |
-| `pgsql` | pgsql |
-| `pro` | prolog |
+## Common pitfalls
+
+- Passing extension with dot (`".kt"`) instead of `"kt"`.
+- Assuming the helper mirrors every upstream highlight.js alias at all times.
+- Forgetting a fallback path (`?: "plaintext"`) for unknown extensions.

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -1,23 +1,29 @@
 # HighlightTheme
 
-Represents a syntax highlighting theme used by the engine to map `hljs-*` tokens to Compose `SpanStyle`s.
+`HighlightTheme` maps `hljs-*` token classes to Compose `SpanStyle` values used by the highlight
+pipeline.
 
-Theme initialization depends on how the theme is created:
+Full API in Dokka:
 
-- Built-ins (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) use precompiled color maps and do not parse CSS at runtime.
-- CSS-backed themes (`fromAsset`, `fromCss`) are lazy and parse CSS on first `colorMap` access.
-- Color-map themes (`fromColorMap`) use the provided map and do not parse CSS.
+- [`HighlightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-theme/index.html)
+- [`rememberTomorrowTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-theme.html)
+- [`rememberTomorrowNightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-night-theme.html)
+- [`rememberAtomOneDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-dark-theme.html)
+- [`rememberAtomOneLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-light-theme.html)
 
-## Built-in themes
+## When to use each theme source
 
-| Factory | Style | `remember` helper |
-|---|---|---|
-| `HighlightTheme.tomorrow()` | Light | `rememberTomorrowTheme()` |
-| `HighlightTheme.tomorrowNight()` | Dark | `rememberTomorrowNightTheme()` |
-| `HighlightTheme.atomOneDark()` | Dark | `rememberAtomOneDarkTheme()` |
-| `HighlightTheme.atomOneLight()` | Light | `rememberAtomOneLightTheme()` |
+- Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`): fastest setup,
+  precompiled maps, no CSS parsing at runtime.
+- `fromAsset(...)`: best for shipping a highlight.js CSS file with your app.
+- `fromCss(...)`: useful when CSS comes from network, config, or generated text.
+- `fromColorMap(...)`: best when you want full programmatic control, for example Material 3
+  dynamic color integration.
 
-Use the `remember*` helpers inside composables to keep stable theme instances across recompositions:
+## Recommended usage in Compose
+
+Use `remember*Theme()` helpers inside composables so the theme instance stays stable across
+recompositions.
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
@@ -30,38 +36,29 @@ HighlightThemeProvider(
 ) { ... }
 ```
 
-## Custom theme from an asset file
-
-Drop any [Highlight.js CSS theme](https://github.com/highlightjs/highlight.js/tree/main/src/styles) into `src/main/assets/themes/` and load it at runtime:
+## Custom theme from asset CSS
 
 ```kotlin
+import androidx.compose.ui.platform.LocalContext
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.ui.HighlightThemeProvider
-import androidx.compose.ui.platform.LocalContext
 
-// src/main/assets/themes/github.css  <- place the CSS here
 val appContext = LocalContext.current.applicationContext
 val theme = HighlightTheme.fromAsset(
     context   = appContext,
     assetPath = "themes/github.css",
     name      = "github",
 )
+
 HighlightThemeProvider(lightHighlightTheme = theme) { ... }
 ```
 
 !!! note
-    `HighlightTheme.fromAsset()` normalizes the passed `Context` to `applicationContext` internally.
-    Passing `applicationContext` at call sites is still recommended for clarity.
-
-!!! note
-    `fromAsset()` is lazy - CSS parsing happens on first use, not at factory-call time.
+    `fromAsset()` is lazy. CSS parsing happens on first theme usage, not at factory call time.
 
 ## Custom theme from raw CSS
 
 ```kotlin
-import dev.hossain.highlight.engine.HighlightTheme
-
-val css = // ... fetch from network or build programmatically
 val theme = HighlightTheme.fromCss(
     cssText = css,
     name    = "my-runtime-theme",
@@ -70,17 +67,7 @@ val theme = HighlightTheme.fromCss(
 
 ## Custom theme from a color map
 
-For full control - e.g. deriving colors from Material 3 dynamic color:
-
 ```kotlin
-import dev.hossain.highlight.engine.HighlightTheme
-
-val colorMap = mapOf(
-    "hljs"          to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
-    "hljs-keyword"  to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
-    "hljs-string"   to SpanStyle(color = Color(0xFF032F62)),
-    "hljs-comment"  to SpanStyle(color = Color(0xFF6A737D), fontStyle = FontStyle.Italic),
-)
 val theme = HighlightTheme.fromColorMap(
     name             = "my-dynamic-theme",
     colorMap         = colorMap,
@@ -89,31 +76,27 @@ val theme = HighlightTheme.fromColorMap(
 )
 ```
 
-## Theme identity
+## Theme identity behavior
 
-`HighlightTheme` uses both `name` and a content identity digest for `equals()` and `hashCode()`. This means:
+`HighlightTheme` equality is based on both `name` and content identity. This gives stable
+memoization while still triggering re-highlighting when CSS content changes.
 
-- Two themes with the same name **and** same CSS content are equal (memoization preserved)
-- Two themes with the same name but **different** CSS content are **not** equal (re-highlighting triggers correctly)
-- Two themes with different names are never equal
+- Same name and same CSS content -> equal.
+- Same name and different CSS content -> not equal.
+- Different names -> not equal.
 
 ```kotlin
 val light = HighlightTheme.fromCss(lightCss, "custom")
 val dark  = HighlightTheme.fromCss(darkCss,  "custom")
-light == dark  // false - same name but different CSS content
+light == dark  // false
 
 val a = HighlightTheme.fromCss(css, "custom")
 val b = HighlightTheme.fromCss(css, "custom")
-a == b         // true  - same name and same CSS content
+a == b         // true
 ```
 
-Compose APIs (`remember`, `LaunchedEffect`) correctly detect theme changes based on this combined identity.
+## Common pitfalls
 
-## Properties
-
-| Property | Description |
-|---|---|
-| `name` | Display name for this theme |
-| `colorMap` | Lazily parsed `Map<String, SpanStyle>` (hljs class name to style) |
-| `backgroundColor` | Background color from the `.hljs` CSS rule |
-| `defaultTextColor` | Default text color from the `.hljs` CSS rule |
+- Passing activity context to long-lived themes in non-Compose layers.
+- Expecting `fromAsset()` parse failures at construction time rather than first use.
+- Recreating custom themes every recomposition instead of `remember`ing stable instances.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,34 +1,34 @@
 # API Reference
 
-This section documents the public API of `compose-highlight`.
+Use this section as the human guide to the public API surface.
 
-| Class / Function | Description |
-|---|---|
-| [`SyntaxHighlightedCode`](syntax-highlighted-code.md) | Primary composable - renders a styled, highlighted code block |
-| [`SyntaxHighlightedTextEditor`](syntax-highlighted-text-editor.md) | **Experimental** - editable code field with live syntax highlighting as the user types |
-| [`HighlightThemeProvider`](syntax-highlighted-code.md) | Provides a shared theme and engine to a composable subtree |
-| [`CodeBlockStyle`](code-block-style.md) | Visual style configuration (shape, padding, font, copy button size) |
-| [`SyntaxHighlightedCodeDefaults`](code-block-style.md#syntaxhighlightedcodedefaults) | Default constants and helper composables (`CopyButton`, `LanguageLabel`) |
-| [`HighlightTheme`](highlight-theme.md) | Theme model backed by a Highlight.js CSS file |
-| [`HighlightEngine`](highlight-engine.md) | Lower-level engine for custom highlighting pipelines |
-| [`HighlightLanguage`](highlight-language.md) | Maps file extensions to Highlight.js language identifiers |
-| [`HighlightResult`](highlight-engine.md) | Result of `HighlightEngine.highlight()` - annotated string, span count, timing |
-| [`ThemedHighlightResult`](highlight-engine.md) | Result of `HighlightEngine.highlightBothThemes()` - light and dark variants |
-| [`AutoHighlightResult`](highlight-engine.md) | Result type returned by `HighlightEngine.highlightAuto()` |
-| [`HighlightTimings`](../guides/performance.md#timing-callbacks) | Per-stage timing breakdown (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) |
-| [`HighlightLanguageInfo`](highlight-engine.md) | Metadata returned by `HighlightEngine.getLanguage()` |
-| [`HighlightException`](highlight-engine.md) | Sealed exception hierarchy for all engine errors |
-| [`ExperimentalHighlightApi`](syntax-highlighted-text-editor.md) | Opt-in annotation for experimental APIs |
-| [`rememberHighlightedCode`](syntax-highlighted-code.md) | Composable helper - highlights code and returns an `AnnotatedString` state |
-| [`rememberHighlightedCodeBothThemes`](syntax-highlighted-code.md) | Highlights once, produces light + dark variants |
-| [`rememberSyntaxHighlightedEditorValue`](syntax-highlighted-text-editor.md) | **Experimental** - pipeline helper for live editor highlighting; returns `TextFieldValue` with spans applied |
-| [`SyntaxHighlightedTextEditorDefaults`](syntax-highlighted-text-editor.md) | **Experimental** - pre-allocated `DefaultTextStyle` and `DEBOUNCE_MS` constants for the editor |
-| [`rememberHighlightEngine`](highlight-engine.md) | Returns the shared or standalone `HighlightEngine` for the current composition |
-| `rememberTomorrowTheme` | Composable factory for the built-in Tomorrow (light) theme |
-| `rememberTomorrowNightTheme` | Composable factory for the built-in Tomorrow Night (dark) theme |
-| `rememberAtomOneDarkTheme` | Composable factory for the built-in Atom One Dark theme |
-| `rememberAtomOneLightTheme` | Composable factory for the built-in Atom One Light theme |
+These pages focus on:
 
----
+- when to use each API
+- recommended integration patterns
+- pitfalls and lifecycle/performance guidance
 
-For the full generated KDoc reference, see the [Dokka API Docs](https://hossain-khan.github.io/android-compose-highlight/api/).
+For exhaustive signatures, parameters, properties, and generated KDoc, use Dokka.
+
+## Human reference guides
+
+### UI APIs
+
+- [`SyntaxHighlightedCode`](syntax-highlighted-code.md) - primary read-only code block composable
+- [`SyntaxHighlightedTextEditor`](syntax-highlighted-text-editor.md) - experimental editable code field
+- [`CodeBlockStyle`](code-block-style.md) - visual styling for code block layout and density
+
+### Engine and theme APIs
+
+- [`HighlightEngine`](highlight-engine.md) - low-level highlighting pipeline and lifecycle control
+- [`HighlightTheme`](highlight-theme.md) - theme creation and identity behavior
+- [`HighlightLanguage`](highlight-language.md) - extension-to-language mapping helper
+
+## Full generated API (Dokka)
+
+- [Dokka API Docs](https://hossain-khan.github.io/android-compose-highlight/api/)
+
+Quick-entry Dokka pages:
+
+- [dev.hossain.highlight.ui](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/index.html)
+- [dev.hossain.highlight.engine](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/index.html)


### PR DESCRIPTION
## What changed
This PR applies phase 2 of the docs reference cleanup so reference pages stay human-focused while Dokka remains the source of truth for full API specs.

## Refactored files
- docs/reference/highlight-theme.md
- docs/reference/highlight-language.md
- docs/reference/code-block-style.md
- docs/reference/index.md

## Approach
- Removed large member/property dumps that duplicated Dokka pages.
- Kept practical guidance: when to use, recommended patterns, examples, and pitfalls.
- Added direct Dokka links at the top of each page.
- Reshaped reference/index.md into a guide hub plus clear Dokka gateway.

## Validation
- zensical build --clean passes with no warnings.
