### PR TITLE
docs: add docs build checks and reference authoring guardrails

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,34 +222,14 @@ dev.hossain:compose-highlight:<version>
 
 **Writing style - never use the em dash `-` character** in commit messages, code comments, KDoc, CHANGELOG entries, or any other text. Use a regular hyphen/minus `-` instead.
 
-## Docs site
+## Reference docs authoring
 
-The documentation site at https://hossain-khan.github.io/android-compose-highlight/ is built with two tools:
+The `docs/reference/` pages are human-facing guides, while Dokka is the source of truth for exhaustive API details.
 
-- **Zensical** (v0.0.43) - Static site generator for the main docs (Markdown in `docs/`). Configured via `zensical.toml`.
-- **Dokka** - Generates the Kotlin API reference under `docs/api/`, rethemed to match the Zensical chrome via `compose-highlight/dokka-theme/`.
-
-**Local preview:**
-```bash
-# Zensical docs site (main docs)
-zensical serve
-# Open http://localhost:8000
-
-# Dokka API reference (must serve over HTTP, not file://)
-./gradlew :compose-highlight:dokkaGenerate
-cd docs && python3 -m http.server 8765
-# Open http://localhost:8765/api/index.html
-```
-
-**Dokka retheme** (`compose-highlight/dokka-theme/`):
-- `dokka-zensical-chrome.js` - Injects Material-style header, sidebar, and footer around Dokka's content. Includes a "Back to Docs" link in the sidebar pointing to `../index.html`. All sidebar items are expanded by default.
-- `zensical-overrides.css` - Overrides Dokka's CSS variables to match Zensical's light/dark schemes.
-- `zensical-assets/` - Frozen copies of Zensical's Material CSS bundles (pinned by hash).
-- The palette toggle is synced between Zensical (`/`) and Dokka (`/api/`) via a shared localStorage key.
-
-**CI workflow** (`.github/workflows/docs.yml`): Generates Dokka API docs, builds Zensical site, deploys `site/` to GitHub Pages.
-
-**Updating Zensical CSS assets:** When Zensical is upgraded, copy the new hashed CSS files from `site/assets/stylesheets/modern/` into `compose-highlight/dokka-theme/zensical-assets/` and update the references in `compose-highlight/build.gradle.kts`. See `compose-highlight/dokka-theme/README.md` for the full refresh procedure.
+- Keep in `docs/reference/`: when to use an API, usage patterns, examples, and pitfalls.
+- Avoid duplicating full signatures, parameter tables, property tables, or method lists that Dokka already provides.
+- Include a "Full API in Dokka" link near the top of each reference page.
+- Validate docs changes with `zensical build --clean` and fix all link or anchor warnings before merging.
 
 ## Docs site
 
@@ -279,4 +259,3 @@ cd docs && python3 -m http.server 8765
 **CI workflow** (`.github/workflows/docs.yml`): Generates Dokka API docs, builds Zensical site, deploys `site/` to GitHub Pages.
 
 **Updating Zensical CSS assets:** When Zensical is upgraded, copy the new hashed CSS files from `site/assets/stylesheets/modern/` into `compose-highlight/dokka-theme/zensical-assets/` and update the references in `compose-highlight/build.gradle.kts`. See `compose-highlight/dokka-theme/README.md` for the full refresh procedure.
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for code changes
+      - name: Check for code and docs changes
         id: changes
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -35,6 +35,7 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
           CODE_CHANGED=false
+          DOCS_CHANGED=false
           while IFS= read -r file; do
             if [[ "$file" == compose-highlight/src/* || \
                   "$file" == sample/src/* || \
@@ -56,15 +57,42 @@ jobs:
                   "$file" == *.gradle.kts || \
                   "$file" == ".github/workflows/ci.yml" ]]; then
               CODE_CHANGED=true
-              break
+            fi
+
+            if [[ "$file" == docs/* || \
+                  "$file" == zensical.toml || \
+                  "$file" == pyproject.toml || \
+                  "$file" == compose-highlight/dokka-theme/* || \
+                  "$file" == ".github/workflows/docs.yml" ]]; then
+              DOCS_CHANGED=true
             fi
           done <<< "$CHANGED"
           echo "code=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "docs=$DOCS_CHANGED" >> "$GITHUB_OUTPUT"
           echo "Code changed: $CODE_CHANGED"
+          echo "Docs changed: $DOCS_CHANGED"
 
-      - name: No code changes - skipping build
+      - name: No code/docs changes - skipping build
+        if: steps.changes.outputs.code == 'false' && steps.changes.outputs.docs == 'false'
+        run: echo "No Android or docs-related files changed. Skipping heavy checks."
+
+      - name: Set up Python
+        if: steps.changes.outputs.docs == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+
+      - name: Install docs dependencies
+        if: steps.changes.outputs.docs == 'true'
+        run: pip install .
+
+      - name: Validate docs build
+        if: steps.changes.outputs.docs == 'true'
+        run: zensical build --clean
+
+      - name: No Android code changes - skipping Android build
         if: steps.changes.outputs.code == 'false'
-        run: echo "Only non-code files changed. Skipping build and test."
+        run: echo "No Android-impacting files changed. Skipping Android build and tests."
 
       - name: Set up JDK 17
         if: steps.changes.outputs.code == 'true'


### PR DESCRIPTION
## Summary
Phase 3 adds lightweight docs quality guardrails so docs drift and broken links are caught early.

## Changes
- Updated `.github/workflows/ci.yml` change detection to track both Android-impacting and docs-impacting files.
- Added docs validation steps in CI when docs-related files change:
  - setup Python
  - install project docs deps (`pip install .`)
  - run `zensical build --clean`
- Kept Android build/test steps scoped to Android-impacting file changes.
- Cleaned duplicate `## Docs site` section in `.github/copilot-instructions.md`.
- Added a new `## Reference docs authoring` section to enforce the docs-reference vs Dokka split.

## Why
- Preserve fast CI by skipping heavy Android checks on docs-only changes.
- Still enforce docs correctness (links/anchors) on docs changes.
- Prevent re-introducing API duplication in `docs/reference/`.

## Validation
- Local `zensical build --clean` passes with no warnings.
