### PR TITLE
fix: broken cross-directory links in guides

### DIFF
--- a/docs/guides/language-selection.md
+++ b/docs/guides/language-selection.md
@@ -12,7 +12,7 @@ SyntaxHighlightedCode(code = snippet, language = "typescript")
 SyntaxHighlightedCode(code = snippet, language = "sql")
 ```
 
-For a full list of supported language identifiers, call `engine.supportedLanguages()` at runtime. For the extension-to-language mapping, see the [HighlightLanguage reference](reference/highlight-language).
+For a full list of supported language identifiers, call `engine.supportedLanguages()` at runtime. For the extension-to-language mapping, see the [HighlightLanguage reference](../reference/highlight-language).
 
 ---
 
@@ -39,7 +39,7 @@ SyntaxHighlightedCode(
 )
 ```
 
-See the full [extension map](reference/highlight-language#supported-extensions).
+See the full [extension map](../reference/highlight-language#supported-extensions).
 
 ---
 

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -143,4 +143,4 @@ val (lightAnnotated, darkAnnotated) = themedPair
 // Switch between lightAnnotated and darkAnnotated instantly
 ```
 
-See [`rememberHighlightedCodeBothThemes`](reference/syntax-highlighted-code#rememberhighlightedcodeboththemes) for the ready-made composable helper.
+See [`rememberHighlightedCodeBothThemes`](../reference/syntax-highlighted-code#rememberhighlightedcodeboththemes) for the ready-made composable helper.


### PR DESCRIPTION
Fixed 3 broken links in the guides directory that resolved to 404 pages.

**Root cause:** Links like `reference/highlight-language` from `guides/language-selection.md` resolved to `/guides/reference/highlight-language` (404) instead of `/reference/highlight-language`.

**Fixed:**
- `guides/language-selection.md` - 2 links to `../reference/highlight-language`
- `guides/theming.md` - 1 link to `../reference/syntax-highlighted-code`

All other cross-directory links were verified correct.