### PR TITLE
fix: restrict internal engine helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Restrict engine helper visibility** - made `ThemeParser` and `HtmlToAnnotatedString`
+  internal so CSS parsing and HTML conversion remain implementation details instead of
+  becoming part of the published ABI.
+
 ## [0.25.0] - 2026-05-30
 
 ### Fixed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -36,7 +36,7 @@ import kotlin.time.measureTimedValue
  *    an HTML string where each token is wrapped in a `<span class="hljs-keyword">` (or similar).
  *    highlight.js only assigns class names - it does not apply any colors itself.
  *
- * 2. **Resolves colors** - [HighlightTheme] lazily parses its CSS file via [ThemeParser], which
+ * 2. **Resolves colors** - [HighlightTheme] lazily parses its CSS file with the theme parser, which
  *    translates CSS rules like `.hljs-keyword { color: #7928a1 }` into a map of
  *    `"hljs-keyword" -> SpanStyle(color=Color(0xFF7928a1))`. This is the bridge between
  *    CSS-based theming and Compose's styling model.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTimings.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTimings.kt
@@ -18,7 +18,7 @@ import kotlin.time.Duration
  * | [jsonUnescape] | `unescapeJsString()` pass over the returned JSON string |
  * | [htmlParse] | `Jsoup.parseBodyFragment()` - HTML to DOM |
  * | [treeWalk] | DOM node walk + `SpanStyle` lookup from theme color map |
- * | [themeParse] | `ThemeParser.parse()` - first-use only; [Duration.ZERO] on cache hits |
+ * | [themeParse] | Theme CSS parsing - first-use only; [Duration.ZERO] on cache hits |
  * | [total] | End-to-end time for the full highlight call |
  *
  * ## Usage
@@ -46,7 +46,7 @@ import kotlin.time.Duration
  *   output into a DOM tree.
  * @property treeWalk Time for the DOM tree walk and [androidx.compose.ui.text.SpanStyle]
  *   application loop that builds the [androidx.compose.ui.text.AnnotatedString].
- * @property themeParse Time for [ThemeParser.parse] - CSS parsing on first use of a
+ * @property themeParse Time for theme CSS parsing on first use of a
  *   [HighlightTheme]. [Duration.ZERO] on all subsequent calls for the same theme instance
  *   because the color map is lazily computed and cached.
  * @property total Full elapsed wall-clock time for the [HighlightEngine.highlight] call.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -16,7 +16,7 @@ import kotlin.time.measureTimedValue
  * Uses jsoup to parse the HTML fragment and performs a recursive tree walk,
  * pushing/popping [SpanStyle] for each `<span class="hljs-*">` element.
  */
-object HtmlToAnnotatedString {
+internal object HtmlToAnnotatedString {
     /**
      * Converts highlighted HTML to [AnnotatedString] using the provided color map.
      *

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemeParser.kt
@@ -26,7 +26,7 @@ import kotlin.math.roundToInt
  * is sufficient. At-rule blocks (e.g. `@media`, `@supports`) are stripped before parsing to
  * prevent inner rules from overwriting top-level color declarations.
  */
-object ThemeParser {
+internal object ThemeParser {
     /**
      * Parses a CSS theme file from assets into a color map.
      * Results are not cached here - callers should use [lazy] to cache per theme.


### PR DESCRIPTION
## Summary
- Make ThemeParser and HtmlToAnnotatedString internal so implementation helpers do not leak into the public ABI
- Update public KDoc to avoid linking to internal helper types
- Add an Unreleased changelog entry

## Verification
- ./gradlew lintKotlin
- ./gradlew :compose-highlight:test
- ./gradlew :compose-highlight:assembleDebug :sample:assembleDebug
- ./gradlew :compose-highlight:compileDebugAndroidTestKotlin
- npx markdownlint-cli CHANGELOG.md