### PR TITLE
chore: prepare release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-01
+
 ### Changed (Breaking)
 
 - **Library file layout reorganized for stable release** - implementation-only types now

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.25.0")
+    implementation("dev.hossain:compose-highlight:0.26.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.25.0
+VERSION_NAME=0.26.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 30
-        versionName = "0.25.0"
+        versionCode = 31
+        versionName = "0.26.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Prepare 0.26.0 release artifacts via scripts/prepare-release.sh and run required checks.

- updates VERSION_NAME and related version references
- updates CHANGELOG.md release section date/version
- bumps sample versionCode/versionName
- checks passed: formatKotlin, :compose-highlight:assembleDebug, :sample:assembleDebug, :compose-highlight:test