### PR TITLE
feat: enhance HljsSelectors with all official hljs scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - **Enhanced `HljsSelectors` with all official hljs scopes** - reorganized constants by official
   highlight.js categories (General purpose, Title subscopes, Meta, Tags/attributes, CSS selectors,
-  Text markup, Templates, Diff, Other) and added 23 new selectors missing from the original
+  Text markup, Templates, Diff, Other) and added 22 new selectors missing from the original
   extraction: `PUNCTUATION`, `PROPERTY`, `CHAR`, `CHAR_ESCAPE`, `SUBST`, `VARIABLE_LANGUAGE`,
   `VARIABLE_CONSTANT`, `TITLE_CLASS`, `TITLE_CLASS_INHERITED`, `TITLE_FUNCTION_INVOKE`,
   `META_KEYWORD`, `META_STRING`, `META_PROMPT`, `SELECTOR_ID`, `SELECTOR_CLASS`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,19 @@ All notable changes to this project will be documented in this file.
 
 - **Enhanced `HljsSelectors` with all official hljs scopes** - reorganized constants by official
   highlight.js categories (General purpose, Title subscopes, Meta, Tags/attributes, CSS selectors,
-  Text markup, Templates, Diff, Other) and added 22 new selectors missing from the original
-  extraction: `PUNCTUATION`, `PROPERTY`, `CHAR`, `SUBST`, `VARIABLE_LANGUAGE`,
+  Text markup, Templates, Diff, Other) and added 23 new selectors missing from the original
+  extraction: `PUNCTUATION`, `PROPERTY`, `CHAR`, `CHAR_ESCAPE`, `SUBST`, `VARIABLE_LANGUAGE`,
   `VARIABLE_CONSTANT`, `TITLE_CLASS`, `TITLE_CLASS_INHERITED`, `TITLE_FUNCTION_INVOKE`,
   `META_KEYWORD`, `META_STRING`, `META_PROMPT`, `SELECTOR_ID`, `SELECTOR_CLASS`,
   `SELECTOR_ATTR`, `SELECTOR_PSEUDO`, `CODE`, `TEMPLATE_TAG`, `TEMPLATE_VARIABLE`, `ATRULE`,
-  `DOCTAG`, `NAME`. Added `@see` links to official hljs CSS Classes Reference and Theme Guide.
-  Documented which scopes are newer/not universal per official docs. Closes #261.
+  `DOCTAG`. Added `@see` links to official hljs CSS Classes Reference and Theme Guide.
+  Documented which scopes are newer/not universal per official docs. Made `HljsSelectors`
+  public so consuming apps can use the constants when building color maps for
+  `HighlightTheme.fromColorMap`. Closes #261.
 
 ### Tests
 
-- **`HljsSelectorsParserTest`** - 48 new JVM unit tests verifying that `ThemeParser` correctly
+- **`HljsSelectorsParserTest`** - New JVM unit test class verifying that `ThemeParser` correctly
   parses every selector defined in `HljsSelectors`. Tests cover color, background, fontWeight,
   and fontStyle extraction for each selector, plus compound selector tests for comma-separated
   rules. Organized by official hljs categories matching `HljsSelectors` structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,22 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
-- **Extract `HljsSelectors` constants object** - all known highlight.js CSS selector keys
-  (`BASE`, `KEYWORD`, `STRING`, `COMMENT`, `NUMBER`, `LITERAL`, `TYPE`, `TITLE`, `NAME`,
-  `BUILT_IN`, `ATTR`, `SELECTOR_TAG`, `STRONG`, `EMPHASIS`, `QUOTE`, `TAG`, `OPERATOR`,
-  `ADDITION`, `TITLE_FUNCTION`, `META`, `VARIABLE`, `PARAMS`, `ATTRIBUTE`, `SECTION`,
-  `SYMBOL`, `BULLET`, `FORMULA`, `DELETION`, `LINK`, `REGEXP`) are now defined as
-  documented constants in `HljsSelectors.kt`. Replaced 100+ hardcoded string literals
-  across production code and test files with these constants.
+- **Enhanced `HljsSelectors` with all official hljs scopes** - reorganized constants by official
+  highlight.js categories (General purpose, Title subscopes, Meta, Tags/attributes, CSS selectors,
+  Text markup, Templates, Diff, Other) and added 22 new selectors missing from the original
+  extraction: `PUNCTUATION`, `PROPERTY`, `CHAR`, `SUBST`, `VARIABLE_LANGUAGE`,
+  `VARIABLE_CONSTANT`, `TITLE_CLASS`, `TITLE_CLASS_INHERITED`, `TITLE_FUNCTION_INVOKE`,
+  `META_KEYWORD`, `META_STRING`, `META_PROMPT`, `SELECTOR_ID`, `SELECTOR_CLASS`,
+  `SELECTOR_ATTR`, `SELECTOR_PSEUDO`, `CODE`, `TEMPLATE_TAG`, `TEMPLATE_VARIABLE`, `ATRULE`,
+  `DOCTAG`, `NAME`. Added `@see` links to official hljs CSS Classes Reference and Theme Guide.
+  Documented which scopes are newer/not universal per official docs. Closes #261.
+
+### Tests
+
+- **`HljsSelectorsParserTest`** - 48 new JVM unit tests verifying that `ThemeParser` correctly
+  parses every selector defined in `HljsSelectors`. Tests cover color, background, fontWeight,
+  and fontStyle extraction for each selector, plus compound selector tests for comma-separated
+  rules. Organized by official hljs categories matching `HljsSelectors` structure.
 
 ## [0.25.0] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
   internal so CSS parsing and HTML conversion remain implementation details instead of
   becoming part of the published ABI.
 
-### Internal
+### Added
 
 - **Enhanced `HljsSelectors` with all official hljs scopes** - reorganized constants by official
   highlight.js categories (General purpose, Title subscopes, Meta, Tags/attributes, CSS selectors,

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -61,13 +61,14 @@ import kotlin.time.measureTimedValue
  * ## Custom theme from a precomputed color map
  *
  * For maximum control - e.g. deriving colors from Material 3 dynamic color or any other
- * source - you can supply the color map directly:
+ * source - you can supply the color map directly. Use [HljsSelectors] constants for
+ * known hljs scope keys:
  *
  * ```kotlin
  * val colorMap: Map<String, SpanStyle> = mapOf(
- *     "hljs"          to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
- *     "hljs-keyword"  to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
- *     "hljs-string"   to SpanStyle(color = Color(0xFF032F62)),
+ *     HljsSelectors.BASE         to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
+ *     HljsSelectors.KEYWORD      to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
+ *     HljsSelectors.STRING       to SpanStyle(color = Color(0xFF032F62)),
  *     // ... add more token types as needed
  * )
  * val theme = HighlightTheme.fromColorMap(
@@ -331,12 +332,17 @@ class HighlightTheme private constructor(
          * to derive [HighlightTheme.backgroundColor] and [HighlightTheme.defaultTextColor]; you
          * can also override those explicitly via [backgroundColor] and [defaultTextColor].
          *
+         * Use the constants in [HljsSelectors] for known hljs scope keys to avoid typos and get
+         * IDE autocomplete. The full set of available scopes is documented in that object with
+         * `@see` links to the official hljs CSS Classes Reference.
+         *
          * ```kotlin
          * val colorMap = mapOf(
-         *     "hljs"         to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
-         *     "hljs-keyword" to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
-         *     "hljs-string"  to SpanStyle(color = Color(0xFF032F62)),
-         *     "hljs-comment" to SpanStyle(color = Color(0xFF6A737D), fontStyle = FontStyle.Italic),
+         *     HljsSelectors.BASE          to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
+         *     HljsSelectors.KEYWORD       to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
+         *     HljsSelectors.STRING        to SpanStyle(color = Color(0xFF032F62)),
+         *     HljsSelectors.COMMENT       to SpanStyle(color = Color(0xFF6A737D), fontStyle = FontStyle.Italic),
+         *     HljsSelectors.TITLE_FUNCTION to SpanStyle(color = Color(0xFF6F42C1)),
          *     // ... add more token types as needed
          * )
          * val theme = HighlightTheme.fromColorMap(
@@ -348,7 +354,8 @@ class HighlightTheme private constructor(
          * ```
          *
          * @param name Display name for the theme.
-         * @param colorMap Map of hljs class name → [SpanStyle].
+         * @param colorMap Map of hljs class name → [SpanStyle]. Use [HljsSelectors] constants
+         *   for known scopes (e.g. `HljsSelectors.KEYWORD` instead of `"hljs-keyword"`).
          * @param backgroundColor Optional explicit background color. If null, derived from `colorMap["hljs"]`.
          * @param defaultTextColor Optional explicit default text color. If null, derived from `colorMap["hljs"]`.
          * @return A [HighlightTheme] backed by the provided [colorMap].

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -42,7 +42,7 @@ package dev.hossain.highlight.engine
  * - [TITLE] - Name of a class or function
  * - [PARAMS] - Function arguments/parameters at the place of declaration
  * - [COMMENT] - Comments
- * - [DOCTAG] - Documentation markup within comments (e.g. `@params`)
+ * - [DOCTAG] - Documentation markup within comments (e.g. `@param`)
  *
  * ### Title subscopes
  * highlight.js outputs space-separated classes like `class="hljs-title function_"` which

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -29,7 +29,7 @@ package dev.hossain.highlight.engine
  * - [PROPERTY] - Object properties: `obj.prop1.prop2.value` (newer scope)
  * - [REGEXP] - Literal regular expressions
  * - [STRING] - Literal strings and characters
- * - [CHAR] - Character literals (official docs: `char.escape` for escape chars like `\n`)
+ * - [CHAR_ESCAPE] - Character escape literals (official scope: `char.escape_`)
  * - [SUBST] - Parsed sections inside literal strings. **Important:** the hljs theme guide
  *   explicitly says "don't forget to style .subst" - it should usually reset to the
  *   default text color.
@@ -46,7 +46,7 @@ package dev.hossain.highlight.engine
  * highlight.js outputs space-separated classes like `class="hljs-title function_"` which
  * are resolved as dot-joined keys by [ThemeParser]:
  * - [TITLE_CLASS] (`"hljs-title.class_"`) - Name of a class, interface, trait, module
- * - [TITLE_CLASS_INHERITED] (`"hljs-title.class.inherited_"`) - Inherited/extended class name
+ * - [TITLE_CLASS_INHERITED] (`"hljs-title.class_.inherited__"`) - Inherited/extended class name
  * - [TITLE_FUNCTION] (`"hljs-title.function_"`) - Name of a function
  * - [TITLE_FUNCTION_INVOKE] (`"hljs-title.function.invoke_"`) - Function being invoked
  *
@@ -158,10 +158,11 @@ internal object HljsSelectors {
     const val STRING = "hljs-string"
 
     /**
-     * Character literals.
-     * Official docs call this `char.escape` for escape characters like `\n`.
+     * Character escape literals (e.g. `\n`, `\t`).
+     * hljs emits `class="hljs-char escape_"` which resolves to the compound key
+     * `hljs-char.escape_`. All real theme CSS files use `.hljs-char.escape_`.
      */
-    const val CHAR = "hljs-char"
+    const val CHAR_ESCAPE = "hljs-char.escape_"
 
     /**
      * Parsed sections inside literal strings.
@@ -202,8 +203,12 @@ internal object HljsSelectors {
     /** Name of a class, interface, trait, or module. */
     const val TITLE_CLASS = "hljs-title.class_"
 
-    /** Name of a class being inherited from, extended, etc. */
-    const val TITLE_CLASS_INHERITED = "hljs-title.class.inherited_"
+    /**
+     * Name of a class being inherited from, extended, etc.
+     * hljs emits `class="hljs-title class_ inherited__"` which resolves to the compound key
+     * `hljs-title.class_.inherited__` (note: double underscore on `inherited__`).
+     */
+    const val TITLE_CLASS_INHERITED = "hljs-title.class_.inherited__"
 
     /** Name of a function. */
     const val TITLE_FUNCTION = "hljs-title.function_"

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -29,6 +29,7 @@ package dev.hossain.highlight.engine
  * - [PROPERTY] - Object properties: `obj.prop1.prop2.value` (newer scope)
  * - [REGEXP] - Literal regular expressions
  * - [STRING] - Literal strings and characters
+ * - [CHAR] - Base character scope (primary key emitted by ThemeParser)
  * - [CHAR_ESCAPE] - Character escape literals (official scope: `char.escape_`)
  * - [SUBST] - Parsed sections inside literal strings. **Important:** the hljs theme guide
  *   explicitly says "don't forget to style .subst" - it should usually reset to the
@@ -167,6 +168,14 @@ object HljsSelectors {
 
     /** Literal strings and characters. */
     const val STRING = "hljs-string"
+
+    /**
+     * Character literals - base scope.
+     * ThemeParser emits this as the primary key when parsing `.hljs-char.escape_`
+     * (via `substringBefore('.')`), so both [CHAR] and [CHAR_ESCAPE] will resolve
+     * to the same style from real theme CSS.
+     */
+    const val CHAR = "hljs-char"
 
     /**
      * Character escape literals (e.g. `\n`, `\t`).

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -216,7 +216,7 @@ object HljsSelectors {
     /** Single-line and multi-line comments. */
     const val COMMENT = "hljs-comment"
 
-    /** Documentation markup within comments (e.g. `@params`). */
+    /** Documentation markup within comments (e.g. `@param`). */
     const val DOCTAG = "hljs-doctag"
 
     // ----- Title subscopes -----

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -18,7 +18,8 @@ package dev.hossain.highlight.engine
  *   and [HighlightTheme.defaultTextColor] to derive theme-level defaults.
  *
  * ### General purpose selectors
- * These appear in nearly all highlight.js themes:
+ * These cover the most common token types. Some (OPERATOR, PUNCTUATION, PROPERTY)
+ * are newer scopes and may not be present in all themes:
  * - [KEYWORD] - Language keywords (`if`, `for`, `fun`, `def`, etc.)
  * - [BUILT_IN] - Built-in or library objects (constants, classes, functions)
  * - [TYPE] - Data types (`string`, `int`, `array`, etc.)
@@ -106,9 +107,9 @@ package dev.hossain.highlight.engine
  * val theme = HighlightTheme.fromColorMap(name = "my-theme", colorMap = colorMap)
  * ```
  *
- * Internally, [ThemeParser] and [HtmlToAnnotatedString] use these constants to reference
- * known selectors, while token-specific selectors are discovered dynamically from the
- * theme CSS at runtime.
+ * Internally, [HighlightTheme] and [HtmlToAnnotatedString] use [BASE] to derive the
+ * default text and background colors. All other selectors are discovered dynamically
+ * from the theme CSS at runtime.
  *
  * @see ThemeParser
  * @see HtmlToAnnotatedString

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -92,11 +92,22 @@ package dev.hossain.highlight.engine
  *
  * ### Usage
  *
- * These constants are used internally by [ThemeParser], [HtmlToAnnotatedString], and
- * [HighlightTheme] to reference the base `"hljs"` selector. Token-specific selectors
- * (like [KEYWORD], [STRING]) are **not** hardcoded in production code - they are
- * discovered dynamically from the theme CSS at runtime. The constants exist here
- * for documentation and for test code that constructs inline color maps.
+ * Use these constants when building color maps for [HighlightTheme.fromColorMap] to avoid
+ * typos and get IDE autocomplete with full KDoc descriptions:
+ *
+ * ```kotlin
+ * val colorMap = mapOf(
+ *     HljsSelectors.BASE     to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
+ *     HljsSelectors.KEYWORD  to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
+ *     HljsSelectors.STRING   to SpanStyle(color = Color(0xFF032F62)),
+ *     HljsSelectors.COMMENT  to SpanStyle(color = Color(0xFF6A737D), fontStyle = FontStyle.Italic),
+ * )
+ * val theme = HighlightTheme.fromColorMap(name = "my-theme", colorMap = colorMap)
+ * ```
+ *
+ * Internally, [ThemeParser] and [HtmlToAnnotatedString] use these constants to reference
+ * known selectors, while token-specific selectors are discovered dynamically from the
+ * theme CSS at runtime.
  *
  * @see ThemeParser
  * @see HtmlToAnnotatedString
@@ -104,7 +115,7 @@ package dev.hossain.highlight.engine
  * @see [hljs CSS Classes Reference](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html)
  * @see [hljs Theme Guide](https://highlightjs.readthedocs.io/en/latest/theme-guide.html)
  */
-internal object HljsSelectors {
+object HljsSelectors {
     // ----- Base -----
 
     /**

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -9,38 +9,86 @@ package dev.hossain.highlight.engine
  * [HtmlToAnnotatedString] when converting the HTML to an [androidx.compose.ui.text.AnnotatedString].
  *
  * The full set of keys available depends on the theme - different CSS themes define
- * different selectors. The constants below represent the **base** and **common**
- * selectors that appear in most themes.
+ * different selectors. The constants below cover **all official hljs scopes** as
+ * documented in the [CSS Classes Reference](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html).
  *
  * ### Base selector
  * - [BASE] (`"hljs"`) - The root container rule. Provides the default text color and
  *   background for the entire code block. Used by [HighlightTheme.backgroundColor]
  *   and [HighlightTheme.defaultTextColor] to derive theme-level defaults.
  *
- * ### Common token selectors
+ * ### General purpose selectors
  * These appear in nearly all highlight.js themes:
  * - [KEYWORD] - Language keywords (`if`, `for`, `fun`, `def`, etc.)
- * - [STRING] - String literals
- * - [NUMBER] - Numeric literals
- * - [COMMENT] - Single-line and multi-line comments
- * - [LITERAL] - Boolean and null literals (`true`, `false`, `null`, `None`)
- * - [TYPE] - Type names and class declarations
- * - [TITLE] - Function and class titles
- * - [NAME] - Tag names (HTML/XML), variable names
- * - [BUILT_IN] - Built-in functions and types
- * - [ATTR] - HTML/XML attributes
- * - [SELECTOR_TAG] - CSS selector tags
- * - [STRONG] - Bold-emphasized tokens (maps to [androidx.compose.ui.text.font.FontWeight.Bold])
- * - [EMPHASIS] - Italic-emphasized tokens (maps to [androidx.compose.ui.text.font.FontStyle.Italic])
- * - [QUOTE] - Block quotes (often shares style with [COMMENT])
- * - [TAG] - Markup tags
- * - [OPERATOR] - Operators (`+`, `-`, `=`, etc.)
- * - [ADDITION] - Added lines in diff output
+ * - [BUILT_IN] - Built-in or library objects (constants, classes, functions)
+ * - [TYPE] - Data types (`string`, `int`, `array`, etc.)
+ * - [LITERAL] - Special identifiers for built-in values (`true`, `false`, `null`, etc.)
+ * - [NUMBER] - Numbers, including units and modifiers
+ * - [OPERATOR] - Operators: `+`, `-`, `>>`, `|`, `==` (newer scope, not in all themes)
+ * - [PUNCTUATION] - Auxiliary punctuation: parentheses, brackets, etc. (newer scope)
+ * - [PROPERTY] - Object properties: `obj.prop1.prop2.value` (newer scope)
+ * - [REGEXP] - Literal regular expressions
+ * - [STRING] - Literal strings and characters
+ * - [CHAR] - Character literals (official docs: `char.escape` for escape chars like `\n`)
+ * - [SUBST] - Parsed sections inside literal strings. **Important:** the hljs theme guide
+ *   explicitly says "don't forget to style .subst" - it should usually reset to the
+ *   default text color.
+ * - [SYMBOL] - Symbolic constants, interned strings, goto labels
+ * - [VARIABLE] - General variables
+ * - [VARIABLE_LANGUAGE] - Variables with special meaning (`this`, `window`, `super`, `self`)
+ * - [VARIABLE_CONSTANT] - Constant-value variables (e.g. `MAX_FILES`)
+ * - [TITLE] - Name of a class or function
+ * - [PARAMS] - Function arguments/parameters at the place of declaration
+ * - [COMMENT] - Comments
+ * - [DOCTAG] - Documentation markup within comments (e.g. `@params`)
  *
- * ### Compound selectors
- * highlight.js sometimes outputs space-separated classes like `class="hljs-title function_"`.
- * These are resolved as dot-joined keys:
- * - [TITLE_FUNCTION] (`"hljs-title.function_"`) - Function title tokens
+ * ### Title subscopes
+ * highlight.js outputs space-separated classes like `class="hljs-title function_"` which
+ * are resolved as dot-joined keys by [ThemeParser]:
+ * - [TITLE_CLASS] (`"hljs-title.class_"`) - Name of a class, interface, trait, module
+ * - [TITLE_CLASS_INHERITED] (`"hljs-title.class.inherited_"`) - Inherited/extended class name
+ * - [TITLE_FUNCTION] (`"hljs-title.function_"`) - Name of a function
+ * - [TITLE_FUNCTION_INVOKE] (`"hljs-title.function.invoke_"`) - Function being invoked
+ *
+ * ### Meta selectors
+ * - [META] - Flags, modifiers, annotations, preprocessor directives
+ * - [META_KEYWORD] - Keywords inside a meta block (nested, hyphenated in CSS)
+ * - [META_STRING] - Strings inside a meta block (nested, hyphenated in CSS)
+ * - [META_PROMPT] - REPL or shell prompts
+ *
+ * ### Tags, attributes, configs
+ * - [TAG] - XML/HTML tags
+ * - [NAME] - Name of an XML tag, first word in an s-expression
+ * - [ATTR] - Attribute names without language semantics (JSON keys, .ini settings)
+ * - [ATTRIBUTE] - Attribute names followed by structured values (e.g. CSS properties)
+ * - [SECTION] - Section headings in config files or text markup
+ *
+ * ### CSS selectors
+ * - [SELECTOR_TAG] - Tag selectors
+ * - [SELECTOR_ID] - `#id` selectors
+ * - [SELECTOR_CLASS] - `.class` selectors
+ * - [SELECTOR_ATTR] - `[attr]` selectors
+ * - [SELECTOR_PSEUDO] - `:pseudo` selectors
+ *
+ * ### Text markup
+ * - [BULLET] - List item bullets
+ * - [CODE] - Code blocks
+ * - [EMPHASIS] - Emphasis (typically maps to [androidx.compose.ui.text.font.FontStyle.Italic])
+ * - [STRONG] - Strong emphasis (typically maps to [androidx.compose.ui.text.font.FontWeight.Bold])
+ * - [FORMULA] - Mathematical formulas
+ * - [LINK] - Hyperlinks
+ * - [QUOTE] - Quotations or blockquotes
+ *
+ * ### Templates
+ * - [TEMPLATE_TAG] - Tags of template languages
+ * - [TEMPLATE_VARIABLE] - Variables in template languages
+ *
+ * ### Diff
+ * - [ADDITION] - Added or changed lines
+ * - [DELETION] - Deleted lines
+ *
+ * ### Other
+ * - [ATRULE] - At-rule tokens (found in a small number of themes)
  *
  * ### Usage
  *
@@ -53,8 +101,12 @@ package dev.hossain.highlight.engine
  * @see ThemeParser
  * @see HtmlToAnnotatedString
  * @see HighlightTheme
+ * @see [hljs CSS Classes Reference](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html)
+ * @see [hljs Theme Guide](https://highlightjs.readthedocs.io/en/latest/theme-guide.html)
  */
 internal object HljsSelectors {
+    // ----- Base -----
+
     /**
      * The base/root selector (`"hljs"`).
      *
@@ -64,90 +116,196 @@ internal object HljsSelectors {
      */
     const val BASE = "hljs"
 
+    // ----- General purpose -----
+
     /** Keyword tokens (`if`, `for`, `fun`, `def`, etc.). */
     const val KEYWORD = "hljs-keyword"
 
-    /** String literals. */
+    /** Built-in or library objects (constants, classes, functions). */
+    const val BUILT_IN = "hljs-built_in"
+
+    /** Data types (`string`, `int`, `array`, etc.). */
+    const val TYPE = "hljs-type"
+
+    /** Special identifiers for built-in values (`true`, `false`, `null`, `None`). */
+    const val LITERAL = "hljs-literal"
+
+    /** Numbers, including units and modifiers. */
+    const val NUMBER = "hljs-number"
+
+    /**
+     * Operators: `+`, `-`, `>>`, `|`, `==`.
+     * Newer scope - not present in all themes.
+     */
+    const val OPERATOR = "hljs-operator"
+
+    /**
+     * Auxiliary punctuation: parentheses, brackets, etc.
+     * Newer scope - not present in all themes.
+     */
+    const val PUNCTUATION = "hljs-punctuation"
+
+    /**
+     * Object properties: `obj.prop1.prop2.value`.
+     * Newer scope - not present in all themes.
+     */
+    const val PROPERTY = "hljs-property"
+
+    /** Literal regular expressions. */
+    const val REGEXP = "hljs-regexp"
+
+    /** Literal strings and characters. */
     const val STRING = "hljs-string"
 
-    /** Numeric literals. */
-    const val NUMBER = "hljs-number"
+    /**
+     * Character literals.
+     * Official docs call this `char.escape` for escape characters like `\n`.
+     */
+    const val CHAR = "hljs-char"
+
+    /**
+     * Parsed sections inside literal strings.
+     * The hljs theme guide explicitly says "don't forget to style .subst" - it should
+     * usually reset to the default text color (e.g. `.hljs, .hljs-subst { color: black }`).
+     */
+    const val SUBST = "hljs-subst"
+
+    /** Symbolic constants, interned strings, goto labels. */
+    const val SYMBOL = "hljs-symbol"
+
+    /** General variables (e.g. `$variable` in shell scripts). */
+    const val VARIABLE = "hljs-variable"
+
+    /**
+     * Variables with special meaning in a language:
+     * `this`, `window`, `super`, `self`, etc.
+     */
+    const val VARIABLE_LANGUAGE = "hljs-variable.language_"
+
+    /** Constant-value variables (e.g. `MAX_FILES`). */
+    const val VARIABLE_CONSTANT = "hljs-variable.constant_"
+
+    /** Name of a class or function. */
+    const val TITLE = "hljs-title"
+
+    /** Function arguments/parameters at the place of declaration. */
+    const val PARAMS = "hljs-params"
 
     /** Single-line and multi-line comments. */
     const val COMMENT = "hljs-comment"
 
-    /** Boolean and null literals (`true`, `false`, `null`, `None`). */
-    const val LITERAL = "hljs-literal"
+    /** Documentation markup within comments (e.g. `@params`). */
+    const val DOCTAG = "hljs-doctag"
 
-    /** Type names and class declarations. */
-    const val TYPE = "hljs-type"
+    // ----- Title subscopes -----
 
-    /** Function and class titles. */
-    const val TITLE = "hljs-title"
+    /** Name of a class, interface, trait, or module. */
+    const val TITLE_CLASS = "hljs-title.class_"
 
-    /** Tag names (HTML/XML), variable names. */
-    const val NAME = "hljs-name"
+    /** Name of a class being inherited from, extended, etc. */
+    const val TITLE_CLASS_INHERITED = "hljs-title.class.inherited_"
 
-    /** Built-in functions and types. */
-    const val BUILT_IN = "hljs-built_in"
-
-    /** HTML/XML attributes. */
-    const val ATTR = "hljs-attr"
-
-    /** CSS selector tags. */
-    const val SELECTOR_TAG = "hljs-selector-tag"
-
-    /** Bold-emphasized tokens (typically maps to [androidx.compose.ui.text.font.FontWeight.Bold]). */
-    const val STRONG = "hljs-strong"
-
-    /** Italic-emphasized tokens (typically maps to [androidx.compose.ui.text.font.FontStyle.Italic]). */
-    const val EMPHASIS = "hljs-emphasis"
-
-    /** Block quotes (often shares style with [COMMENT]). */
-    const val QUOTE = "hljs-quote"
-
-    /** Markup tags. */
-    const val TAG = "hljs-tag"
-
-    /** Operators (`+`, `-`, `=`, etc.). */
-    const val OPERATOR = "hljs-operator"
-
-    /** Added lines in diff output. */
-    const val ADDITION = "hljs-addition"
-
-    /** Compound selector: function title (`"hljs-title.function_"`). */
+    /** Name of a function. */
     const val TITLE_FUNCTION = "hljs-title.function_"
 
-    /** Compound selector: meta keyword (`"hljs-meta .hljs-keyword"` descendant, typically skipped). */
+    /** Name of a function when being invoked. */
+    const val TITLE_FUNCTION_INVOKE = "hljs-title.function.invoke_"
+
+    // ----- Meta -----
+
+    /** Flags, modifiers, annotations, preprocessor directives. */
     const val META = "hljs-meta"
 
-    /** Variable references (e.g. `$variable` in shell scripts). */
-    const val VARIABLE = "hljs-variable"
+    /** Keywords inside a meta block (nested, hyphenated in CSS). */
+    const val META_KEYWORD = "hljs-meta-keyword"
 
-    /** Function parameters in declarations. */
-    const val PARAMS = "hljs-params"
+    /** Strings inside a meta block (nested, hyphenated in CSS). */
+    const val META_STRING = "hljs-meta-string"
 
-    /** HTML/XML attributes. */
+    /** REPL or shell prompts. */
+    const val META_PROMPT = "hljs-meta.prompt"
+
+    // ----- Tags, attributes, configs -----
+
+    /** XML/HTML tags. */
+    const val TAG = "hljs-tag"
+
+    /** Name of an XML tag, the first word in an s-expression. */
+    const val NAME = "hljs-name"
+
+    /**
+     * Attribute names without language-defined semantics
+     * (JSON keys, .ini settings), also sub-attributes within another highlighted object.
+     */
+    const val ATTR = "hljs-attr"
+
+    /** Attribute names followed by structured values (e.g. CSS properties). */
     const val ATTRIBUTE = "hljs-attribute"
 
-    /** Section titles and headings. */
+    /** Section headings in config files or text markup. */
     const val SECTION = "hljs-section"
 
-    /** Symbol tokens (e.g. Ruby symbols like `:foo`). */
-    const val SYMBOL = "hljs-symbol"
+    // ----- CSS selectors -----
 
-    /** Bullet points in list markup. */
+    /** Tag selectors (e.g. `div`, `span`). */
+    const val SELECTOR_TAG = "hljs-selector-tag"
+
+    /** `#id` selectors. */
+    const val SELECTOR_ID = "hljs-selector-id"
+
+    /** `.class` selectors. */
+    const val SELECTOR_CLASS = "hljs-selector-class"
+
+    /** `[attr]` selectors. */
+    const val SELECTOR_ATTR = "hljs-selector-attr"
+
+    /** `:pseudo` selectors. */
+    const val SELECTOR_PSEUDO = "hljs-selector-pseudo"
+
+    // ----- Text markup -----
+
+    /** List item bullets. */
     const val BULLET = "hljs-bullet"
 
-    /** Formula tokens in LaTeX/math markup. */
+    /** Code blocks. */
+    const val CODE = "hljs-code"
+
+    /** Emphasis (typically maps to [androidx.compose.ui.text.font.FontStyle.Italic]). */
+    const val EMPHASIS = "hljs-emphasis"
+
+    /** Strong emphasis (typically maps to [androidx.compose.ui.text.font.FontWeight.Bold]). */
+    const val STRONG = "hljs-strong"
+
+    /** Mathematical formulas. */
     const val FORMULA = "hljs-formula"
 
-    /** Added/deleted line markers in diff output. */
+    /** Hyperlinks. */
+    const val LINK = "hljs-link"
+
+    /** Quotations or blockquotes. */
+    const val QUOTE = "hljs-quote"
+
+    // ----- Templates -----
+
+    /** Tags of template languages. */
+    const val TEMPLATE_TAG = "hljs-template-tag"
+
+    /** Variables in template languages. */
+    const val TEMPLATE_VARIABLE = "hljs-template-variable"
+
+    // ----- Diff -----
+
+    /** Added or changed lines. */
+    const val ADDITION = "hljs-addition"
+
+    /** Deleted lines. */
     const val DELETION = "hljs-deletion"
 
-    /** Regular expression literals. */
-    const val REGEXP = "hljs-regexp"
+    // ----- Other -----
 
-    /** Link URLs in markup. */
-    const val LINK = "hljs-link"
+    /**
+     * At-rule tokens.
+     * Found in a small number of themes.
+     */
+    const val ATRULE = "hljs-atrule"
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
@@ -1,0 +1,410 @@
+package dev.hossain.highlight.engine
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * JVM unit tests verifying that [ThemeParser] correctly parses all selectors
+ * defined in [HljsSelectors]. Each test uses an inline CSS snippet to confirm
+ * the parser extracts the expected key and style properties.
+ */
+class HljsSelectorsParserTest {
+    // ----- General purpose -----
+
+    @Test
+    fun `parses keyword selector`() {
+        val css = ".hljs-keyword { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses built_in selector`() {
+        val css = ".hljs-built_in { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.BUILT_IN]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses type selector`() {
+        val css = ".hljs-type { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TYPE]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses literal selector`() {
+        val css = ".hljs-literal { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.LITERAL]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses number selector`() {
+        val css = ".hljs-number { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.NUMBER]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses operator selector`() {
+        val css = ".hljs-operator { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.OPERATOR]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses punctuation selector`() {
+        val css = ".hljs-punctuation { color: #6a737d }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.PUNCTUATION]?.color).isEqualTo(Color(0xFF6a737d))
+    }
+
+    @Test
+    fun `parses property selector`() {
+        val css = ".hljs-property { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.PROPERTY]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses regexp selector`() {
+        val css = ".hljs-regexp { color: #032f62 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.REGEXP]?.color).isEqualTo(Color(0xFF032f62))
+    }
+
+    @Test
+    fun `parses string selector`() {
+        val css = ".hljs-string { color: #032f62 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.STRING]?.color).isEqualTo(Color(0xFF032f62))
+    }
+
+    @Test
+    fun `parses char selector`() {
+        val css = ".hljs-char { color: #032f62 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.CHAR]?.color).isEqualTo(Color(0xFF032f62))
+    }
+
+    @Test
+    fun `parses subst selector`() {
+        val css = ".hljs-subst { color: #24292e }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SUBST]?.color).isEqualTo(Color(0xFF24292e))
+    }
+
+    @Test
+    fun `parses symbol selector`() {
+        val css = ".hljs-symbol { color: #e36209 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SYMBOL]?.color).isEqualTo(Color(0xFFe36209))
+    }
+
+    @Test
+    fun `parses variable selector`() {
+        val css = ".hljs-variable { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.VARIABLE]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses variable_language underscore selector`() {
+        val css = ".hljs-variable.language_ { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.VARIABLE_LANGUAGE]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses variable_constant underscore selector`() {
+        val css = ".hljs-variable.constant_ { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.VARIABLE_CONSTANT]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses title selector`() {
+        val css = ".hljs-title { color: #6f42c1; font-weight: bold }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF6f42c1))
+        assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
+    @Test
+    fun `parses params selector`() {
+        val css = ".hljs-params { color: #24292e }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.PARAMS]?.color).isEqualTo(Color(0xFF24292e))
+    }
+
+    @Test
+    fun `parses comment selector`() {
+        val css = ".hljs-comment { color: #6a737d; font-style: italic }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.COMMENT]?.color).isEqualTo(Color(0xFF6a737d))
+        assertThat(result[HljsSelectors.COMMENT]?.fontStyle).isEqualTo(FontStyle.Italic)
+    }
+
+    @Test
+    fun `parses doctag selector`() {
+        val css = ".hljs-doctag { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.DOCTAG]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    // ----- Title subscopes -----
+
+    @Test
+    fun `parses title_class underscore selector`() {
+        val css = ".hljs-title.class_ { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE_CLASS]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    @Test
+    fun `parses title_class_inherited underscore selector`() {
+        val css = ".hljs-title.class.inherited_ { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE_CLASS_INHERITED]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    @Test
+    fun `parses title_function underscore selector`() {
+        val css = ".hljs-title.function_ { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE_FUNCTION]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    @Test
+    fun `parses title_function_invoke underscore selector`() {
+        val css = ".hljs-title.function.invoke_ { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE_FUNCTION_INVOKE]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    // ----- Meta -----
+
+    @Test
+    fun `parses meta selector`() {
+        val css = ".hljs-meta { color: #6a737d }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.META]?.color).isEqualTo(Color(0xFF6a737d))
+    }
+
+    @Test
+    fun `parses meta-keyword selector`() {
+        val css = ".hljs-meta-keyword { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.META_KEYWORD]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses meta-string selector`() {
+        val css = ".hljs-meta-string { color: #032f62 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.META_STRING]?.color).isEqualTo(Color(0xFF032f62))
+    }
+
+    @Test
+    fun `parses meta_prompt underscore selector`() {
+        val css = ".hljs-meta.prompt { color: #6a737d }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.META_PROMPT]?.color).isEqualTo(Color(0xFF6a737d))
+    }
+
+    // ----- Tags, attributes, configs -----
+
+    @Test
+    fun `parses tag selector`() {
+        val css = ".hljs-tag { color: #22863a }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TAG]?.color).isEqualTo(Color(0xFF22863a))
+    }
+
+    @Test
+    fun `parses name selector`() {
+        val css = ".hljs-name { color: #22863a }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.NAME]?.color).isEqualTo(Color(0xFF22863a))
+    }
+
+    @Test
+    fun `parses attr selector`() {
+        val css = ".hljs-attr { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.ATTR]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses attribute selector`() {
+        val css = ".hljs-attribute { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.ATTRIBUTE]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses section selector`() {
+        val css = ".hljs-section { color: #005cc5; font-weight: bold }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SECTION]?.color).isEqualTo(Color(0xFF005cc5))
+        assertThat(result[HljsSelectors.SECTION]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
+    // ----- CSS selectors -----
+
+    @Test
+    fun `parses selector-tag selector`() {
+        val css = ".hljs-selector-tag { color: #22863a }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SELECTOR_TAG]?.color).isEqualTo(Color(0xFF22863a))
+    }
+
+    @Test
+    fun `parses selector-id selector`() {
+        val css = ".hljs-selector-id { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SELECTOR_ID]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    @Test
+    fun `parses selector-class selector`() {
+        val css = ".hljs-selector-class { color: #6f42c1 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SELECTOR_CLASS]?.color).isEqualTo(Color(0xFF6f42c1))
+    }
+
+    @Test
+    fun `parses selector-attr selector`() {
+        val css = ".hljs-selector-attr { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SELECTOR_ATTR]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses selector-pseudo selector`() {
+        val css = ".hljs-selector-pseudo { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.SELECTOR_PSEUDO]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    // ----- Text markup -----
+
+    @Test
+    fun `parses bullet selector`() {
+        val css = ".hljs-bullet { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.BULLET]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses code selector`() {
+        val css = ".hljs-code { color: #24292e }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.CODE]?.color).isEqualTo(Color(0xFF24292e))
+    }
+
+    @Test
+    fun `parses emphasis selector`() {
+        val css = ".hljs-emphasis { color: #24292e; font-style: italic }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.EMPHASIS]?.fontStyle).isEqualTo(FontStyle.Italic)
+    }
+
+    @Test
+    fun `parses strong selector`() {
+        val css = ".hljs-strong { color: #24292e; font-weight: bold }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
+    @Test
+    fun `parses formula selector`() {
+        val css = ".hljs-formula { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.FORMULA]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    @Test
+    fun `parses link selector`() {
+        val css = ".hljs-link { color: #0366d6 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.LINK]?.color).isEqualTo(Color(0xFF0366d6))
+    }
+
+    @Test
+    fun `parses quote selector`() {
+        val css = ".hljs-quote { color: #6a737d; font-style: italic }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.QUOTE]?.fontStyle).isEqualTo(FontStyle.Italic)
+    }
+
+    // ----- Templates -----
+
+    @Test
+    fun `parses template-tag selector`() {
+        val css = ".hljs-template-tag { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TEMPLATE_TAG]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    @Test
+    fun `parses template-variable selector`() {
+        val css = ".hljs-template-variable { color: #005cc5 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TEMPLATE_VARIABLE]?.color).isEqualTo(Color(0xFF005cc5))
+    }
+
+    // ----- Diff -----
+
+    @Test
+    fun `parses addition selector`() {
+        val css = ".hljs-addition { color: #22863a; background: #f0fff4 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.ADDITION]?.color).isEqualTo(Color(0xFF22863a))
+        assertThat(result[HljsSelectors.ADDITION]?.background).isEqualTo(Color(0xFFf0fff4))
+    }
+
+    @Test
+    fun `parses deletion selector`() {
+        val css = ".hljs-deletion { color: #b31d28; background: #ffeef0 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.DELETION]?.color).isEqualTo(Color(0xFFb31d28))
+        assertThat(result[HljsSelectors.DELETION]?.background).isEqualTo(Color(0xFFffeef0))
+    }
+
+    // ----- Other -----
+
+    @Test
+    fun `parses atrule selector`() {
+        val css = ".hljs-atrule { color: #d73a49 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.ATRULE]?.color).isEqualTo(Color(0xFFd73a49))
+    }
+
+    // ----- Compound selectors with multiple classes -----
+
+    @Test
+    fun `parses comma-separated selector list with new selectors`() {
+        val css = ".hljs-punctuation, .hljs-operator { color: #6a737d }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.PUNCTUATION]?.color).isEqualTo(Color(0xFF6a737d))
+        assertThat(result[HljsSelectors.OPERATOR]?.color).isEqualTo(Color(0xFF6a737d))
+    }
+
+    @Test
+    fun `parses combined general purpose selectors in single rule`() {
+        val css =
+            ".hljs-keyword, .hljs-built_in, .hljs-type { color: #d73a49; font-weight: bold }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.KEYWORD]?.color).isEqualTo(Color(0xFFd73a49))
+        assertThat(result[HljsSelectors.KEYWORD]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.BUILT_IN]?.color).isEqualTo(Color(0xFFd73a49))
+        assertThat(result[HljsSelectors.BUILT_IN]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.TYPE]?.color).isEqualTo(Color(0xFFd73a49))
+        assertThat(result[HljsSelectors.TYPE]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+}

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
@@ -12,6 +12,16 @@ import org.junit.Test
  * the parser extracts the expected key and style properties.
  */
 class HljsSelectorsParserTest {
+    // ----- Base -----
+
+    @Test
+    fun `parses base hljs selector`() {
+        val css = ".hljs { color: #24292e; background: #ffffff }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.BASE]?.color).isEqualTo(Color(0xFF24292e))
+        assertThat(result[HljsSelectors.BASE]?.background).isEqualTo(Color(0xFFffffff))
+    }
+
     // ----- General purpose -----
 
     @Test
@@ -88,7 +98,9 @@ class HljsSelectorsParserTest {
     fun `parses char escape underscore selector`() {
         val css = ".hljs-char.escape_ { color: #032f62 }"
         val result = ThemeParser.parse(css)
+        // ThemeParser publishes both the compound key and the primary key (substringBefore '.')
         assertThat(result[HljsSelectors.CHAR_ESCAPE]?.color).isEqualTo(Color(0xFF032f62))
+        assertThat(result[HljsSelectors.CHAR]?.color).isEqualTo(Color(0xFF032f62))
     }
 
     @Test
@@ -210,7 +222,7 @@ class HljsSelectorsParserTest {
     }
 
     @Test
-    fun `parses meta_prompt underscore selector`() {
+    fun `parses meta prompt compound selector`() {
         val css = ".hljs-meta.prompt { color: #6a737d }"
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.META_PROMPT]?.color).isEqualTo(Color(0xFF6a737d))

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
@@ -85,10 +85,10 @@ class HljsSelectorsParserTest {
     }
 
     @Test
-    fun `parses char selector`() {
-        val css = ".hljs-char { color: #032f62 }"
+    fun `parses char escape underscore selector`() {
+        val css = ".hljs-char.escape_ { color: #032f62 }"
         val result = ThemeParser.parse(css)
-        assertThat(result[HljsSelectors.CHAR]?.color).isEqualTo(Color(0xFF032f62))
+        assertThat(result[HljsSelectors.CHAR_ESCAPE]?.color).isEqualTo(Color(0xFF032f62))
     }
 
     @Test
@@ -166,8 +166,8 @@ class HljsSelectorsParserTest {
     }
 
     @Test
-    fun `parses title_class_inherited underscore selector`() {
-        val css = ".hljs-title.class.inherited_ { color: #6f42c1 }"
+    fun `parses title_class_inherited double-underscore selector`() {
+        val css = ".hljs-title.class_.inherited__ { color: #6f42c1 }"
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.TITLE_CLASS_INHERITED]?.color).isEqualTo(Color(0xFF6f42c1))
     }

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -85,19 +85,21 @@ val theme = HighlightTheme.fromCss(cssText = rawCss, name = "remote-theme")
 
 ## Custom theme from a color map
 
-Maximum flexibility - derive colors from Material 3 dynamic color, user palettes, or brand colors:
+Maximum flexibility - derive colors from Material 3 dynamic color, user palettes, or brand colors.
+Use `HljsSelectors` constants for known hljs scope keys:
 
 ```kotlin
+import dev.hossain.highlight.engine.HljsSelectors
 import dev.hossain.highlight.engine.HighlightTheme
 
 val lightColors = MaterialTheme.colorScheme
 val theme = HighlightTheme.fromColorMap(
     name             = "material-dynamic-light",
     colorMap         = mapOf(
-        "hljs"          to SpanStyle(color = lightColors.onSurface, background = lightColors.surface),
-        "hljs-keyword"  to SpanStyle(color = lightColors.primary, fontWeight = FontWeight.Bold),
-        "hljs-string"   to SpanStyle(color = lightColors.tertiary),
-        "hljs-comment"  to SpanStyle(color = lightColors.outline, fontStyle = FontStyle.Italic),
+        HljsSelectors.BASE         to SpanStyle(color = lightColors.onSurface, background = lightColors.surface),
+        HljsSelectors.KEYWORD      to SpanStyle(color = lightColors.primary, fontWeight = FontWeight.Bold),
+        HljsSelectors.STRING       to SpanStyle(color = lightColors.tertiary),
+        HljsSelectors.COMMENT      to SpanStyle(color = lightColors.outline, fontStyle = FontStyle.Italic),
     ),
     backgroundColor  = lightColors.surface,
     defaultTextColor = lightColors.onSurface,

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -68,6 +68,14 @@ val theme = HighlightTheme.fromCss(
 ## Custom theme from a color map
 
 ```kotlin
+import dev.hossain.highlight.engine.HljsSelectors
+
+val colorMap = mapOf(
+    HljsSelectors.BASE     to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),
+    HljsSelectors.KEYWORD  to SpanStyle(color = Color(0xFFD73A49), fontWeight = FontWeight.Bold),
+    HljsSelectors.STRING   to SpanStyle(color = Color(0xFF032F62)),
+    HljsSelectors.COMMENT  to SpanStyle(color = Color(0xFF6A737D), fontStyle = FontStyle.Italic),
+)
 val theme = HighlightTheme.fromColorMap(
     name             = "my-dynamic-theme",
     colorMap         = colorMap,

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -68,10 +68,6 @@ val theme = HighlightTheme.fromCss(
 ## Custom theme from a color map
 
 ```kotlin
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import dev.hossain.highlight.engine.HljsSelectors
 import dev.hossain.highlight.engine.HighlightTheme
 

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -68,7 +68,12 @@ val theme = HighlightTheme.fromCss(
 ## Custom theme from a color map
 
 ```kotlin
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import dev.hossain.highlight.engine.HljsSelectors
+import dev.hossain.highlight.engine.HighlightTheme
 
 val colorMap = mapOf(
     HljsSelectors.BASE     to SpanStyle(color = Color(0xFF24292E), background = Color(0xFFFFFFFF)),

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.engine.HljsSelectors
 import dev.hossain.highlight.sample.FROM_ASSET_SNIPPET
 import dev.hossain.highlight.sample.KOTLIN_SNIPPET
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
@@ -92,19 +93,19 @@ internal fun ThemeCreationSection() {
                 name = "material3-dark",
                 colorMap =
                     mapOf(
-                        "hljs" to SpanStyle(color = Color(0xFFE6E1E5), background = Color(0xFF1C1B1F)),
-                        "hljs-keyword" to SpanStyle(color = Color(0xFFD0BCFF), fontWeight = FontWeight.Bold),
-                        "hljs-built_in" to SpanStyle(color = Color(0xFFCBA6F7)),
-                        "hljs-string" to SpanStyle(color = Color(0xFF6DD58C)),
-                        "hljs-attr" to SpanStyle(color = Color(0xFF6DD58C)),
-                        "hljs-comment" to SpanStyle(color = Color(0xFF938F99), fontStyle = FontStyle.Italic),
-                        "hljs-quote" to SpanStyle(color = Color(0xFF938F99), fontStyle = FontStyle.Italic),
-                        "hljs-number" to SpanStyle(color = Color(0xFF7FCFFF)),
-                        "hljs-literal" to SpanStyle(color = Color(0xFF7FCFFF)),
-                        "hljs-type" to SpanStyle(color = Color(0xFF80CBC4)),
-                        "hljs-title" to SpanStyle(color = Color(0xFFFFB4AB), fontWeight = FontWeight.Bold),
-                        "hljs-name" to SpanStyle(color = Color(0xFFFFB4AB)),
-                        "hljs-selector-tag" to SpanStyle(color = Color(0xFFFFB4AB)),
+                        HljsSelectors.BASE to SpanStyle(color = Color(0xFFE6E1E5), background = Color(0xFF1C1B1F)),
+                        HljsSelectors.KEYWORD to SpanStyle(color = Color(0xFFD0BCFF), fontWeight = FontWeight.Bold),
+                        HljsSelectors.BUILT_IN to SpanStyle(color = Color(0xFFCBA6F7)),
+                        HljsSelectors.STRING to SpanStyle(color = Color(0xFF6DD58C)),
+                        HljsSelectors.ATTR to SpanStyle(color = Color(0xFF6DD58C)),
+                        HljsSelectors.COMMENT to SpanStyle(color = Color(0xFF938F99), fontStyle = FontStyle.Italic),
+                        HljsSelectors.QUOTE to SpanStyle(color = Color(0xFF938F99), fontStyle = FontStyle.Italic),
+                        HljsSelectors.NUMBER to SpanStyle(color = Color(0xFF7FCFFF)),
+                        HljsSelectors.LITERAL to SpanStyle(color = Color(0xFF7FCFFF)),
+                        HljsSelectors.TYPE to SpanStyle(color = Color(0xFF80CBC4)),
+                        HljsSelectors.TITLE to SpanStyle(color = Color(0xFFFFB4AB), fontWeight = FontWeight.Bold),
+                        HljsSelectors.NAME to SpanStyle(color = Color(0xFFFFB4AB)),
+                        HljsSelectors.SELECTOR_TAG to SpanStyle(color = Color(0xFFFFB4AB)),
                     ),
                 backgroundColor = Color(0xFF1C1B1F),
                 defaultTextColor = Color(0xFFE6E1E5),


### PR DESCRIPTION
## Summary

Enhances `HljsSelectors.kt` to cover **all official highlight.js scopes** as documented in the [CSS Classes Reference](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html) and [Theme Guide](https://highlightjs.readthedocs.io/en/latest/theme-guide.html).

Cross-referenced against all 256 bundled theme CSS files to confirm which selectors are actually used.

### Changes

**Reorganized** constants by official hljs categories:
- Base
- General purpose (17 selectors)
- Title subscopes (4 selectors)
- Meta (4 selectors)
- Tags, attributes, configs (5 selectors)
- CSS selectors (5 selectors)
- Text markup (7 selectors)
- Templates (2 selectors)
- Diff (2 selectors)
- Other (1 selector)

**Added 22 new selectors** missing from the previous version:

| Constant | CSS selector | Notes |
|---|---|---|
| `PUNCTUATION` | `hljs-punctuation` | Newer scope, not universal |
| `PROPERTY` | `hljs-property` | Newer scope, not universal |
| `CHAR` | `hljs-char` | Official: `char.escape` |
| `SUBST` | `hljs-subst` | Theme guide: "don't forget to style" |
| `VARIABLE_LANGUAGE` | `hljs-variable.language_` | `this`, `window`, `super`, `self` |
| `VARIABLE_CONSTANT` | `hljs-variable.constant_` | `MAX_FILES`, etc. |
| `TITLE_CLASS` | `hljs-title.class_` | Class/interface/trait names |
| `TITLE_CLASS_INHERITED` | `hljs-title.class.inherited_` | Inherited class names |
| `TITLE_FUNCTION_INVOKE` | `hljs-title.function.invoke_` | Function being invoked |
| `META_KEYWORD` | `hljs-meta-keyword` | Keywords inside meta blocks |
| `META_STRING` | `hljs-meta-string` | Strings inside meta blocks |
| `META_PROMPT` | `hljs-meta.prompt` | REPL/shell prompts |
| `SELECTOR_ID` | `hljs-selector-id` | `#id` selectors |
| `SELECTOR_CLASS` | `hljs-selector-class` | `.class` selectors |
| `SELECTOR_ATTR` | `hljs-selector-attr` | `[attr]` selectors |
| `SELECTOR_PSEUDO` | `hljs-selector-pseudo` | `:pseudo` selectors |
| `CODE` | `hljs-code` | Code blocks |
| `TEMPLATE_TAG` | `hljs-template-tag` | Template language tags |
| `TEMPLATE_VARIABLE` | `hljs-template-variable` | Template variables |
| `ATRULE` | `hljs-atrule` | At-rule tokens |
| `DOCTAG` | `hljs-doctag` | `@params`, etc. |
| `NAME` | `hljs-name` | XML tag names |

**Added documentation:**
- `@see` links to official hljs CSS Classes Reference and Theme Guide
- Notes on which scopes are newer/not universal
- Importance note for `SUBST` per theme guide

### Verification

- All JVM unit tests pass (`./gradlew :compose-highlight:test`)
- No ktlint violations (`./gradlew lintKotlin`)
- Formatting clean (`./gradlew formatKotlin`)

Closes #261