### PR TITLE
chore: prepare release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-30
+
 ### Fixed
 
 - **`SyntaxHighlightedTextEditor` / `rememberSyntaxHighlightedEditorValue` - preserve span

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.24.1")
+    implementation("dev.hossain:compose-highlight:0.25.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.24.1
+VERSION_NAME=0.25.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 29
-        versionName = "0.24.1"
+        versionCode = 30
+        versionName = "0.25.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
Prepare `0.25.0` release metadata and version references.

## Changes
- Updated `gradle.properties` version to `0.25.0`
- Updated README dependency snippet to `0.25.0`
- Updated sample app `versionName` to `0.25.0` and incremented `versionCode`
- Updated `pyproject.toml` version to `0.25.0`
- Renamed CHANGELOG section from `[Unreleased]` to `[0.25.0] - 2026-05-30`

## Verification
Executed required pre-release checks:
- `./gradlew formatKotlin`
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug`
- `./gradlew :compose-highlight:test`

All passed successfully.
