### PR TITLE
docs(build): clarify Dokka HTML customization usage

### DIFF
--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -196,9 +196,11 @@ dokka {
         outputDirectory.set(rootDir.resolve("docs/api"))
     }
     // Theme overrides + chrome rewrite that align Dokka's HTML output with the Zensical
-    // Material site at /. The CSS overrides Dokka's color/font variables and hides Dokka's
-    // native chrome; the JS wraps each page's #main in real Material scaffolding. See
-    // compose-highlight/dokka-theme/README.md for refresh procedure and breakage notes.
+    // Material site at /. This uses Dokka's official HTML customization extension points:
+    // https://kotlinlang.org/docs/dokka-html.html#customization
+    // - customStyleSheets: CSS overrides for Dokka variables/chrome
+    // - customAssets: JS wrapper that rebuilds page chrome around #main
+    // See compose-highlight/dokka-theme/README.md for refresh procedure and breakage notes.
     pluginsConfiguration.html {
         customStyleSheets.from(
             layout.projectDirectory.file("dokka-theme/zensical-overrides.css"),
@@ -300,5 +302,4 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         }
     )
 }
-
 


### PR DESCRIPTION
## Summary
Adds an official Dokka customization docs link to the Dokka config block in `compose-highlight/build.gradle.kts`.

## Why
The retheme setup uses supported Dokka HTML customization extension points (`customStyleSheets` and `customAssets`), but this was not explicitly linked in the build script. This update makes the intent clear and reduces the perception that the override is a hack.

## Change
- Added reference to:
  - https://kotlinlang.org/docs/dokka-html.html#customization
- Clarified that the setup uses Dokka official extension points.
