### PR TITLE
fix: correct META_PROMPT selector mapping

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HljsSelectors.kt
@@ -247,7 +247,7 @@ object HljsSelectors {
     const val META_STRING = "hljs-meta-string"
 
     /** REPL or shell prompts. */
-    const val META_PROMPT = "hljs-meta.prompt"
+    const val META_PROMPT = "hljs-meta.prompt_"
 
     // ----- Tags, attributes, configs -----
 

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HljsSelectorsParserTest.kt
@@ -224,7 +224,7 @@ class HljsSelectorsParserTest {
 
     @Test
     fun `parses meta prompt compound selector`() {
-        val css = ".hljs-meta.prompt { color: #6a737d }"
+        val css = ".hljs-meta.prompt_ { color: #6a737d }"
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.META_PROMPT]?.color).isEqualTo(Color(0xFF6a737d))
     }


### PR DESCRIPTION
## Summary
- fix HljsSelectors.META_PROMPT from hljs-meta.prompt to hljs-meta.prompt_
- align parser test fixture to .hljs-meta.prompt_
- match Highlight.js sub-scope class naming for meta.prompt

## Verification
- ./gradlew :compose-highlight:test

Fixes #264