### PR TITLE
refactor: extract hljs selector strings to HljsSelectors constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
   internal so CSS parsing and HTML conversion remain implementation details instead of
   becoming part of the published ABI.
 
+### Internal
+
+- **Extract `HljsSelectors` constants object** - all known highlight.js CSS selector keys
+  (`BASE`, `KEYWORD`, `STRING`, `COMMENT`, `NUMBER`, `LITERAL`, `TYPE`, `TITLE`, `NAME`,
+  `BUILT_IN`, `ATTR`, `SELECTOR_TAG`, `STRONG`, `EMPHASIS`, `QUOTE`, `TAG`, `OPERATOR`,
+  `ADDITION`, `TITLE_FUNCTION`, `META`, `VARIABLE`, `PARAMS`, `ATTRIBUTE`, `SECTION`,
+  `SYMBOL`, `BULLET`, `FORMULA`, `DELETION`, `LINK`, `REGEXP`) are now defined as
+  documented constants in `HljsSelectors.kt`. Replaced 100+ hardcoded string literals
+  across production code and test files with these constants.
+
 ## [0.25.0] - 2026-05-30
 
 ### Fixed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -161,12 +161,12 @@ class HighlightTheme private constructor(
 
     /** Background color from the `.hljs` CSS rule. Unspecified if not present in theme. */
     val backgroundColor: Color by lazy {
-        colorMap["hljs"]?.background?.takeIf { it != Color.Unspecified } ?: Color.Unspecified
+        colorMap[HljsSelectors.BASE]?.background?.takeIf { it != Color.Unspecified } ?: Color.Unspecified
     }
 
     /** Default text color from the `.hljs` CSS rule. Unspecified if not present in theme. */
     val defaultTextColor: Color by lazy {
-        colorMap["hljs"]?.color?.takeIf { it != Color.Unspecified } ?: Color.Unspecified
+        colorMap[HljsSelectors.BASE]?.color?.takeIf { it != Color.Unspecified } ?: Color.Unspecified
     }
 
     /**
@@ -364,8 +364,8 @@ class HighlightTheme private constructor(
             val effectiveColorMap =
                 if (backgroundColor != null || defaultTextColor != null) {
                     val base = immutableMap.toMutableMap()
-                    val existing = base["hljs"] ?: SpanStyle()
-                    base["hljs"] =
+                    val existing = base[HljsSelectors.BASE] ?: SpanStyle()
+                    base[HljsSelectors.BASE] =
                         existing.copy(
                             background = backgroundColor ?: existing.background,
                             color = defaultTextColor ?: existing.color,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -120,4 +120,34 @@ internal object HljsSelectors {
 
     /** Compound selector: meta keyword (`"hljs-meta .hljs-keyword"` descendant, typically skipped). */
     const val META = "hljs-meta"
+
+    /** Variable references (e.g. `$variable` in shell scripts). */
+    const val VARIABLE = "hljs-variable"
+
+    /** Function parameters in declarations. */
+    const val PARAMS = "hljs-params"
+
+    /** HTML/XML attributes. */
+    const val ATTRIBUTE = "hljs-attribute"
+
+    /** Section titles and headings. */
+    const val SECTION = "hljs-section"
+
+    /** Symbol tokens (e.g. Ruby symbols like `:foo`). */
+    const val SYMBOL = "hljs-symbol"
+
+    /** Bullet points in list markup. */
+    const val BULLET = "hljs-bullet"
+
+    /** Formula tokens in LaTeX/math markup. */
+    const val FORMULA = "hljs-formula"
+
+    /** Added/deleted line markers in diff output. */
+    const val DELETION = "hljs-deletion"
+
+    /** Regular expression literals. */
+    const val REGEXP = "hljs-regexp"
+
+    /** Link URLs in markup. */
+    const val LINK = "hljs-link"
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -1,0 +1,123 @@
+package dev.hossain.highlight.engine
+
+/**
+ * Known highlight.js CSS selector keys used throughout the library.
+ *
+ * highlight.js wraps each syntax token in a `<span class="hljs-*">` element.
+ * These class names are mapped to [androidx.compose.ui.text.SpanStyle] entries
+ * by [ThemeParser] when parsing a theme CSS file, and looked up by
+ * [HtmlToAnnotatedString] when converting the HTML to an [androidx.compose.ui.text.AnnotatedString].
+ *
+ * The full set of keys available depends on the theme - different CSS themes define
+ * different selectors. The constants below represent the **base** and **common**
+ * selectors that appear in most themes.
+ *
+ * ### Base selector
+ * - [BASE] (`"hljs"`) - The root container rule. Provides the default text color and
+ *   background for the entire code block. Used by [HighlightTheme.backgroundColor]
+ *   and [HighlightTheme.defaultTextColor] to derive theme-level defaults.
+ *
+ * ### Common token selectors
+ * These appear in nearly all highlight.js themes:
+ * - [KEYWORD] - Language keywords (`if`, `for`, `fun`, `def`, etc.)
+ * - [STRING] - String literals
+ * - [NUMBER] - Numeric literals
+ * - [COMMENT] - Single-line and multi-line comments
+ * - [LITERAL] - Boolean and null literals (`true`, `false`, `null`, `None`)
+ * - [TYPE] - Type names and class declarations
+ * - [TITLE] - Function and class titles
+ * - [NAME] - Tag names (HTML/XML), variable names
+ * - [BUILT_IN] - Built-in functions and types
+ * - [ATTR] - HTML/XML attributes
+ * - [SELECTOR_TAG] - CSS selector tags
+ * - [STRONG] - Bold-emphasized tokens (maps to [androidx.compose.ui.text.font.FontWeight.Bold])
+ * - [EMPHASIS] - Italic-emphasized tokens (maps to [androidx.compose.ui.text.font.FontStyle.Italic])
+ * - [QUOTE] - Block quotes (often shares style with [COMMENT])
+ * - [TAG] - Markup tags
+ * - [OPERATOR] - Operators (`+`, `-`, `=`, etc.)
+ * - [ADDITION] - Added lines in diff output
+ *
+ * ### Compound selectors
+ * highlight.js sometimes outputs space-separated classes like `class="hljs-title function_"`.
+ * These are resolved as dot-joined keys:
+ * - [TITLE_FUNCTION] (`"hljs-title.function_"`) - Function title tokens
+ *
+ * ### Usage
+ *
+ * These constants are used internally by [ThemeParser], [HtmlToAnnotatedString], and
+ * [HighlightTheme] to reference the base `"hljs"` selector. Token-specific selectors
+ * (like [KEYWORD], [STRING]) are **not** hardcoded in production code - they are
+ * discovered dynamically from the theme CSS at runtime. The constants exist here
+ * for documentation and for test code that constructs inline color maps.
+ *
+ * @see ThemeParser
+ * @see HtmlToAnnotatedString
+ * @see HighlightTheme
+ */
+internal object HljsSelectors {
+    /**
+     * The base/root selector (`"hljs"`).
+     *
+     * Present in all themes. Provides the default text color and background for the
+     * entire code block. Used to derive [HighlightTheme.backgroundColor] and
+     * [HighlightTheme.defaultTextColor].
+     */
+    const val BASE = "hljs"
+
+    /** Keyword tokens (`if`, `for`, `fun`, `def`, etc.). */
+    const val KEYWORD = "hljs-keyword"
+
+    /** String literals. */
+    const val STRING = "hljs-string"
+
+    /** Numeric literals. */
+    const val NUMBER = "hljs-number"
+
+    /** Single-line and multi-line comments. */
+    const val COMMENT = "hljs-comment"
+
+    /** Boolean and null literals (`true`, `false`, `null`, `None`). */
+    const val LITERAL = "hljs-literal"
+
+    /** Type names and class declarations. */
+    const val TYPE = "hljs-type"
+
+    /** Function and class titles. */
+    const val TITLE = "hljs-title"
+
+    /** Tag names (HTML/XML), variable names. */
+    const val NAME = "hljs-name"
+
+    /** Built-in functions and types. */
+    const val BUILT_IN = "hljs-built_in"
+
+    /** HTML/XML attributes. */
+    const val ATTR = "hljs-attr"
+
+    /** CSS selector tags. */
+    const val SELECTOR_TAG = "hljs-selector-tag"
+
+    /** Bold-emphasized tokens (typically maps to [androidx.compose.ui.text.font.FontWeight.Bold]). */
+    const val STRONG = "hljs-strong"
+
+    /** Italic-emphasized tokens (typically maps to [androidx.compose.ui.text.font.FontStyle.Italic]). */
+    const val EMPHASIS = "hljs-emphasis"
+
+    /** Block quotes (often shares style with [COMMENT]). */
+    const val QUOTE = "hljs-quote"
+
+    /** Markup tags. */
+    const val TAG = "hljs-tag"
+
+    /** Operators (`+`, `-`, `=`, etc.). */
+    const val OPERATOR = "hljs-operator"
+
+    /** Added lines in diff output. */
+    const val ADDITION = "hljs-addition"
+
+    /** Compound selector: function title (`"hljs-title.function_"`). */
+    const val TITLE_FUNCTION = "hljs-title.function_"
+
+    /** Compound selector: meta keyword (`"hljs-meta .hljs-keyword"` descendant, typically skipped). */
+    const val META = "hljs-meta"
+}

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedString.kt
@@ -54,7 +54,7 @@ internal object HtmlToAnnotatedString {
 
         // Apply the .hljs base text color across the entire string so that plain-text tokens
         // (identifiers, whitespace, etc.) inherit the theme color rather than LocalContentColor.
-        val baseTextColor = colorMap["hljs"]?.color?.takeIf { it != Color.Unspecified }
+        val baseTextColor = colorMap[HljsSelectors.BASE]?.color?.takeIf { it != Color.Unspecified }
         val baseStyle = baseTextColor?.let { SpanStyle(color = it) }
 
         val (result, treeWalkDuration) =
@@ -126,8 +126,8 @@ internal object HtmlToAnnotatedString {
 
         // Each builder gets its own independent base text color from its own color map.
         // Do NOT share a single base style - light and dark themes have different default colors.
-        val lightBaseStyle = lightColorMap["hljs"]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
-        val darkBaseStyle = darkColorMap["hljs"]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
+        val lightBaseStyle = lightColorMap[HljsSelectors.BASE]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
+        val darkBaseStyle = darkColorMap[HljsSelectors.BASE]?.color?.takeIf { it != Color.Unspecified }?.let { SpanStyle(color = it) }
 
         val lightBuilder = AnnotatedString.Builder()
         val darkBuilder = AnnotatedString.Builder()

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeAssetTest.kt
@@ -21,7 +21,7 @@ class HighlightThemeAssetTest {
     fun `tomorrow factory produces valid colorMap`() {
         val theme = HighlightTheme.tomorrow()
         assertThat(theme.colorMap).isNotEmpty()
-        assertThat(theme.colorMap).containsKey("hljs")
+        assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
         assertThat(theme.colorMap).containsKey("hljs-keyword")
     }
 
@@ -29,21 +29,21 @@ class HighlightThemeAssetTest {
     fun `tomorrowNight factory produces valid colorMap`() {
         val theme = HighlightTheme.tomorrowNight()
         assertThat(theme.colorMap).isNotEmpty()
-        assertThat(theme.colorMap).containsKey("hljs")
+        assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
     }
 
     @Test
     fun `atomOneDark factory produces valid colorMap`() {
         val theme = HighlightTheme.atomOneDark()
         assertThat(theme.colorMap).isNotEmpty()
-        assertThat(theme.colorMap).containsKey("hljs")
+        assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
     }
 
     @Test
     fun `atomOneLight factory produces valid colorMap`() {
         val theme = HighlightTheme.atomOneLight()
         assertThat(theme.colorMap).isNotEmpty()
-        assertThat(theme.colorMap).containsKey("hljs")
+        assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
     }
 
     @Test
@@ -81,7 +81,7 @@ class HighlightThemeAssetTest {
 
         themes.forEach { theme ->
             assertThat(theme.colorMap).isNotEmpty()
-            assertThat(theme.colorMap).containsKey("hljs")
+            assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
         }
     }
 

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeAssetTest.kt
@@ -22,7 +22,7 @@ class HighlightThemeAssetTest {
         val theme = HighlightTheme.tomorrow()
         assertThat(theme.colorMap).isNotEmpty()
         assertThat(theme.colorMap).containsKey(HljsSelectors.BASE)
-        assertThat(theme.colorMap).containsKey("hljs-keyword")
+        assertThat(theme.colorMap).containsKey(HljsSelectors.KEYWORD)
     }
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
@@ -31,7 +31,7 @@ class HighlightThemeTest {
     @Test
     fun `fromCss extracts keyword color correctly`() {
         val theme = HighlightTheme.fromCss(sampleCss, "test")
-        val style = theme.colorMap["hljs-keyword"]
+        val style = theme.colorMap[HljsSelectors.KEYWORD]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0xFF8959a8.toInt()))
     }
@@ -61,12 +61,12 @@ class HighlightThemeTest {
         val map =
             mapOf(
                 HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
-                "hljs-keyword" to SpanStyle(color = Color.Blue),
-                "hljs-string" to SpanStyle(color = Color.Green),
+                HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue),
+                HljsSelectors.STRING to SpanStyle(color = Color.Green),
             )
         val theme = HighlightTheme.fromColorMap(name = "custom", colorMap = map)
         assertThat(theme.colorMap).hasSize(3)
-        assertThat(theme.colorMap["hljs-keyword"]!!.color).isEqualTo(Color.Blue)
+        assertThat(theme.colorMap[HljsSelectors.KEYWORD]!!.color).isEqualTo(Color.Blue)
     }
 
     @Test
@@ -95,12 +95,12 @@ class HighlightThemeTest {
 
     @Test
     fun `fromColorMap defensive copy prevents external mutation`() {
-        val mutable = mutableMapOf("hljs-keyword" to SpanStyle(color = Color.Blue))
+        val mutable = mutableMapOf(HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue))
         val theme = HighlightTheme.fromColorMap("copy-test", mutable)
         // Mutate the original map after theme creation
-        mutable["hljs-keyword"] = SpanStyle(color = Color.Red)
+        mutable[HljsSelectors.KEYWORD] = SpanStyle(color = Color.Red)
         // Theme should still have the original color
-        assertThat(theme.colorMap["hljs-keyword"]?.color).isEqualTo(Color.Blue)
+        assertThat(theme.colorMap[HljsSelectors.KEYWORD]?.color).isEqualTo(Color.Blue)
     }
 
     @Test
@@ -140,7 +140,7 @@ class HighlightThemeTest {
         val theme =
             HighlightTheme.fromColorMap(
                 name = "no-hljs",
-                colorMap = mapOf("hljs-keyword" to SpanStyle(color = Color.Blue)),
+                colorMap = mapOf(HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue)),
             )
         assertThat(theme.backgroundColor).isEqualTo(Color.Unspecified)
     }
@@ -191,7 +191,7 @@ class HighlightThemeTest {
         val map =
             mapOf(
                 HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
-                "hljs-keyword" to SpanStyle(color = Color.Blue),
+                HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue),
             )
         val a = HighlightTheme.fromColorMap(name = "dynamic", colorMap = map)
         val b = HighlightTheme.fromColorMap(name = "dynamic", colorMap = map)
@@ -201,8 +201,8 @@ class HighlightThemeTest {
 
     @Test
     fun `themes created with fromColorMap with same name but different colorMap are not equal`() {
-        val mapA = mapOf("hljs-keyword" to SpanStyle(color = Color.Blue))
-        val mapB = mapOf("hljs-keyword" to SpanStyle(color = Color.Red))
+        val mapA = mapOf(HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue))
+        val mapB = mapOf(HljsSelectors.KEYWORD to SpanStyle(color = Color.Red))
         val a = HighlightTheme.fromColorMap(name = "dynamic", colorMap = mapA)
         val b = HighlightTheme.fromColorMap(name = "dynamic", colorMap = mapB)
         assertThat(a).isNotEqualTo(b)
@@ -213,7 +213,7 @@ class HighlightThemeTest {
         val map =
             mapOf(
                 HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
-                "hljs-keyword" to SpanStyle(color = Color.Blue),
+                HljsSelectors.KEYWORD to SpanStyle(color = Color.Blue),
             )
         val withoutOverride = HighlightTheme.fromColorMap(name = "dynamic", colorMap = map)
         val withSameOverride =
@@ -245,9 +245,9 @@ class HighlightThemeTest {
 
     @Test
     fun `fromColorMap preserves FontWeight in SpanStyle`() {
-        val map = mapOf("hljs-strong" to SpanStyle(fontWeight = FontWeight.Bold, color = Color.Yellow))
+        val map = mapOf(HljsSelectors.STRONG to SpanStyle(fontWeight = FontWeight.Bold, color = Color.Yellow))
         val theme = HighlightTheme.fromColorMap("bold-test", map)
-        assertThat(theme.colorMap["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(theme.colorMap[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     // ----- theme not equal to non-HighlightTheme -----

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
@@ -39,7 +39,7 @@ class HighlightThemeTest {
     @Test
     fun `fromCss extracts base hljs rule`() {
         val theme = HighlightTheme.fromCss(sampleCss, "test")
-        assertThat(theme.colorMap["hljs"]).isNotNull()
+        assertThat(theme.colorMap[HljsSelectors.BASE]).isNotNull()
     }
 
     @Test
@@ -60,7 +60,7 @@ class HighlightThemeTest {
     fun `fromColorMap preserves all entries`() {
         val map =
             mapOf(
-                "hljs" to SpanStyle(color = Color.Black, background = Color.White),
+                HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
                 "hljs-keyword" to SpanStyle(color = Color.Blue),
                 "hljs-string" to SpanStyle(color = Color.Green),
             )
@@ -71,7 +71,7 @@ class HighlightThemeTest {
 
     @Test
     fun `fromColorMap with explicit backgroundColor overrides hljs background`() {
-        val map = mapOf("hljs" to SpanStyle(color = Color.Black, background = Color.White))
+        val map = mapOf(HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White))
         val theme =
             HighlightTheme.fromColorMap(
                 name = "override-bg",
@@ -83,7 +83,7 @@ class HighlightThemeTest {
 
     @Test
     fun `fromColorMap with explicit defaultTextColor overrides hljs color`() {
-        val map = mapOf("hljs" to SpanStyle(color = Color.Black, background = Color.White))
+        val map = mapOf(HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White))
         val theme =
             HighlightTheme.fromColorMap(
                 name = "override-text",
@@ -190,7 +190,7 @@ class HighlightThemeTest {
     fun `themes created with fromColorMap with same name and same colorMap are equal`() {
         val map =
             mapOf(
-                "hljs" to SpanStyle(color = Color.Black, background = Color.White),
+                HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
                 "hljs-keyword" to SpanStyle(color = Color.Blue),
             )
         val a = HighlightTheme.fromColorMap(name = "dynamic", colorMap = map)
@@ -212,7 +212,7 @@ class HighlightThemeTest {
     fun `themes created with fromColorMap with equivalent hljs override are equal`() {
         val map =
             mapOf(
-                "hljs" to SpanStyle(color = Color.Black, background = Color.White),
+                HljsSelectors.BASE to SpanStyle(color = Color.Black, background = Color.White),
                 "hljs-keyword" to SpanStyle(color = Color.Blue),
             )
         val withoutOverride = HighlightTheme.fromColorMap(name = "dynamic", colorMap = map)

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -10,7 +10,7 @@ class HtmlToAnnotatedStringTest {
     private val baseColor = Color(0xFF4D4D4C.toInt())
     private val colorMap =
         mapOf(
-            "hljs" to SpanStyle(color = baseColor, background = Color(0xFFFFFFFF.toInt())),
+            HljsSelectors.BASE to SpanStyle(color = baseColor, background = Color(0xFFFFFFFF.toInt())),
             "hljs-keyword" to SpanStyle(color = Color(0xFF8959a8.toInt())),
             "hljs-string" to SpanStyle(color = Color(0xFF718c00.toInt())),
             "hljs-number" to SpanStyle(color = Color(0xFFf5871f.toInt())),
@@ -22,13 +22,13 @@ class HtmlToAnnotatedStringTest {
 
     /** colorMap without a base .hljs entry - for tests that verify pre-base-style behavior. */
     private val colorMapNoBase =
-        colorMap.filterKeys { it != "hljs" }
+        colorMap.filterKeys { it != HljsSelectors.BASE }
 
     // Dark-theme color map used in convertBothThemes tests - different colors than colorMap.
     private val darkBaseColor = Color(0xFFABB2BF.toInt())
     private val darkColorMap =
         mapOf(
-            "hljs" to SpanStyle(color = darkBaseColor, background = Color(0xFF282C34.toInt())),
+            HljsSelectors.BASE to SpanStyle(color = darkBaseColor, background = Color(0xFF282C34.toInt())),
             "hljs-keyword" to SpanStyle(color = Color(0xFFC678DD.toInt())),
             "hljs-string" to SpanStyle(color = Color(0xFF98C379.toInt())),
             "hljs-number" to SpanStyle(color = Color(0xFFD19A66.toInt())),
@@ -171,7 +171,7 @@ class HtmlToAnnotatedStringTest {
     fun `convert applies base hljs background color as full-range span background`() {
         val colorMapWithBackground =
             mapOf(
-                "hljs" to SpanStyle(color = baseColor, background = Color(0xFFFFFFFF.toInt())),
+                HljsSelectors.BASE to SpanStyle(color = baseColor, background = Color(0xFFFFFFFF.toInt())),
             )
         val html = """<span class="hljs-keyword">if</span>"""
         val result = HtmlToAnnotatedString.convert(html, colorMapWithBackground)
@@ -206,7 +206,12 @@ class HtmlToAnnotatedStringTest {
     @Test
     fun `convertBothThemes plain text produces identical text in both outputs`() {
         val html = "hello world"
-        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        val (light, dark) =
+            HtmlToAnnotatedString.convertBothThemes(
+                html,
+                colorMapNoBase,
+                darkColorMap.filterKeys { it != HljsSelectors.BASE },
+            )
         assertThat(light.text).isEqualTo("hello world")
         assertThat(dark.text).isEqualTo("hello world")
     }
@@ -243,7 +248,12 @@ class HtmlToAnnotatedStringTest {
         // Use maps without the base .hljs entry so firstOrNull() reliably returns the keyword
         // span rather than the full-range base style span (which would also differ between
         // themes but would not verify that keyword styling is applied correctly).
-        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        val (light, dark) =
+            HtmlToAnnotatedString.convertBothThemes(
+                html,
+                colorMapNoBase,
+                darkColorMap.filterKeys { it != HljsSelectors.BASE },
+            )
         val lightKeyword = light.spanStyles.firstOrNull()
         val darkKeyword = dark.spanStyles.firstOrNull()
         assertThat(lightKeyword).isNotNull()
@@ -290,7 +300,12 @@ class HtmlToAnnotatedStringTest {
     @Test
     fun `convertBothThemes handles compound hljs class correctly in both outputs`() {
         val html = """<span class="hljs-title function_">myFunc</span>"""
-        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        val (light, dark) =
+            HtmlToAnnotatedString.convertBothThemes(
+                html,
+                colorMapNoBase,
+                darkColorMap.filterKeys { it != HljsSelectors.BASE },
+            )
         assertThat(light.spanStyles).hasSize(1)
         assertThat(dark.spanStyles).hasSize(1)
         assertThat(light.spanStyles[0].item.color).isEqualTo(Color(0xFF4271ae.toInt()))
@@ -300,7 +315,12 @@ class HtmlToAnnotatedStringTest {
     @Test
     fun `convertBothThemes handles nested spans in both outputs`() {
         val html = """<span class="hljs-string">"<span class="hljs-keyword">val</span>"</span>"""
-        val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, colorMapNoBase, darkColorMap.filterKeys { it != "hljs" })
+        val (light, dark) =
+            HtmlToAnnotatedString.convertBothThemes(
+                html,
+                colorMapNoBase,
+                darkColorMap.filterKeys { it != HljsSelectors.BASE },
+            )
         assertThat(light.text).isEqualTo(""""val"""")
         assertThat(dark.text).isEqualTo(""""val"""")
         assertThat(light.spanStyles.size).isAtLeast(2)
@@ -312,8 +332,8 @@ class HtmlToAnnotatedStringTest {
         // Use plain text outside the span so the keyword span does not accidentally cover
         // the full range - we only want to verify the absence of the base .hljs wrap.
         val html = """x <span class="hljs-keyword">if</span> y"""
-        val lightNoBase = colorMap.filterKeys { it != "hljs" }
-        val darkNoBase = darkColorMap.filterKeys { it != "hljs" }
+        val lightNoBase = colorMap.filterKeys { it != HljsSelectors.BASE }
+        val darkNoBase = darkColorMap.filterKeys { it != HljsSelectors.BASE }
         val (light, dark) = HtmlToAnnotatedString.convertBothThemes(html, lightNoBase, darkNoBase)
         val lightFullRange = light.spanStyles.filter { it.start == 0 && it.end == light.text.length }
         val darkFullRange = dark.spanStyles.filter { it.start == 0 && it.end == dark.text.length }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HtmlToAnnotatedStringTest.kt
@@ -11,13 +11,13 @@ class HtmlToAnnotatedStringTest {
     private val colorMap =
         mapOf(
             HljsSelectors.BASE to SpanStyle(color = baseColor, background = Color(0xFFFFFFFF.toInt())),
-            "hljs-keyword" to SpanStyle(color = Color(0xFF8959a8.toInt())),
-            "hljs-string" to SpanStyle(color = Color(0xFF718c00.toInt())),
-            "hljs-number" to SpanStyle(color = Color(0xFFf5871f.toInt())),
-            "hljs-comment" to SpanStyle(color = Color(0xFF8e908c.toInt())),
-            "hljs-strong" to SpanStyle(color = Color(0xFFeab700.toInt()), fontWeight = FontWeight.Bold),
+            HljsSelectors.KEYWORD to SpanStyle(color = Color(0xFF8959a8.toInt())),
+            HljsSelectors.STRING to SpanStyle(color = Color(0xFF718c00.toInt())),
+            HljsSelectors.NUMBER to SpanStyle(color = Color(0xFFf5871f.toInt())),
+            HljsSelectors.COMMENT to SpanStyle(color = Color(0xFF8e908c.toInt())),
+            HljsSelectors.STRONG to SpanStyle(color = Color(0xFFeab700.toInt()), fontWeight = FontWeight.Bold),
             // Compound key
-            "hljs-title.function_" to SpanStyle(color = Color(0xFF4271ae.toInt())),
+            HljsSelectors.TITLE_FUNCTION to SpanStyle(color = Color(0xFF4271ae.toInt())),
         )
 
     /** colorMap without a base .hljs entry - for tests that verify pre-base-style behavior. */
@@ -29,12 +29,12 @@ class HtmlToAnnotatedStringTest {
     private val darkColorMap =
         mapOf(
             HljsSelectors.BASE to SpanStyle(color = darkBaseColor, background = Color(0xFF282C34.toInt())),
-            "hljs-keyword" to SpanStyle(color = Color(0xFFC678DD.toInt())),
-            "hljs-string" to SpanStyle(color = Color(0xFF98C379.toInt())),
-            "hljs-number" to SpanStyle(color = Color(0xFFD19A66.toInt())),
-            "hljs-comment" to SpanStyle(color = Color(0xFF5C6370.toInt())),
-            "hljs-strong" to SpanStyle(color = Color(0xFFE5C07B.toInt()), fontWeight = FontWeight.Bold),
-            "hljs-title.function_" to SpanStyle(color = Color(0xFF61AFEF.toInt())),
+            HljsSelectors.KEYWORD to SpanStyle(color = Color(0xFFC678DD.toInt())),
+            HljsSelectors.STRING to SpanStyle(color = Color(0xFF98C379.toInt())),
+            HljsSelectors.NUMBER to SpanStyle(color = Color(0xFFD19A66.toInt())),
+            HljsSelectors.COMMENT to SpanStyle(color = Color(0xFF5C6370.toInt())),
+            HljsSelectors.STRONG to SpanStyle(color = Color(0xFFE5C07B.toInt()), fontWeight = FontWeight.Bold),
+            HljsSelectors.TITLE_FUNCTION to SpanStyle(color = Color(0xFF61AFEF.toInt())),
         )
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -18,7 +18,7 @@ class ThemeParserAssetTest {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow.css")
         assertThat(result).isNotEmpty()
         assertThat(result).containsKey(HljsSelectors.BASE)
-        assertThat(result).containsKey("hljs-keyword")
+        assertThat(result).containsKey(HljsSelectors.KEYWORD)
     }
 
     @Test
@@ -116,21 +116,21 @@ class ThemeParserAssetTest {
     fun `parseAsset 1c-light theme keyword is red`() {
         // .hljs-keyword { color: red } - named color must be parsed to #FF0000
         val result = ThemeParser.parseAsset(context, "1c-light.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFFF0000))
     }
 
     @Test
     fun `parseAsset 1c-light theme comment is green`() {
         // .hljs-comment { color: green } - CSS named green = #008000
         val result = ThemeParser.parseAsset(context, "1c-light.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF008000))
     }
 
     @Test
     fun `parseAsset 1c-light theme tag uses 4-digit hex color`() {
         // .hljs-tag { color: #444a } - 4-digit hex must be parsed to Color(68,68,68,170)
         val result = ThemeParser.parseAsset(context, "1c-light.min.css")
-        assertThat(result["hljs-tag"]?.color).isEqualTo(Color(68, 68, 68, 170))
+        assertThat(result[HljsSelectors.TAG]?.color).isEqualTo(Color(68, 68, 68, 170))
     }
 
     // ----- a11y-light theme regression - @media block overwrites keyword color -----
@@ -148,13 +148,13 @@ class ThemeParserAssetTest {
     fun `parseAsset a11y-light theme keyword is purple not dark text`() {
         // .hljs-keyword { color: #7928a1 } - must survive the @media block override
         val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF7928a1))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF7928a1))
     }
 
     @Test
     fun `parseAsset a11y-light theme string is green named color`() {
         // .hljs-string { color: green } = #008000
         val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF008000))
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -17,7 +17,7 @@ class ThemeParserAssetTest {
     fun `parseAsset loads tomorrow theme from bundled assets`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow.css")
         assertThat(result).isNotEmpty()
-        assertThat(result).containsKey("hljs")
+        assertThat(result).containsKey(HljsSelectors.BASE)
         assertThat(result).containsKey("hljs-keyword")
     }
 
@@ -25,21 +25,21 @@ class ThemeParserAssetTest {
     fun `parseAsset loads tomorrow-night theme from bundled assets`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow-night.css")
         assertThat(result).isNotEmpty()
-        assertThat(result).containsKey("hljs")
+        assertThat(result).containsKey(HljsSelectors.BASE)
     }
 
     @Test
     fun `parseAsset loads atom-one-dark theme from bundled assets`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-dark.css")
         assertThat(result).isNotEmpty()
-        assertThat(result).containsKey("hljs")
+        assertThat(result).containsKey(HljsSelectors.BASE)
     }
 
     @Test
     fun `parseAsset loads atom-one-light theme from bundled assets`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-light.css")
         assertThat(result).isNotEmpty()
-        assertThat(result).containsKey("hljs")
+        assertThat(result).containsKey(HljsSelectors.BASE)
     }
 
     @Test
@@ -61,14 +61,14 @@ class ThemeParserAssetTest {
     // ----- Regression tests: ::selection must not overwrite the real .hljs background -----
     // Both tomorrow.css and tomorrow-night.css contain a `.hljs::selection { background-color: X }`
     // rule. Before the fix, ThemeParser would strip the pseudo-element and store the selection color
-    // under the "hljs" key, overwriting the correct theme background.
+    // under the HljsSelectors.BASE key, overwriting the correct theme background.
 
     @Test
     fun `parseAsset tomorrow theme background is white not selection gray`() {
         // tomorrow.css: .hljs { background: #fff }  ← correct
         //               .hljs::selection { background-color: #d6d6d6 }  ← must NOT win
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow.css")
-        val hljsStyle = result["hljs"]
+        val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFffffff))
     }
@@ -78,7 +78,7 @@ class ThemeParserAssetTest {
         // tomorrow-night.css: .hljs { background: #2d2d2d }  ← correct
         //                     .hljs::selection { background-color: #515151 }  ← must NOT win
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow-night.css")
-        val hljsStyle = result["hljs"]
+        val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF2d2d2d))
     }
@@ -86,7 +86,7 @@ class ThemeParserAssetTest {
     @Test
     fun `parseAsset atom-one-dark theme background is correct dark color`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-dark.css")
-        val hljsStyle = result["hljs"]
+        val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF282c34))
     }
@@ -94,7 +94,7 @@ class ThemeParserAssetTest {
     @Test
     fun `parseAsset atom-one-light theme background is correct light color`() {
         val result = ThemeParser.parseAsset(context, "compose-highlight/themes/atom-one-light.css")
-        val hljsStyle = result["hljs"]
+        val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFfafafa))
     }
@@ -107,7 +107,7 @@ class ThemeParserAssetTest {
     @Test
     fun `parseAsset 1c-light theme background is white`() {
         val result = ThemeParser.parseAsset(context, "1c-light.min.css")
-        val hljsStyle = result["hljs"]
+        val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFFFFFFF))
     }
@@ -141,7 +141,7 @@ class ThemeParserAssetTest {
     @Test
     fun `parseAsset a11y-light theme background is near-white`() {
         val result = ThemeParser.parseAsset(context, "a11y-light.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFfefefe))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFfefefe))
     }
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes1Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes1Test.kt
@@ -43,21 +43,21 @@ class ThemeParserMoreThemes1Test {
     fun `parseAsset monokai-sublime keyword is pink`() {
         // .hljs-attr,.hljs-keyword,.hljs-name,.hljs-selector-tag { color: #f92672 }
         val result = ThemeParser.parseAsset(context, "monokai-sublime.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFf92672))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFf92672))
     }
 
     @Test
     fun `parseAsset monokai-sublime comment is muted brown`() {
         // .hljs-comment,.hljs-deletion,.hljs-meta { color: #75715e }
         val result = ThemeParser.parseAsset(context, "monokai-sublime.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF75715e))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF75715e))
     }
 
     @Test
     fun `parseAsset monokai-sublime string is yellow`() {
         // .hljs-string (among others) { color: #e6db74 }
         val result = ThemeParser.parseAsset(context, "monokai-sublime.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFFe6db74))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFFe6db74))
     }
 
     // ── panda-syntax-light ─────────────────────────────────────────────────────────────────────────
@@ -74,21 +74,21 @@ class ThemeParserMoreThemes1Test {
     fun `parseAsset panda-syntax-light keyword is magenta`() {
         // .hljs-deletion,.hljs-keyword { color: #d92792 }
         val result = ThemeParser.parseAsset(context, "panda-syntax-light.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFd92792))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFd92792))
     }
 
     @Test
     fun `parseAsset panda-syntax-light comment is muted gray`() {
         // .hljs-comment,.hljs-quote { color: #676b79 }
         val result = ThemeParser.parseAsset(context, "panda-syntax-light.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF676b79))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF676b79))
     }
 
     @Test
     fun `parseAsset panda-syntax-light string is dark teal`() {
         // .hljs-string (among others) { color: #0d7d6c }
         val result = ThemeParser.parseAsset(context, "panda-syntax-light.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF0d7d6c))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF0d7d6c))
     }
 
     // ── docco ──────────────────────────────────────────────────────────────────────────────────────
@@ -105,28 +105,28 @@ class ThemeParserMoreThemes1Test {
     fun `parseAsset docco keyword is brown-red`() {
         // .hljs-keyword,.hljs-literal,.hljs-selector-tag,.hljs-subst { color: #954121 }
         val result = ThemeParser.parseAsset(context, "docco.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF954121))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF954121))
     }
 
     @Test
     fun `parseAsset docco tag uses named color navy`() {
         // .hljs-attribute,.hljs-name,.hljs-tag { color: navy } - CSS named navy = #000080
         val result = ThemeParser.parseAsset(context, "docco.min.css")
-        assertThat(result["hljs-tag"]?.color).isEqualTo(Color(0xFF000080))
+        assertThat(result[HljsSelectors.TAG]?.color).isEqualTo(Color(0xFF000080))
     }
 
     @Test
     fun `parseAsset docco variable uses named color teal`() {
         // .hljs-template-variable,.hljs-variable { color: teal } - CSS named teal = #008080
         val result = ThemeParser.parseAsset(context, "docco.min.css")
-        assertThat(result["hljs-variable"]?.color).isEqualTo(Color(0xFF008080))
+        assertThat(result[HljsSelectors.VARIABLE]?.color).isEqualTo(Color(0xFF008080))
     }
 
     @Test
     fun `parseAsset docco params uses 3-digit hex #00f`() {
         // .hljs-params { color: #00f } - 3-digit hex expands to #0000ff
         val result = ThemeParser.parseAsset(context, "docco.min.css")
-        assertThat(result["hljs-params"]?.color).isEqualTo(Color(0xFF0000ff))
+        assertThat(result[HljsSelectors.PARAMS]?.color).isEqualTo(Color(0xFF0000ff))
     }
 
     // ── tomorrow-night-blue ────────────────────────────────────────────────────────────────────────
@@ -149,14 +149,14 @@ class ThemeParserMoreThemes1Test {
     fun `parseAsset tomorrow-night-blue keyword is lavender`() {
         // .hljs-keyword,.hljs-selector-tag { color: #ebbbff }
         val result = ThemeParser.parseAsset(context, "tomorrow-night-blue.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFebbbff))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFebbbff))
     }
 
     @Test
     fun `parseAsset tomorrow-night-blue comment is muted blue`() {
         // .hljs-comment,.hljs-quote { color: #7285b7 }
         val result = ThemeParser.parseAsset(context, "tomorrow-night-blue.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF7285b7))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF7285b7))
     }
 
     // ── stackoverflow-dark ─────────────────────────────────────────────────────────────────────────
@@ -176,20 +176,20 @@ class ThemeParserMoreThemes1Test {
         // The descendant .hljs-meta .hljs-keyword must be skipped, but standalone hljs-keyword
         // must still receive the correct color.
         val result = ThemeParser.parseAsset(context, "stackoverflow-dark.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF88aece))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF88aece))
     }
 
     @Test
     fun `parseAsset stackoverflow-dark comment uses 3-digit hex #999`() {
         // .hljs-comment { color: #999 } - 3-digit hex expands to #999999
         val result = ThemeParser.parseAsset(context, "stackoverflow-dark.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF999999))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF999999))
     }
 
     @Test
     fun `parseAsset stackoverflow-dark string is olive green`() {
         // .hljs-string (among others) { color: #b5bd68 }
         val result = ThemeParser.parseAsset(context, "stackoverflow-dark.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFFb5bd68))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFFb5bd68))
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes1Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes1Test.kt
@@ -30,13 +30,13 @@ class ThemeParserMoreThemes1Test {
     @Test
     fun `parseAsset monokai-sublime background is dark`() {
         val result = ThemeParser.parseAsset(context, "monokai-sublime.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF23241f))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF23241f))
     }
 
     @Test
     fun `parseAsset monokai-sublime base text color is off-white`() {
         val result = ThemeParser.parseAsset(context, "monokai-sublime.min.css")
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFf8f8f2))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFf8f8f2))
     }
 
     @Test
@@ -67,7 +67,7 @@ class ThemeParserMoreThemes1Test {
     @Test
     fun `parseAsset panda-syntax-light background is light gray`() {
         val result = ThemeParser.parseAsset(context, "panda-syntax-light.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFe6e6e6))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFe6e6e6))
     }
 
     @Test
@@ -98,7 +98,7 @@ class ThemeParserMoreThemes1Test {
     @Test
     fun `parseAsset docco background is near-white`() {
         val result = ThemeParser.parseAsset(context, "docco.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFf8f8ff))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFf8f8ff))
     }
 
     @Test
@@ -135,14 +135,14 @@ class ThemeParserMoreThemes1Test {
     @Test
     fun `parseAsset tomorrow-night-blue background is deep blue`() {
         val result = ThemeParser.parseAsset(context, "tomorrow-night-blue.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF002451))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF002451))
     }
 
     @Test
     fun `parseAsset tomorrow-night-blue base text is white via 3-digit hex`() {
         // .hljs { color: #fff } - 3-digit hex #fff expands to #ffffff
         val result = ThemeParser.parseAsset(context, "tomorrow-night-blue.min.css")
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFffffff))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFffffff))
     }
 
     @Test
@@ -167,7 +167,7 @@ class ThemeParserMoreThemes1Test {
     @Test
     fun `parseAsset stackoverflow-dark background is near-black`() {
         val result = ThemeParser.parseAsset(context, "stackoverflow-dark.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF1c1b1b))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF1c1b1b))
     }
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes2Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes2Test.kt
@@ -34,14 +34,14 @@ class ThemeParserMoreThemes2Test {
     fun `parseAsset agate background is dark gray`() {
         // .hljs { background: #333 } - 3-digit hex expands to #333333
         val result = ThemeParser.parseAsset(context, "agate.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF333333))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF333333))
     }
 
     @Test
     fun `parseAsset agate base text is white via 3-digit hex`() {
         // .hljs { color: #fff } - 3-digit hex expands to #ffffff
         val result = ThemeParser.parseAsset(context, "agate.min.css")
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFffffff))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFffffff))
     }
 
     @Test
@@ -71,7 +71,7 @@ class ThemeParserMoreThemes2Test {
     @Test
     fun `parseAsset routeros background is light gray`() {
         val result = ThemeParser.parseAsset(context, "routeros.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFf0f0f0))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFf0f0f0))
     }
 
     @Test
@@ -103,7 +103,7 @@ class ThemeParserMoreThemes2Test {
     @Test
     fun `parseAsset grayscale background is white`() {
         val result = ThemeParser.parseAsset(context, "grayscale.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFffffff))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFffffff))
     }
 
     @Test
@@ -137,7 +137,7 @@ class ThemeParserMoreThemes2Test {
     @Test
     fun `parseAsset xcode background is white`() {
         val result = ThemeParser.parseAsset(context, "xcode.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFffffff))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFffffff))
     }
 
     @Test
@@ -170,13 +170,13 @@ class ThemeParserMoreThemes2Test {
     @Test
     fun `parseAsset paraiso-light background is warm off-white`() {
         val result = ThemeParser.parseAsset(context, "paraiso-light.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFe7e9db))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFe7e9db))
     }
 
     @Test
     fun `parseAsset paraiso-light base text color is dark purple-gray`() {
         val result = ThemeParser.parseAsset(context, "paraiso-light.min.css")
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFF4f424c))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF4f424c))
     }
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes2Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes2Test.kt
@@ -48,21 +48,21 @@ class ThemeParserMoreThemes2Test {
     fun `parseAsset agate keyword is peach`() {
         // .hljs-built_in,.hljs-keyword,.hljs-literal,.hljs-selector-tag { color: #fcc28c }
         val result = ThemeParser.parseAsset(context, "agate.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFfcc28c))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFfcc28c))
     }
 
     @Test
     fun `parseAsset agate comment uses 3-digit hex #888`() {
         // .hljs-code,.hljs-comment,.hljs-formula { color: #888 } - 3-digit expands to #888888
         val result = ThemeParser.parseAsset(context, "agate.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF888888))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF888888))
     }
 
     @Test
     fun `parseAsset agate attribute uses 3-digit hex #ffa`() {
         // .hljs-attribute,.hljs-title,.hljs-type { color: #ffa } - expands to #ffffaa
         val result = ThemeParser.parseAsset(context, "agate.min.css")
-        assertThat(result["hljs-attribute"]?.color).isEqualTo(Color(0xFFffffaa))
+        assertThat(result[HljsSelectors.ATTRIBUTE]?.color).isEqualTo(Color(0xFFffffaa))
     }
 
     // ── routeros ───────────────────────────────────────────────────────────────────────────────────
@@ -78,22 +78,22 @@ class ThemeParserMoreThemes2Test {
     fun `parseAsset routeros keyword is bold with no color`() {
         // .hljs-keyword (among others) { font-weight: 700 } - no color declared for keyword
         val result = ThemeParser.parseAsset(context, "routeros.min.css")
-        assertThat(result["hljs-keyword"]?.fontWeight).isEqualTo(FontWeight.Bold)
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color.Unspecified)
+        assertThat(result[HljsSelectors.KEYWORD]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color.Unspecified)
     }
 
     @Test
     fun `parseAsset routeros string uses 3-digit hex #800`() {
         // .hljs-string (among others) { color: #800 } - 3-digit expands to #880000
         val result = ThemeParser.parseAsset(context, "routeros.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF880000))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF880000))
     }
 
     @Test
     fun `parseAsset routeros comment is muted gray`() {
         // .hljs-comment { color: #888 } - 3-digit expands to #888888
         val result = ThemeParser.parseAsset(context, "routeros.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF888888))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF888888))
     }
 
     // ── grayscale ──────────────────────────────────────────────────────────────────────────────────
@@ -110,15 +110,15 @@ class ThemeParserMoreThemes2Test {
     fun `parseAsset grayscale keyword has both color and bold in same rule`() {
         // .hljs-keyword,.hljs-selector-tag,.hljs-subst { color: #333; font-weight: 700 }
         val result = ThemeParser.parseAsset(context, "grayscale.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF333333))
-        assertThat(result["hljs-keyword"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF333333))
+        assertThat(result[HljsSelectors.KEYWORD]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
     fun `parseAsset grayscale comment uses 3-digit hex #777`() {
         // .hljs-comment,.hljs-quote { color: #777 } - 3-digit expands to #777777
         val result = ThemeParser.parseAsset(context, "grayscale.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF777777))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF777777))
     }
 
     @Test
@@ -126,8 +126,8 @@ class ThemeParserMoreThemes2Test {
         // .hljs-string { color: #333; background: url(data:image/png;...) }
         // url() is not a parseable color - background must be Unspecified but color must survive
         val result = ThemeParser.parseAsset(context, "grayscale.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF333333))
-        assertThat(result["hljs-string"]?.background).isEqualTo(Color.Unspecified)
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF333333))
+        assertThat(result[HljsSelectors.STRING]?.background).isEqualTo(Color.Unspecified)
     }
 
     // ── xcode ──────────────────────────────────────────────────────────────────────────────────────
@@ -145,14 +145,14 @@ class ThemeParserMoreThemes2Test {
         // .hljs-attribute,.hljs-keyword,.hljs-literal,.hljs-name,.hljs-selector-tag,.hljs-tag
         //   { color: #aa0d91 }
         val result = ThemeParser.parseAsset(context, "xcode.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFaa0d91))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFaa0d91))
     }
 
     @Test
     fun `parseAsset xcode comment is dark green`() {
         // .hljs-comment,.hljs-quote { color: #007400 }
         val result = ThemeParser.parseAsset(context, "xcode.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF007400))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF007400))
     }
 
     @Test
@@ -161,7 +161,7 @@ class ThemeParserMoreThemes2Test {
         // The descendant .hljs-meta .hljs-string must be skipped, but standalone .hljs-string
         // must still receive the color.
         val result = ThemeParser.parseAsset(context, "xcode.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFFc41a16))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFFc41a16))
     }
 
     // ── paraiso-light ──────────────────────────────────────────────────────────────────────────────
@@ -183,20 +183,20 @@ class ThemeParserMoreThemes2Test {
     fun `parseAsset paraiso-light keyword is purple`() {
         // .hljs-keyword,.hljs-selector-tag { color: #815ba4 }
         val result = ThemeParser.parseAsset(context, "paraiso-light.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF815ba4))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF815ba4))
     }
 
     @Test
     fun `parseAsset paraiso-light string is green`() {
         // .hljs-addition,.hljs-bullet,.hljs-string,.hljs-symbol { color: #48b685 }
         val result = ThemeParser.parseAsset(context, "paraiso-light.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF48b685))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF48b685))
     }
 
     @Test
     fun `parseAsset paraiso-light comment is muted purple`() {
         // .hljs-comment,.hljs-quote { color: #776e71 }
         val result = ThemeParser.parseAsset(context, "paraiso-light.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF776e71))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF776e71))
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes3Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes3Test.kt
@@ -33,8 +33,8 @@ class ThemeParserMoreThemes3Test {
     @Test
     fun `parseAsset arduino-light base hljs background and color`() {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFFFFFFF))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFF434F54))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFFFFFFF))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF434F54))
     }
 
     @Test
@@ -83,8 +83,8 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
         // .hljs{background:#2e3440} and .hljs,.hljs-subst{color:#d8dee9} are two separate rules.
         // SpanStyle merge must preserve background from rule 1 when rule 2 adds color.
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF2E3440))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFD8DEE9))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF2E3440))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFD8DEE9))
     }
 
     @Test
@@ -137,7 +137,7 @@ class ThemeParserMoreThemes3Test {
     fun `parseAsset cybertopia-cherry base hljs not in map because var() colors are unresolvable`() {
         val result = ThemeParser.parseAsset(context, "cybertopia-cherry.min.css")
         // .hljs{color:var(--hljs-mono-1);background:var(--hljs-bg)} → both null → not stored
-        assertThat(result.containsKey("hljs")).isFalse()
+        assertThat(result.containsKey(HljsSelectors.BASE)).isFalse()
     }
 
     @Test
@@ -160,8 +160,8 @@ class ThemeParserMoreThemes3Test {
     @Test
     fun `parseAsset an-old-hope base hljs background and color`() {
         val result = ThemeParser.parseAsset(context, "an-old-hope.min.css")
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF1C1D21))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFC0C5CE))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF1C1D21))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFC0C5CE))
     }
 
     @Test
@@ -183,8 +183,8 @@ class ThemeParserMoreThemes3Test {
     @Test
     fun `parseAsset atom-one-dark base hljs background and color`() {
         val result = ThemeParser.parseAsset(context, "atom-one-dark.min.css")
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFABB2BF))
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF282C34))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFABB2BF))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF282C34))
     }
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes3Test.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserMoreThemes3Test.kt
@@ -42,30 +42,30 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
         // rgba(149,165,166,.8) → alpha = round(0.8 * 255) = 204 = 0xCC
         // ARGB: 0xCC95A5A6
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xCC95A5A6))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xCC95A5A6))
     }
 
     @Test
     fun `parseAsset arduino-light keyword color`() {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF00979D))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF00979D))
     }
 
     @Test
     fun `parseAsset arduino-light section uses 3-digit hex with bold`() {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
         // .hljs-section,.hljs-title{color:#800;font-weight:700} → #800 expands to #880000
-        assertThat(result["hljs-section"]?.color).isEqualTo(Color(0xFF880000))
-        assertThat(result["hljs-section"]?.fontWeight).isEqualTo(FontWeight.Bold)
-        assertThat(result["hljs-title"]?.color).isEqualTo(Color(0xFF880000))
-        assertThat(result["hljs-title"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.SECTION]?.color).isEqualTo(Color(0xFF880000))
+        assertThat(result[HljsSelectors.SECTION]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF880000))
+        assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
     fun `parseAsset arduino-light emphasis is italic and strong is bold`() {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
-        assertThat(result["hljs-emphasis"]?.fontStyle).isEqualTo(FontStyle.Italic)
-        assertThat(result["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.EMPHASIS]?.fontStyle).isEqualTo(FontStyle.Italic)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
@@ -73,7 +73,7 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "arduino-light.min.css")
         // .hljs-meta .hljs-keyword{color:#728e00} has a space → skipped
         // .hljs-meta{color:#434f54} is standalone → stored
-        assertThat(result["hljs-meta"]?.color).isEqualTo(Color(0xFF434F54))
+        assertThat(result[HljsSelectors.META]?.color).isEqualTo(Color(0xFF434F54))
     }
 
     // ── nord ─────────────────────────────────────────────────────────────────
@@ -92,7 +92,7 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
         // .hljs-addition{background-color:rgba(163,190,140,.5)} → alpha=round(0.5*255)=128=0x80
         // ARGB: 0x80A3BE8C
-        assertThat(result["hljs-addition"]?.background).isEqualTo(Color(0x80A3BE8C))
+        assertThat(result[HljsSelectors.ADDITION]?.background).isEqualTo(Color(0x80A3BE8C))
     }
 
     @Test
@@ -100,13 +100,13 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
         // .hljs-deletion{background-color:rgba(191,97,106,.5)} → alpha=128=0x80
         // ARGB: 0x80BF616A
-        assertThat(result["hljs-deletion"]?.background).isEqualTo(Color(0x80BF616A))
+        assertThat(result[HljsSelectors.DELETION]?.background).isEqualTo(Color(0x80BF616A))
     }
 
     @Test
     fun `parseAsset nord keyword color`() {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF81A1C1))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF81A1C1))
     }
 
     @Test
@@ -114,14 +114,14 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
         // language-css .hljs-keyword{color:#d08770} has a space → skipped
         // Top-level .hljs-keyword{color:#81a1c1} wins
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF81A1C1))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF81A1C1))
     }
 
     @Test
     fun `parseAsset nord string and comment colors`() {
         val result = ThemeParser.parseAsset(context, "nord.min.css")
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFFA3BE8C))
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF4C566A))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFFA3BE8C))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF4C566A))
     }
 
     // ── cybertopia-cherry ─────────────────────────────────────────────────────
@@ -145,14 +145,14 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "cybertopia-cherry.min.css")
         // .hljs-code,.hljs-comment,.hljs-quote{color:var(...);font-style:italic}
         // color=null but fontStyle=Italic → rule IS stored
-        assertThat(result["hljs-comment"]?.fontStyle).isEqualTo(FontStyle.Italic)
-        assertThat(result["hljs-quote"]?.fontStyle).isEqualTo(FontStyle.Italic)
+        assertThat(result[HljsSelectors.COMMENT]?.fontStyle).isEqualTo(FontStyle.Italic)
+        assertThat(result[HljsSelectors.QUOTE]?.fontStyle).isEqualTo(FontStyle.Italic)
     }
 
     @Test
     fun `parseAsset cybertopia-cherry strong is bold`() {
         val result = ThemeParser.parseAsset(context, "cybertopia-cherry.min.css")
-        assertThat(result["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     // ── an-old-hope ───────────────────────────────────────────────────────────
@@ -167,15 +167,15 @@ class ThemeParserMoreThemes3Test {
     @Test
     fun `parseAsset an-old-hope keyword and string colors`() {
         val result = ThemeParser.parseAsset(context, "an-old-hope.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFB45EA4))
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF4FB4D7))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFB45EA4))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF4FB4D7))
     }
 
     @Test
     fun `parseAsset an-old-hope comment and attribute colors`() {
         val result = ThemeParser.parseAsset(context, "an-old-hope.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFFB6B18B))
-        assertThat(result["hljs-attribute"]?.color).isEqualTo(Color(0xFFEE7C2B))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFFB6B18B))
+        assertThat(result[HljsSelectors.ATTRIBUTE]?.color).isEqualTo(Color(0xFFEE7C2B))
     }
 
     // ── atom-one-dark ─────────────────────────────────────────────────────────
@@ -190,7 +190,7 @@ class ThemeParserMoreThemes3Test {
     @Test
     fun `parseAsset atom-one-dark keyword color`() {
         val result = ThemeParser.parseAsset(context, "atom-one-dark.min.css")
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFC678DD))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFC678DD))
     }
 
     @Test
@@ -198,7 +198,7 @@ class ThemeParserMoreThemes3Test {
         val result = ThemeParser.parseAsset(context, "atom-one-dark.min.css")
         // Selector list includes ".hljs-meta .hljs-string" (has space → skipped)
         // Top-level ".hljs-string" in the same rule still gets #98c379
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF98C379))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF98C379))
     }
 
     @Test
@@ -207,7 +207,7 @@ class ThemeParserMoreThemes3Test {
         // .hljs-built_in,.hljs-class .hljs-title,.hljs-title.class_{color:#e6c07b}
         // .hljs-class .hljs-title has space → skipped
         // .hljs-built_in gets #e6c07b
-        assertThat(result["hljs-built_in"]?.color).isEqualTo(Color(0xFFE6C07B))
+        assertThat(result[HljsSelectors.BUILT_IN]?.color).isEqualTo(Color(0xFFE6C07B))
     }
 
     @Test
@@ -216,13 +216,13 @@ class ThemeParserMoreThemes3Test {
         // .hljs-bullet,.hljs-link,...{color:#61aeee} stores hljs-link with color
         // .hljs-link{text-decoration:underline} → parseDeclarations returns null (not parsed) → skipped
         // The earlier color must not be overwritten
-        assertThat(result["hljs-link"]?.color).isEqualTo(Color(0xFF61AEEE))
+        assertThat(result[HljsSelectors.LINK]?.color).isEqualTo(Color(0xFF61AEEE))
     }
 
     @Test
     fun `parseAsset atom-one-dark comment is italic and has color`() {
         val result = ThemeParser.parseAsset(context, "atom-one-dark.min.css")
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF5C6370))
-        assertThat(result["hljs-comment"]?.fontStyle).isEqualTo(FontStyle.Italic)
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF5C6370))
+        assertThat(result[HljsSelectors.COMMENT]?.fontStyle).isEqualTo(FontStyle.Italic)
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -47,7 +47,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts color for hljs-comment`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs-comment"]
+        val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0xFF8e908c.toInt()))
     }
@@ -55,7 +55,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts color for hljs-keyword from compound selector`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs-keyword"]
+        val style = result[HljsSelectors.KEYWORD]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0xFF8959a8.toInt()))
     }
@@ -63,7 +63,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts color for hljs-string`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs-string"]
+        val style = result[HljsSelectors.STRING]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0xFF718c00.toInt()))
     }
@@ -79,7 +79,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts font-weight bold`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs-strong"]
+        val style = result[HljsSelectors.STRONG]
         assertThat(style).isNotNull()
         assertThat(style!!.fontWeight).isEqualTo(FontWeight.Bold)
         assertThat(style.color).isEqualTo(Color(0xFFeab700.toInt()))
@@ -88,7 +88,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts font-style italic`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs-emphasis"]
+        val style = result[HljsSelectors.EMPHASIS]
         assertThat(style).isNotNull()
         assertThat(style!!.fontStyle).isEqualTo(FontStyle.Italic)
     }
@@ -96,8 +96,8 @@ class ThemeParserTest {
     @Test
     fun `parse handles compound selector hljs-title-function_`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        // ".hljs-title.function_" should produce "hljs-title.function_" key
-        val style = result["hljs-title.function_"]
+        // ".hljs-title.function_" should produce HljsSelectors.TITLE_FUNCTION key
+        val style = result[HljsSelectors.TITLE_FUNCTION]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0xFF4271ae.toInt()))
     }
@@ -126,14 +126,14 @@ class ThemeParserTest {
         val css = ".hljs-operator { opacity: 0.7 }"
         val result = ThemeParser.parse(css)
         // opacity is not a supported property, so no entry should be created
-        assertThat(result["hljs-operator"]).isNull()
+        assertThat(result[HljsSelectors.OPERATOR]).isNull()
     }
 
     @Test
     fun `parse handles 3-digit hex colors`() {
         val css = ".hljs-comment { color: #abc }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-comment"]
+        val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
         // #abc expands to #aabbcc
         assertThat(style!!.color).isEqualTo(Color(0xFFaabbcc.toInt()))
@@ -144,14 +144,14 @@ class ThemeParserTest {
         val minified = ".hljs{color:#4d4d4c;background:#fff}.hljs-keyword{color:#8959a8}"
         val result = ThemeParser.parse(minified)
         assertThat(result[HljsSelectors.BASE]).isNotNull()
-        assertThat(result["hljs-keyword"]).isNotNull()
+        assertThat(result[HljsSelectors.KEYWORD]).isNotNull()
     }
 
     @Test
     fun `parse handles rgb color format`() {
         val css = ".hljs-comment { color: rgb(142, 144, 140) }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-comment"]
+        val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(142, 144, 140))
     }
@@ -160,7 +160,7 @@ class ThemeParserTest {
     fun `parse handles rgba with fractional alpha`() {
         val css = ".hljs-keyword { color: rgba(255, 0, 128, 0.75); }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-keyword"]
+        val style = result[HljsSelectors.KEYWORD]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(255, 0, 128, 191)) // 0.75 * 255 ≈ 191
     }
@@ -169,7 +169,7 @@ class ThemeParserTest {
     fun `parse handles rgba with integer alpha`() {
         val css = ".hljs-string { color: rgba(0, 128, 255, 200); }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-string"]
+        val style = result[HljsSelectors.STRING]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(0, 128, 255, 200))
     }
@@ -178,7 +178,7 @@ class ThemeParserTest {
     fun `parse handles rgba with leading-dot fractional alpha`() {
         val css = ".hljs-comment { color: rgba(255, 0, 0, .75); }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-comment"]
+        val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(255, 0, 0, 191)) // 0.75 * 255 ≈ 191
     }
@@ -196,7 +196,7 @@ class ThemeParserTest {
     fun `parse treats font-weight 700 as bold`() {
         val css = ".hljs-strong { font-weight: 700; color: #eab700 }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-strong"]
+        val style = result[HljsSelectors.STRONG]
         assertThat(style).isNotNull()
         assertThat(style!!.fontWeight).isEqualTo(FontWeight.Bold)
     }
@@ -205,42 +205,42 @@ class ThemeParserTest {
     fun `parse treats font-weight 600 as bold`() {
         val css = ".hljs-strong { font-weight: 600 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
     fun `parse treats font-weight 800 as bold`() {
         val css = ".hljs-strong { font-weight: 800 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
     fun `parse treats font-weight 900 as bold`() {
         val css = ".hljs-strong { font-weight: 900 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-strong"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     @Test
     fun `parse treats font-weight 400 as normal`() {
         val css = ".hljs-comment { font-weight: 400; color: #888 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-comment"]?.fontWeight).isEqualTo(FontWeight.Normal)
+        assertThat(result[HljsSelectors.COMMENT]?.fontWeight).isEqualTo(FontWeight.Normal)
     }
 
     @Test
     fun `parse treats font-weight 100 as normal`() {
         val css = ".hljs-comment { font-weight: 100; color: #888 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-comment"]?.fontWeight).isEqualTo(FontWeight.Normal)
+        assertThat(result[HljsSelectors.COMMENT]?.fontWeight).isEqualTo(FontWeight.Normal)
     }
 
     @Test
     fun `parse treats font-weight normal keyword as normal`() {
         val css = ".hljs-comment { font-weight: normal; color: #888 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-comment"]?.fontWeight).isEqualTo(FontWeight.Normal)
+        assertThat(result[HljsSelectors.COMMENT]?.fontWeight).isEqualTo(FontWeight.Normal)
     }
 
     @Test
@@ -248,7 +248,7 @@ class ThemeParserTest {
         // 8-digit hex: first two digits are alpha (AARRGGBB), rest are RGB
         val css = ".hljs-comment { color: #ff8e908c }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-comment"]
+        val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
     }
 
@@ -258,7 +258,7 @@ class ThemeParserTest {
         val css = ".hljs-meta .hljs-keyword { color: #8959a8 }"
         val result = ThemeParser.parse(css)
         // The descendant selector should not create an entry for hljs-keyword
-        assertThat(result["hljs-keyword"]).isNull()
+        assertThat(result[HljsSelectors.KEYWORD]).isNull()
     }
 
     @Test
@@ -287,7 +287,7 @@ class ThemeParserTest {
     fun `parse handles CSS named color red`() {
         val css = ".hljs-keyword { color: red }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFFF0000))
     }
 
     @Test
@@ -295,7 +295,7 @@ class ThemeParserTest {
         val css = ".hljs-comment { color: green }"
         val result = ThemeParser.parse(css)
         // CSS named 'green' = #008000 (not #00ff00)
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF008000))
     }
 
     @Test
@@ -309,8 +309,8 @@ class ThemeParserTest {
     fun `parse handles CSS named colors grey and silver`() {
         val css = ".hljs-comment { color: grey } .hljs-tag { color: silver }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF808080))
-        assertThat(result["hljs-tag"]?.color).isEqualTo(Color(0xFFC0C0C0))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF808080))
+        assertThat(result[HljsSelectors.TAG]?.color).isEqualTo(Color(0xFFC0C0C0))
     }
 
     @Test
@@ -322,24 +322,24 @@ class ThemeParserTest {
         // Verify via valid hljs selectors
         val css2 = ".hljs-keyword { color: navy } .hljs-string { color: olive }"
         val result2 = ThemeParser.parse(css2)
-        assertThat(result2["hljs-keyword"]?.color).isEqualTo(Color(0xFF000080))
-        assertThat(result2["hljs-string"]?.color).isEqualTo(Color(0xFF808000))
+        assertThat(result2[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF000080))
+        assertThat(result2[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF808000))
     }
 
     @Test
     fun `parse handles CSS named color gold and orange`() {
         val css = ".hljs-number { color: gold } .hljs-literal { color: orange }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-number"]?.color).isEqualTo(Color(0xFFFFD700))
-        assertThat(result["hljs-literal"]?.color).isEqualTo(Color(0xFFFFA500))
+        assertThat(result[HljsSelectors.NUMBER]?.color).isEqualTo(Color(0xFFFFD700))
+        assertThat(result[HljsSelectors.LITERAL]?.color).isEqualTo(Color(0xFFFFA500))
     }
 
     @Test
     fun `parse is case-insensitive for named colors`() {
         val css = ".hljs-keyword { color: RED } .hljs-string { color: Green }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF008000))
     }
 
     @Test
@@ -348,8 +348,8 @@ class ThemeParserTest {
         val result = ThemeParser.parse(css)
         // inherit and CSS variables are not parseable - entries should have no color set
         // (they may still appear if font-weight/style was set, but color should be Unspecified)
-        result["hljs-keyword"]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
-        result["hljs-string"]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
+        result[HljsSelectors.KEYWORD]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
+        result[HljsSelectors.STRING]?.let { assertThat(it.color).isEqualTo(Color.Unspecified) }
     }
 
     // ----- 4-digit hex color tests -----
@@ -359,7 +359,7 @@ class ThemeParserTest {
         // #444a = R:0x44=68, G:0x44=68, B:0x44=68, A:0xaa=170
         val css = ".hljs-tag { color: #444a }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-tag"]
+        val style = result[HljsSelectors.TAG]
         assertThat(style).isNotNull()
         assertThat(style!!.color).isEqualTo(Color(68, 68, 68, 170))
     }
@@ -370,7 +370,7 @@ class ThemeParserTest {
         // #f0af = R:0xff=255, G:0x00=0, B:0xaa=170, A:0xff=255
         val css = ".hljs-keyword { color: #f00f }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs-keyword"]
+        val style = result[HljsSelectors.KEYWORD]
         assertThat(style).isNotNull()
         // #f00f = R:0xff, G:0x00, B:0x00, A:0xff
         assertThat(style!!.color).isEqualTo(Color(255, 0, 0, 255))
@@ -392,9 +392,9 @@ class ThemeParserTest {
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFFFFFFF))
         assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF0000FF))
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF000000))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFFF0000))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF008000))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF000000))
     }
 
     // ----- a11y-light theme regression -----
@@ -414,7 +414,7 @@ class ThemeParserTest {
                 "}"
         val result = ThemeParser.parse(css)
         // Color must be the purple from the real rule, not lost due to @media override
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF7928a1))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF7928a1))
     }
 
     @Test
@@ -425,8 +425,8 @@ class ThemeParserTest {
                 "@media print{.hljs-string{color:black}}" +
                 ".hljs-number{color:#f5871f}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF718c00))
-        assertThat(result["hljs-number"]?.color).isEqualTo(Color(0xFFf5871f))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF718c00))
+        assertThat(result[HljsSelectors.NUMBER]?.color).isEqualTo(Color(0xFFf5871f))
     }
 
     // ----- descendant non-hljs selector regression -----
@@ -475,7 +475,7 @@ class ThemeParserTest {
             ".hljs-keyword{color:#aabbcc}" +
                 ".hljs-keyword{color:#112233}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFF112233))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFF112233))
     }
 
     @Test
@@ -484,8 +484,8 @@ class ThemeParserTest {
             ".hljs-title{color:#78bb65}" +
                 ".hljs-title{font-weight:700}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-title"]?.color).isEqualTo(Color(0xFF78BB65))
-        assertThat(result["hljs-title"]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF78BB65))
+        assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
     }
 
     // ----- CSS4 rgb() space-separated syntax -----
@@ -494,7 +494,7 @@ class ThemeParserTest {
     fun `parse handles CSS4 rgb space-separated without alpha`() {
         val css = ".hljs-keyword { color: rgb(255 0 128) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(255, 0, 128))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(255, 0, 128))
     }
 
     @Test
@@ -502,7 +502,7 @@ class ThemeParserTest {
         val css = ".hljs-keyword { color: rgb(255 0 128 / 0.5) }"
         val result = ThemeParser.parse(css)
         // 0.5 * 255 = 127.5, roundToInt = 128
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(255, 0, 128, 128))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(255, 0, 128, 128))
     }
 
     @Test
@@ -510,7 +510,7 @@ class ThemeParserTest {
         // CSS4 allows rgba() with space-separated values just like rgb()
         val css = ".hljs-comment { color: rgba(255 0 128 / 0.5) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(255, 0, 128, 128))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(255, 0, 128, 128))
     }
 
     @Test
@@ -518,7 +518,7 @@ class ThemeParserTest {
         // 100% = 255, 0% = 0, 50% = 127
         val css = ".hljs-string { color: rgb(100% 0% 50%) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(255, 0, 127))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(255, 0, 127))
     }
 
     @Test
@@ -526,7 +526,7 @@ class ThemeParserTest {
         // 100%=255, 0%=0, 50%=127, alpha 50%=127
         val css = ".hljs-string { color: rgb(100% 0% 50% / 50%) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(255, 0, 127, 127))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(255, 0, 127, 127))
     }
 
     @Test
@@ -561,9 +561,9 @@ class ThemeParserTest {
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(30, 30, 30))
         assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(212, 212, 212))
-        assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(86, 156, 214))
-        assertThat(result["hljs-string"]?.color).isEqualTo(Color(206, 145, 120))
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(86, 156, 214))
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(206, 145, 120))
         // 0.8 * 255 = 204
-        assertThat(result["hljs-comment"]?.color).isEqualTo(Color(106, 153, 85, 204))
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(106, 153, 85, 204))
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -71,7 +71,7 @@ class ThemeParserTest {
     @Test
     fun `parse extracts hljs background color`() {
         val result = ThemeParser.parse(tomorrowCssSample)
-        val style = result["hljs"]
+        val style = result[HljsSelectors.BASE]
         assertThat(style).isNotNull()
         assertThat(style!!.background).isEqualTo(Color(0xFFffffff.toInt()))
     }
@@ -143,7 +143,7 @@ class ThemeParserTest {
     fun `parse handles minified CSS without whitespace`() {
         val minified = ".hljs{color:#4d4d4c;background:#fff}.hljs-keyword{color:#8959a8}"
         val result = ThemeParser.parse(minified)
-        assertThat(result["hljs"]).isNotNull()
+        assertThat(result[HljsSelectors.BASE]).isNotNull()
         assertThat(result["hljs-keyword"]).isNotNull()
     }
 
@@ -187,7 +187,7 @@ class ThemeParserTest {
     fun `parse handles background-color property`() {
         val css = ".hljs { background-color: #1e1e1e }"
         val result = ThemeParser.parse(css)
-        val style = result["hljs"]
+        val style = result[HljsSelectors.BASE]
         assertThat(style).isNotNull()
         assertThat(style!!.background).isEqualTo(Color(0xFF1e1e1e.toInt()))
     }
@@ -270,7 +270,7 @@ class ThemeParserTest {
                 ".hljs ::selection, .hljs::selection { background-color: #516d7b; color: #7ea2b4 }"
         val result = ThemeParser.parse(css)
         // The real background color must be preserved
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF161b1d))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF161b1d))
     }
 
     @Test
@@ -278,7 +278,7 @@ class ThemeParserTest {
         // :focus, :hover etc. should not pollute the color map
         val css = ".hljs { background: #1e1e1e } .hljs:hover { background: #ff0000 }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF1e1e1e))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF1e1e1e))
     }
 
     // ----- Named color tests -----
@@ -302,7 +302,7 @@ class ThemeParserTest {
     fun `parse handles CSS named color white as background`() {
         val css = ".hljs { color: blue; background: white }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFFFFFFF))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFFFFFFF))
     }
 
     @Test
@@ -390,8 +390,8 @@ class ThemeParserTest {
                 ".hljs-keyword,.hljs-name,.hljs-function{color:red}" +
                 ".hljs-string,.hljs-number{color:#000}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFFFFFFFF))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFF0000FF))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFFFFFFF))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF0000FF))
         assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(0xFFFF0000))
         assertThat(result["hljs-comment"]?.color).isEqualTo(Color(0xFF008000))
         assertThat(result["hljs-string"]?.color).isEqualTo(Color(0xFF000000))
@@ -442,8 +442,8 @@ class ThemeParserTest {
                 ".hljs mark{background:#555;color:inherit}"
         val result = ThemeParser.parse(css)
         // Real background must survive - .hljs mark must not overwrite it
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF333333))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFffffff))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF333333))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFffffff))
     }
 
     @Test
@@ -453,19 +453,19 @@ class ThemeParserTest {
             ".hljs{background:#fff;color:#000}" +
                 ".hljs a{color:inherit}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFF000000))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF000000))
     }
 
     @Test
     fun `parse split rules for same selector merges SpanStyle preserving earlier properties`() {
         // e.g. nord theme: .hljs{background:#2e3440} followed by .hljs,.hljs-subst{color:#d8dee9}
-        // Without merge, the second rule would overwrite result["hljs"], losing the background.
+        // Without merge, the second rule would overwrite result[HljsSelectors.BASE], losing the background.
         val css =
             ".hljs{background:#2e3440}" +
                 ".hljs,.hljs-subst{color:#d8dee9}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.background).isEqualTo(Color(0xFF2E3440))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0xFFD8DEE9))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFF2E3440))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFFD8DEE9))
     }
 
     @Test
@@ -533,21 +533,21 @@ class ThemeParserTest {
     fun `parse handles CSS4 rgb black edge case`() {
         val css = ".hljs { color: rgb(0 0 0) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0, 0, 0))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0, 0, 0))
     }
 
     @Test
     fun `parse handles CSS4 rgb opaque white with slash alpha 1`() {
         val css = ".hljs { color: rgb(255 255 255 / 1) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.color).isEqualTo(Color(255, 255, 255, 255))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(255, 255, 255, 255))
     }
 
     @Test
     fun `parse handles CSS4 rgb transparent black with slash alpha 0`() {
         val css = ".hljs { color: rgb(0 0 0 / 0) }"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.color).isEqualTo(Color(0, 0, 0, 0))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0, 0, 0, 0))
     }
 
     @Test
@@ -559,8 +559,8 @@ class ThemeParserTest {
                 ".hljs-string{color:rgb(206 145 120)}" +
                 ".hljs-comment{color:rgb(106 153 85 / 0.8)}"
         val result = ThemeParser.parse(css)
-        assertThat(result["hljs"]?.background).isEqualTo(Color(30, 30, 30))
-        assertThat(result["hljs"]?.color).isEqualTo(Color(212, 212, 212))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(30, 30, 30))
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(212, 212, 212))
         assertThat(result["hljs-keyword"]?.color).isEqualTo(Color(86, 156, 214))
         assertThat(result["hljs-string"]?.color).isEqualTo(Color(206, 145, 120))
         // 0.8 * 255 = 204


### PR DESCRIPTION
## Summary

Extracts hardcoded `"hljs"` string literals into a documented constants object to eliminate duplication and improve maintainability.

### Changes

- **Created `HljsSelectors.kt`** - Internal object with documented constants for all known highlight.js CSS selector keys:
  - `BASE` (`"hljs"`) - Root container rule for default text/background colors
  - Common token selectors: `KEYWORD`, `STRING`, `NUMBER`, `COMMENT`, `LITERAL`, `TYPE`, `TITLE`, `NAME`, `BUILT_IN`, `ATTR`, `SELECTOR_TAG`, `STRONG`, `EMPHASIS`, `QUOTE`, `TAG`, `OPERATOR`, `ADDITION`
  - Compound selectors: `TITLE_FUNCTION` (`"hljs-title.function_"`), `META`

- **Replaced 80+ occurrences** of hardcoded `"hljs"` string literals across:
  - Production code: `HighlightTheme.kt`, `HtmlToAnnotatedString.kt`
  - Test files: `ThemeParserTest.kt`, `HtmlToAnnotatedStringTest.kt`, `HighlightThemeTest.kt`, `ThemeParserAssetTest.kt`, `ThemeParserMoreThemes1Test.kt`, `ThemeParserMoreThemes2Test.kt`, `ThemeParserMoreThemes3Test.kt`, `HighlightThemeAssetTest.kt`

### Why

The `"hljs"` base selector is used in 12+ places across production code to look up the root theme entry for default text and background colors. Repeating this string literal is error-prone and makes refactoring harder. Token-specific selectors (like `"hljs-keyword"`) remain as string literals in tests since they are theme-dependent and discovered at runtime, but the constants are available for documentation and future use.

### Verification

- All JVM unit tests pass (`./gradlew :compose-highlight:test`)
- No ktlint violations (`./gradlew lintKotlin`)
- Formatting clean (`./gradlew formatKotlin`)