### PR TITLE
fix: use full sha256 for theme content identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ All notable changes to this project will be documented in this file.
   **Dokka** (`compose-highlight/build.gradle.kts`): now suppresses `*.internal*`
   packages from the published API site via `perPackageOption`.
 
+### Fixed
+
+- **`HighlightTheme` content identity now uses full SHA-256 digest** - replaced 64-bit
+  truncated identity (`Long`) with full 256-bit identity (4 x `Long`) for `equals` and
+  `hashCode` inputs. This removes practical collision risk that could suppress Compose
+  re-highlight triggers (`remember` / `LaunchedEffect`) when two distinct themes shared
+  the same 64-bit prefix. Updated build-time theme generator to emit full digest identity
+  arrays for built-in themes so runtime and generated identities stay parity-aligned.
+  Fixes #263.
+
 ### Added
 
 - **Enhanced `HljsSelectors` with all official hljs scopes** - reorganized constants by official

--- a/buildSrc/src/main/kotlin/dev/hossain/highlight/build/CssThemeParser.kt
+++ b/buildSrc/src/main/kotlin/dev/hossain/highlight/build/CssThemeParser.kt
@@ -1,7 +1,7 @@
 package dev.hossain.highlight.build
 
-import java.security.MessageDigest
 import java.nio.ByteBuffer
+import java.security.MessageDigest
 
 /**
  * Build-time CSS parser that mirrors the behavior of the runtime
@@ -44,20 +44,20 @@ internal object CssThemeParser {
     }
 
     /**
-     * Computes the same 64-bit identity that the runtime built-in factories compute via
-     * `contentDigest64("asset", assetPath)`: SHA-256 of `"asset" \0 <assetPath>`, first 8
-     * bytes interpreted as a Long.
+     * Computes the same 256-bit identity that the runtime built-in factories compute via
+     * `contentDigest256("asset", assetPath)`: SHA-256 of `"asset" \0 <assetPath>`.
      *
      * Reproducing this here means generated themes carry the same identity the runtime
      * would have produced - `HighlightTheme.equals` / Compose recomposition keys behave
      * identically before and after this refactor.
      */
-    fun assetContentIdentity(assetPath: String): Long {
+    fun assetContentIdentity(assetPath: String): LongArray {
         val digest = MessageDigest.getInstance("SHA-256")
         digest.update("asset".toByteArray(Charsets.UTF_8))
         digest.update(byteArrayOf(0))
         digest.update(assetPath.toByteArray(Charsets.UTF_8))
-        return ByteBuffer.wrap(digest.digest(), 0, Long.SIZE_BYTES).long
+        val buffer = ByteBuffer.wrap(digest.digest())
+        return LongArray(SHA256_LONG_COUNT) { buffer.long }
     }
 
     private fun applyHljsSelector(
@@ -255,6 +255,7 @@ internal object CssThemeParser {
     private val PROP_PATTERN = Regex("""([\w-]+)\s*:\s*([^;]+)""")
     private val HLJS_SELECTOR_REGEX = Regex("""\.hljs(?:-[\w-]+)?(?:\.[\w][\w-]*)*""")
     private val PSEUDO_CLASS_REGEX = Regex(""":(?!:)[a-zA-Z]""")
+    private const val SHA256_LONG_COUNT = 4
 
     // Same 21 named colors the runtime parser supports.
     private val NAMED_COLORS: Map<String, Long> =

--- a/buildSrc/src/main/kotlin/dev/hossain/highlight/build/ThemeSourceEmitter.kt
+++ b/buildSrc/src/main/kotlin/dev/hossain/highlight/build/ThemeSourceEmitter.kt
@@ -54,8 +54,8 @@ internal object ThemeSourceEmitter {
     }
 
     private fun emitTheme(sb: StringBuilder, theme: ThemeBuildInput) {
-        sb.appendLine("    /** Identity hash for the [${theme.constantName}] color map (matches `contentDigest64(\"asset\", \"${theme.assetPath}\")`). */")
-        sb.appendLine("    const val ${theme.constantName}_IDENTITY: Long = ${theme.contentIdentity}L")
+        sb.appendLine("    /** Identity digest for the [${theme.constantName}] color map (matches `contentDigest256(\"asset\", \"${theme.assetPath}\")`). */")
+        sb.appendLine("    val ${theme.constantName}_IDENTITY: LongArray = longArrayOf(${theme.contentIdentity.joinToString(", ") { "${it}L" }})")
         sb.appendLine()
         sb.appendLine("    /** Color map for the bundled `${theme.assetPath}` theme. */")
         sb.appendLine("    val ${theme.constantName}: Map<String, SpanStyle> = mapOf(")
@@ -101,8 +101,8 @@ internal data class ThemeBuildInput(
     val constantName: String,
     /** Asset path the runtime would have loaded - used to compute matching identity hash. */
     val assetPath: String,
-    /** SHA-256-derived identity hash of [assetPath], 64-bit. */
-    val contentIdentity: Long,
+    /** SHA-256-derived identity digest of [assetPath], represented as 4 x 64-bit chunks. */
+    val contentIdentity: LongArray,
     /** Parsed entries in CSS source order. */
     val entries: List<Pair<String, ParsedStyle>>,
 )

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -108,12 +108,12 @@ class HighlightTheme private constructor(
     val name: String,
     private val colorMapProvider: () -> Map<String, SpanStyle>,
     /**
-     * Precomputed identity hash for the theme content. Computed once at construction time
-     * from the CSS text, asset path, or color-map inputs, and stored as a [Long] so that
+     * Precomputed identity digest for the theme content. Computed once at construction time
+     * from the CSS text, asset path, or color-map inputs, and stored as a 256-bit value so that
      * [equals] and [hashCode] are O(1). Used by Compose keys (`remember`, `LaunchedEffect`)
      * to detect theme changes even when two themes share the same [name].
      */
-    private val contentIdentity: Long,
+    private val contentIdentity: LongArray,
 ) {
     /** Lazily-parsed map of hljs class names → [SpanStyle]. Cached forever. */
     private val colorMapLazy = lazy { colorMapProvider() }
@@ -180,9 +180,9 @@ class HighlightTheme private constructor(
     override fun equals(other: Any?): Boolean =
         other is HighlightTheme &&
             name == other.name &&
-            contentIdentity == other.contentIdentity
+            contentIdentity.contentEquals(other.contentIdentity)
 
-    override fun hashCode(): Int = 31 * name.hashCode() + contentIdentity.hashCode()
+    override fun hashCode(): Int = 31 * name.hashCode() + contentIdentity.contentHashCode()
 
     override fun toString(): String = "HighlightTheme(name=$name)"
 
@@ -199,7 +199,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "tomorrow",
                 colorMapProvider = { GeneratedThemes.TOMORROW },
-                contentIdentity = GeneratedThemes.TOMORROW_IDENTITY,
+                contentIdentity = GeneratedThemes.TOMORROW_IDENTITY.copyOf(),
             )
 
         /**
@@ -215,7 +215,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "tomorrow-night",
                 colorMapProvider = { GeneratedThemes.TOMORROW_NIGHT },
-                contentIdentity = GeneratedThemes.TOMORROW_NIGHT_IDENTITY,
+                contentIdentity = GeneratedThemes.TOMORROW_NIGHT_IDENTITY.copyOf(),
             )
 
         /**
@@ -231,7 +231,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "atom-one-dark",
                 colorMapProvider = { GeneratedThemes.ATOM_ONE_DARK },
-                contentIdentity = GeneratedThemes.ATOM_ONE_DARK_IDENTITY,
+                contentIdentity = GeneratedThemes.ATOM_ONE_DARK_IDENTITY.copyOf(),
             )
 
         /**
@@ -247,7 +247,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "atom-one-light",
                 colorMapProvider = { GeneratedThemes.ATOM_ONE_LIGHT },
-                contentIdentity = GeneratedThemes.ATOM_ONE_LIGHT_IDENTITY,
+                contentIdentity = GeneratedThemes.ATOM_ONE_LIGHT_IDENTITY.copyOf(),
             )
 
         /**
@@ -293,7 +293,7 @@ class HighlightTheme private constructor(
                     if (map.isEmpty()) throw HighlightException.ThemeNotFound(assetPath)
                     map
                 },
-                contentIdentity = contentDigest64("asset", assetPath),
+                contentIdentity = contentDigest256("asset", assetPath),
             )
         }
 
@@ -321,7 +321,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = name,
                 colorMapProvider = { ThemeParser.parse(cssText) },
-                contentIdentity = contentDigest64("css", cssText),
+                contentIdentity = contentDigest256("css", cssText),
             )
 
         /**
@@ -382,7 +382,7 @@ class HighlightTheme private constructor(
                 } else {
                     immutableMap
                 }
-            val contentIdentity = contentDigest64(effectiveColorMap)
+            val contentIdentity = contentDigest256(effectiveColorMap)
             return HighlightTheme(
                 name = name,
                 colorMapProvider = { effectiveColorMap },
@@ -390,18 +390,18 @@ class HighlightTheme private constructor(
             )
         }
 
-        private fun contentDigest64(
+        private fun contentDigest256(
             prefix: String,
             value: String,
-        ): Long =
-            digestToLong {
+        ): LongArray =
+            digestToLongArray {
                 update(prefix.toByteArray(Charsets.UTF_8))
                 update(byteArrayOf(0))
                 update(value.toByteArray(Charsets.UTF_8))
             }
 
-        private fun contentDigest64(colorMap: Map<String, SpanStyle>): Long =
-            digestToLong {
+        private fun contentDigest256(colorMap: Map<String, SpanStyle>): LongArray =
+            digestToLongArray {
                 update("colormap".toByteArray(Charsets.UTF_8))
                 update(byteArrayOf(0))
                 colorMap.toSortedMap().forEach { (selector, style) ->
@@ -412,11 +412,14 @@ class HighlightTheme private constructor(
                 }
             }
 
-        private inline fun digestToLong(updateDigest: MessageDigest.() -> Unit): Long {
+        private inline fun digestToLongArray(updateDigest: MessageDigest.() -> Unit): LongArray {
             val digest = MessageDigest.getInstance("SHA-256")
             digest.updateDigest()
             val bytes = digest.digest()
-            return ByteBuffer.wrap(bytes, 0, Long.SIZE_BYTES).long
+            val buffer = ByteBuffer.wrap(bytes)
+            return LongArray(SHA256_LONG_COUNT) { buffer.long }
         }
+
+        private const val SHA256_LONG_COUNT = 4
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -199,7 +199,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "tomorrow",
                 colorMapProvider = { GeneratedThemes.TOMORROW },
-                contentIdentity = GeneratedThemes.TOMORROW_IDENTITY.copyOf(),
+                contentIdentity = GeneratedThemes.TOMORROW_IDENTITY,
             )
 
         /**
@@ -215,7 +215,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "tomorrow-night",
                 colorMapProvider = { GeneratedThemes.TOMORROW_NIGHT },
-                contentIdentity = GeneratedThemes.TOMORROW_NIGHT_IDENTITY.copyOf(),
+                contentIdentity = GeneratedThemes.TOMORROW_NIGHT_IDENTITY,
             )
 
         /**
@@ -231,7 +231,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "atom-one-dark",
                 colorMapProvider = { GeneratedThemes.ATOM_ONE_DARK },
-                contentIdentity = GeneratedThemes.ATOM_ONE_DARK_IDENTITY.copyOf(),
+                contentIdentity = GeneratedThemes.ATOM_ONE_DARK_IDENTITY,
             )
 
         /**
@@ -247,7 +247,7 @@ class HighlightTheme private constructor(
             HighlightTheme(
                 name = "atom-one-light",
                 colorMapProvider = { GeneratedThemes.ATOM_ONE_LIGHT },
-                contentIdentity = GeneratedThemes.ATOM_ONE_LIGHT_IDENTITY.copyOf(),
+                contentIdentity = GeneratedThemes.ATOM_ONE_LIGHT_IDENTITY,
             )
 
         /**

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/GeneratedThemesParityTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/GeneratedThemesParityTest.kt
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Config
  * sync by:
  * - Loading each bundled CSS file with the runtime parser at test time.
  * - Comparing the resulting `Map<String, SpanStyle>` against the precompiled `GeneratedThemes.*`.
- * - Asserting the runtime-computed `contentDigest64("asset", path)` matches the embedded
+ * - Asserting the runtime-computed `contentDigest256("asset", path)` matches the embedded
  *   `*_IDENTITY` literal so [HighlightTheme] equality and Compose recomposition keys stay
  *   consistent before and after the refactor.
  *
@@ -53,8 +53,8 @@ class GeneratedThemesParityTest {
 
     // ----- Identity parity -----
     // HighlightTheme.equals compares (name, contentIdentity). The runtime fromAsset factory
-    // computes contentIdentity via contentDigest64("asset", path); the buildSrc generator
-    // reproduces that same hash and embeds it as a Long literal. If those two computations
+    // computes contentIdentity via contentDigest256("asset", path); the buildSrc generator
+    // reproduces that same digest and embeds it in a LongArray literal. If those two computations
     // ever drift, the equality check below fails - the test is a real parity assertion, not
     // a tautology over two copies of the same constant.
 
@@ -84,8 +84,8 @@ class GeneratedThemesParityTest {
 
     @Test
     fun `different built-in themes are not equal`() {
-        // Sanity: every built-in carries a distinct identity hash, so the equality check above
-        // is meaningful - it fails if the buildSrc hash collides with anything other than the
+        // Sanity: every built-in carries a distinct identity digest, so the equality check above
+        // is meaningful - it fails if the buildSrc digest collides with anything other than the
         // matching runtime-computed value.
         assertThat(HighlightTheme.tomorrow()).isNotEqualTo(HighlightTheme.tomorrowNight())
         assertThat(HighlightTheme.atomOneLight()).isNotEqualTo(HighlightTheme.atomOneDark())


### PR DESCRIPTION
## Summary
- switch HighlightTheme content identity from truncated 64-bit Long to full SHA-256 digest represented as 4 x Long
- update equals/hashCode to compare the full digest
- update build-time theme generator to emit full digest identity arrays for built-in themes
- keep generated and runtime identity parity aligned
- add Unreleased changelog entry for this fix

## Verification
- ./gradlew :compose-highlight:test

Fixes #263