### PR TITLE
fix: align editor onHighlightComplete with HighlightResult shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed (Breaking - experimental API)
+
+- **Editor `onHighlightComplete` callback shape aligned with `rememberHighlightedCode`** -
+  `SyntaxHighlightedTextEditor` and `rememberSyntaxHighlightedEditorValue` now invoke
+  `onHighlightComplete` with a `HighlightResult` instead of a bare `AnnotatedString`. Callers
+  gain access to `spanCount`, `language`, `durationMs`, and the per-layer `HighlightTimings`
+  breakdown - the same shape `rememberHighlightedCode` already exposes - so observability is
+  consistent across read-only and editable code surfaces. Callers must update lambdas from
+  `{ annotated -> use(annotated) }` to `{ result -> use(result.annotated) }`. Both APIs are
+  marked `@ExperimentalHighlightApi`, so no stable surface is broken. Fixes #277.
+
 ## [0.26.0] - 2026-06-01
 
 ### Changed (Breaking)

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
@@ -4,11 +4,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import org.junit.Rule
 import org.junit.Test
@@ -119,7 +119,7 @@ class RememberSyntaxHighlightedEditorValueTest {
         // When the language changes, the cached snapshot is stale. The composable must detect
         // this in-composition (snapshot.language != language) and fall back to plain text
         // immediately - before the new highlight cycle has completed.
-        var capturedAnnotated: AnnotatedString? = null
+        var capturedResult: HighlightResult? = null
         var currentLanguage by mutableStateOf("kotlin")
         var capturedValue: TextFieldValue? = null
 
@@ -132,14 +132,14 @@ class RememberSyntaxHighlightedEditorValueTest {
                     rememberSyntaxHighlightedEditorValue(
                         value = TextFieldValue("val x = 1"),
                         language = currentLanguage,
-                        onHighlightComplete = { capturedAnnotated = it },
+                        onHighlightComplete = { capturedResult = it },
                     )
             }
         }
 
         // Wait for the initial highlight to confirm spans exist
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
-        capturedAnnotated = null
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedResult != null }
+        capturedResult = null
 
         // Switch language - the snapshot is now stale, stale detection is in-composition
         composeTestRule.runOnIdle { currentLanguage = "sql" }
@@ -151,9 +151,10 @@ class RememberSyntaxHighlightedEditorValueTest {
         }
 
         // Confirm the new highlight cycle eventually fires with the new language
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
-        assertThat(capturedAnnotated!!.text).isEqualTo("val x = 1")
-        assertThat(capturedAnnotated!!.spanStyles).isNotEmpty()
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedResult != null }
+        assertThat(capturedResult!!.language).isEqualTo("sql")
+        assertThat(capturedResult!!.annotated.text).isEqualTo("val x = 1")
+        assertThat(capturedResult!!.annotated.spanStyles).isNotEmpty()
     }
 
     @Test

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import org.junit.Rule
 import org.junit.Test
@@ -104,7 +104,7 @@ class SyntaxHighlightedTextEditorTest {
 
     @Test
     fun onHighlightCompleteCallbackFiresAfterDebounce() {
-        var capturedAnnotated: AnnotatedString? = null
+        var capturedResult: HighlightResult? = null
 
         composeTestRule.setContent {
             HighlightThemeProvider(
@@ -115,16 +115,24 @@ class SyntaxHighlightedTextEditorTest {
                     value = TextFieldValue(sampleCode),
                     onValueChange = {},
                     language = "kotlin",
-                    onHighlightComplete = { capturedAnnotated = it },
+                    onHighlightComplete = { capturedResult = it },
                 )
             }
         }
 
         // Wait for the async highlight pipeline to complete
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedResult != null }
 
-        assertThat(capturedAnnotated!!.text).isEqualTo(sampleCode)
-        assertThat(capturedAnnotated.spanStyles).isNotEmpty()
+        // Result should carry the full HighlightResult shape - matching rememberHighlightedCode.
+        // This locks in the public callback contract introduced for issue #277.
+        val result = checkNotNull(capturedResult)
+        assertThat(result.annotated.text).isEqualTo(sampleCode)
+        assertThat(result.annotated.spanStyles).isNotEmpty()
+        assertThat(result.language).isEqualTo("kotlin")
+        assertThat(result.spanCount).isGreaterThan(0)
+        assertThat(result.durationMs).isAtLeast(0L)
+        // timings is non-null and total matches durationMs (both reflect the same elapsed time).
+        assertThat(result.timings.total.inWholeMilliseconds).isEqualTo(result.durationMs)
     }
 
     @Test
@@ -160,7 +168,7 @@ class SyntaxHighlightedTextEditorTest {
     fun staleSpansNotShownAfterLanguageChange() {
         // When language changes the old snapshot is for a different language, so the composable
         // falls back to plain text in-composition until the new highlight arrives.
-        var capturedAnnotated: AnnotatedString? = null
+        var capturedResult: HighlightResult? = null
         var currentLanguage by mutableStateOf("kotlin")
 
         composeTestRule.setContent {
@@ -172,14 +180,14 @@ class SyntaxHighlightedTextEditorTest {
                     value = TextFieldValue("val x = 1"),
                     onValueChange = {},
                     language = currentLanguage,
-                    onHighlightComplete = { capturedAnnotated = it },
+                    onHighlightComplete = { capturedResult = it },
                 )
             }
         }
 
         // Wait for initial highlight to confirm spans are applied
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
-        capturedAnnotated = null
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedResult != null }
+        capturedResult = null
 
         // Switch to a different language - the old snapshot is now stale
         composeTestRule.runOnIdle { currentLanguage = "sql" }
@@ -196,8 +204,9 @@ class SyntaxHighlightedTextEditorTest {
         assertThat(editableText.spanStyles).isEmpty()
 
         // Now wait for the re-highlight cycle to complete with the new language
-        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedAnnotated != null }
-        assertThat(capturedAnnotated!!.text).isEqualTo("val x = 1")
-        assertThat(capturedAnnotated!!.spanStyles).isNotEmpty()
+        composeTestRule.waitUntil(timeoutMillis = 10_000L) { capturedResult != null }
+        assertThat(capturedResult!!.language).isEqualTo("sql")
+        assertThat(capturedResult!!.annotated.text).isEqualTo("val x = 1")
+        assertThat(capturedResult!!.annotated.spanStyles).isNotEmpty()
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValue.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValue.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import dev.hossain.highlight.engine.HighlightException
+import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.ui.internal.applySnapshotSpans
 import kotlinx.coroutines.delay
@@ -76,10 +77,11 @@ private data class HighlightSnapshot(
  *   highlight call. Defaults to 150 ms. If `debounceMs` changes, the new value is used on the
  *   next keystroke. The currently running debounce window is unaffected (the original delay
  *   completes with its captured-at-suspension value).
- * @param onHighlightComplete Optional callback invoked each time a highlight cycle completes
- *   successfully. Receives the resulting [AnnotatedString] with syntax spans applied. Useful
- *   for testing (wait until the first result arrives) and for observing the highlight output
- *   without owning the editor's text state.
+ * @param onHighlightComplete Optional callback invoked with a [HighlightResult] when a highlight
+ *   cycle completes successfully. Fires after the snapshot is updated. Not called on failure.
+ *   The result carries the highlighted [AnnotatedString], `spanCount`, `language`, `durationMs`,
+ *   and per-layer [HighlightTimings] - matching the shape used by [rememberHighlightedCode] so
+ *   callers can move between read-only and editable APIs without changing their callback shape.
  * @param onError Optional callback invoked with the [HighlightException] when a highlight cycle
  *   fails. The editor falls back to plain text on failure regardless of whether this callback
  *   is set - it is purely observational. Use it to log failures, show a snackbar, or record
@@ -100,7 +102,7 @@ fun rememberSyntaxHighlightedEditorValue(
     language: String,
     theme: HighlightTheme = LocalHighlightTheme.current,
     debounceMs: Long = SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS,
-    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
+    onHighlightComplete: ((HighlightResult) -> Unit)? = null,
     onError: ((HighlightException) -> Unit)? = null,
 ): TextFieldValue {
     val engine = rememberHighlightEngine()
@@ -120,7 +122,7 @@ fun rememberSyntaxHighlightedEditorValue(
             .highlight(value.text, language, theme)
             .onSuccess { result ->
                 highlighted = HighlightSnapshot(result.annotated, language, theme)
-                currentOnHighlightComplete?.invoke(result.annotated)
+                currentOnHighlightComplete?.invoke(result)
             }.onFailure { error ->
                 highlighted = null
                 (error as? HighlightException)?.let { currentOnError?.invoke(it) }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import dev.hossain.highlight.engine.HighlightEngine
 import dev.hossain.highlight.engine.HighlightException
+import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 
 /**
@@ -92,10 +93,12 @@ import dev.hossain.highlight.engine.HighlightTheme
  *   unnecessary WebView calls on fast typists. If `debounceMs` changes, the new value is used
  *   on the next keystroke. The currently running debounce window is unaffected (the original
  *   delay completes with its captured-at-suspension value).
- * @param onHighlightComplete Optional callback invoked each time a highlight cycle completes
- *   successfully. Receives the resulting [AnnotatedString] with syntax spans applied. Useful
- *   for testing (wait until the first result arrives) and for observing the highlight output
- *   without owning the editor's text state. Defaults to `null` (no callback).
+ * @param onHighlightComplete Optional callback invoked with a [HighlightResult] when a highlight
+ *   cycle completes successfully. Fires after the snapshot is updated. Not called on failure.
+ *   The result carries the highlighted [AnnotatedString], `spanCount`, `language`, `durationMs`,
+ *   and per-layer [HighlightTimings] - matching the shape used by [rememberHighlightedCode] so
+ *   callers can move between read-only and editable APIs without changing their callback shape.
+ *   Defaults to `null` (no callback).
  * @param onError Optional callback invoked with the [HighlightException] when a highlight cycle
  *   fails. The editor falls back to plain text on failure regardless of whether this callback
  *   is set - it is purely observational. Use it to log failures, show a snackbar, or record
@@ -117,7 +120,7 @@ fun SyntaxHighlightedTextEditor(
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle,
     debounceMs: Long = SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS,
-    onHighlightComplete: ((AnnotatedString) -> Unit)? = null,
+    onHighlightComplete: ((HighlightResult) -> Unit)? = null,
     onError: ((HighlightException) -> Unit)? = null,
 ) {
     val displayValue =


### PR DESCRIPTION
## Summary

Aligns `SyntaxHighlightedTextEditor` and `rememberSyntaxHighlightedEditorValue` `onHighlightComplete` callback with the shape `rememberHighlightedCode` already exposes - both now receive `HighlightResult` instead of a bare `AnnotatedString`. Editor callers gain `spanCount`, `language`, `durationMs`, and per-layer `HighlightTimings` without dropping to the helper or running their own timing logic.

Both APIs carry `@ExperimentalHighlightApi`, so no stable surface breaks. Locking this in before the annotation comes off avoids a binary-compat regret post-1.0.

## Changes

- `RememberSyntaxHighlightedEditorValue.kt` - parameter type and KDoc updated; invocation passes `result` instead of `result.annotated`.
- `SyntaxHighlightedTextEditor.kt` - same shape change; `HighlightResult` import added.
- `SyntaxHighlightedTextEditorTest.kt` - primary callback test now asserts `language`, `spanCount`, `durationMs`, and `timings.total == durationMs` (locks in the contract). The stale-spans-on-language-change test now asserts the new `result.language` matches the switched-to language.
- `RememberSyntaxHighlightedEditorValueTest.kt` - the one editor test that captured `AnnotatedString?` now captures `HighlightResult?` with the same `language` assertion.
- `CHANGELOG.md` - `Changed (Breaking - experimental API)` entry under `[Unreleased]`.

Sample app and `docs/` needed no changes - the three sample callers of `onHighlightComplete` all use `SyntaxHighlightedCode` (already takes `HighlightResult`), and the docs reference page only mentions the callback name, not its signature.

## Migration

Callers who pass a lambda using the old shape:

```kotlin
// before
onHighlightComplete = { annotated -> use(annotated) }

// after
onHighlightComplete = { result -> use(result.annotated) }
```

## Verification

- `./gradlew :compose-highlight:test` - passes.
- `./gradlew :compose-highlight:compileDebugAndroidTestKotlin :sample:compileDebugKotlin` - passes (instrumented tests compile; not run here, requires a connected device).
- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.

## Test plan

- [ ] CI green on this PR.
- [ ] Connected-device run of `:compose-highlight:connectedDebugAndroidTest` exercises the two updated tests.

Fixes #277.