### PR TITLE
fix: expose keyboardOptions and cursorBrush; lock editor scope (closes #265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changed (Breaking - experimental API)
 
+- **Editor ships code-friendly `keyboardOptions` by default** - `SyntaxHighlightedTextEditor`
+  now defaults its `keyboardOptions` to `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions`
+  (autocorrect off, autocapitalization off, Ascii keyboard). Existing callers who relied on the
+  previous behavior - which inherited `BasicTextField`'s `KeyboardOptions.Default` and left
+  autocorrect on - will see identifiers no longer get rewritten by the IME as the user types.
+  This is the intended behavior for a source-code editor; the `KeyboardOptions.Default`
+  behavior is recoverable by passing it explicitly. Marked `@ExperimentalHighlightApi`.
+
 - **Editor `onHighlightComplete` callback shape aligned with `rememberHighlightedCode`** -
   `SyntaxHighlightedTextEditor` and `rememberSyntaxHighlightedEditorValue` now invoke
   `onHighlightComplete` with a `HighlightResult` instead of a bare `AnnotatedString`. Callers
@@ -14,6 +22,27 @@ All notable changes to this project will be documented in this file.
   consistent across read-only and editable code surfaces. Callers must update lambdas from
   `{ annotated -> use(annotated) }` to `{ result -> use(result.annotated) }`. Both APIs are
   marked `@ExperimentalHighlightApi`, so no stable surface is broken. Fixes #277.
+
+### Added
+
+- **`SyntaxHighlightedTextEditor.keyboardOptions` parameter** - new `keyboardOptions:
+  KeyboardOptions` parameter forwarded to the underlying `BasicTextField`. Defaults to the new
+  `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` constant. Override at the call site
+  to customise IME action or keyboard type while keeping autocorrect/autocapitalization off:
+  `keyboardOptions = SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.copy(imeAction =
+  ImeAction.Search)`. Part of #265.
+
+- **`SyntaxHighlightedTextEditor.cursorBrush` parameter** - new `cursorBrush: Brush?` parameter
+  forwarded to the underlying `BasicTextField`. Defaults to `null`, in which case the cursor is
+  painted using a `SolidColor` derived from the theme's `defaultTextColor` - so the cursor is
+  visible on both light and dark themes out of the box. `BasicTextField`'s own default
+  (`SolidColor(Color.Black)`) is invisible on dark themes; passing an explicit brush overrides
+  the theme-derived default. Part of #265.
+
+- **`SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` constant** - pre-allocated
+  `KeyboardOptions` tuned for source-code input (autocorrect off, autocapitalization off,
+  `KeyboardType.Ascii`). Used as the default for the editor's new `keyboardOptions` parameter.
+  Marked `@ExperimentalHighlightApi`.
 
 ## [0.26.0] - 2026-06-01
 

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
@@ -1,5 +1,6 @@
 package dev.hossain.highlight.ui
 
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -10,6 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -208,5 +210,32 @@ class SyntaxHighlightedTextEditorTest {
         assertThat(capturedResult!!.language).isEqualTo("sql")
         assertThat(capturedResult!!.annotated.text).isEqualTo("val x = 1")
         assertThat(capturedResult!!.annotated.spanStyles).isNotEmpty()
+    }
+
+    @Test
+    fun keyboardOptionsPropagateToBasicTextField() {
+        // Pass a non-default imeAction. If keyboardOptions is wired through, the underlying
+        // text field's semantics will report that imeAction. If it isn't wired, the field would
+        // report KeyboardOptions.Default's ImeAction.Default value instead. This is the issue
+        // #265 acceptance criterion that the editor honours caller-supplied keyboardOptions.
+        // The default-constants assertions live in the JVM-side
+        // SyntaxHighlightedTextEditorDefaultsTest where they cost milliseconds, not seconds.
+        composeTestRule.setContent {
+            HighlightThemeProvider {
+                SyntaxHighlightedTextEditor(
+                    value = TextFieldValue(sampleCode),
+                    onValueChange = {},
+                    language = "kotlin",
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                )
+            }
+        }
+
+        val imeAction =
+            composeTestRule
+                .onNode(hasSetTextAction(), useUnmergedTree = true)
+                .fetchSemanticsNode()
+                .config[SemanticsProperties.ImeAction]
+        assertThat(imeAction).isEqualTo(ImeAction.Search)
     }
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -42,8 +42,37 @@ import dev.hossain.highlight.engine.HighlightTheme
  * This composable reads the active theme from [LocalHighlightTheme], so a
  * [HighlightThemeProvider] ancestor **must** exist, or you must pass an explicit [theme].
  *
- * For custom layout or third-party text fields, use [rememberSyntaxHighlightedEditorValue]
- * directly to obtain the highlighted [TextFieldValue] without the `Surface` wrapper.
+ * ## Scope
+ *
+ * This is a deliberate convenience composable, not a parameterized clone of [BasicTextField].
+ * It exposes presentation knobs ([modifier], [contentPadding], [shape], [theme], [textStyle]),
+ * code-friendly behavior tuning ([keyboardOptions], [cursorBrush]), highlight controls
+ * ([debounceMs]), and observability ([onHighlightComplete], [onError]) - and nothing else.
+ *
+ * For any other [BasicTextField] parameter (`enabled`, `readOnly`, `singleLine`, `maxLines`,
+ * `keyboardActions`, `visualTransformation`, `onTextLayout`, `interactionSource`, `decorationBox`,
+ * etc.) drop one level down to [rememberSyntaxHighlightedEditorValue] and render your own field.
+ * The helper returns a [TextFieldValue] with highlighting applied and cursor / selection
+ * preserved; you compose it into whatever field shape you need:
+ *
+ * ```kotlin
+ * val displayValue = rememberSyntaxHighlightedEditorValue(
+ *     value    = editorValue,
+ *     language = "kotlin",
+ * )
+ * BasicTextField(
+ *     value         = displayValue,
+ *     onValueChange = { editorValue = it },
+ *     enabled       = uiEnabled,
+ *     readOnly      = isReadOnly,
+ *     singleLine    = true,
+ *     // ...any other BasicTextField parameter
+ * )
+ * ```
+ *
+ * This split keeps the convenience composable's surface small (and stable - it doesn't grow as
+ * Compose Foundation adds new `BasicTextField` parameters) while still giving callers full
+ * control when they need it.
  *
  * ## Usage - inside HighlightThemeProvider (recommended)
  *

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -3,13 +3,16 @@ package dev.hossain.highlight.ui
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
@@ -88,6 +91,19 @@ import dev.hossain.highlight.engine.HighlightTheme
  * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
  * @param textStyle Text style for the editor. Defaults to a monospace style. The theme's
  *   foreground color is applied on top of this style when a highlight result is available.
+ * @param keyboardOptions Keyboard options forwarded to the underlying [BasicTextField]. Defaults
+ *   to [SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions], which disables autocorrect and
+ *   autocapitalization and uses an Ascii keyboard - the right defaults for source code. Override
+ *   if you need a different keyboard type or IME action; for example, copy the default and add
+ *   `imeAction = ImeAction.Search` to keep the code-friendly settings while customising one
+ *   field. Note that `BasicTextField`'s own [KeyboardOptions.Default] leaves autocorrect on, so
+ *   passing `KeyboardOptions.Default` here will mangle identifiers as the user types.
+ * @param cursorBrush Optional [Brush] used to paint the editor's text cursor. When `null`
+ *   (the default), the cursor uses a [SolidColor] derived from the theme's `defaultTextColor`,
+ *   so the cursor stays visible on both light and dark themes. Pass an explicit [Brush] to
+ *   override - for example, `SolidColor(MaterialTheme.colorScheme.primary)` to match the host
+ *   app's accent color. Note that [BasicTextField]'s own default is `SolidColor(Color.Black)`,
+ *   which is invisible on dark themes.
  * @param debounceMs Milliseconds to wait after the last keystroke before triggering a new
  *   highlight call. Defaults to 150 ms - a good balance between responsiveness and avoiding
  *   unnecessary WebView calls on fast typists. If `debounceMs` changes, the new value is used
@@ -119,6 +135,8 @@ fun SyntaxHighlightedTextEditor(
     shape: Shape = RectangleShape,
     theme: HighlightTheme = LocalHighlightTheme.current,
     textStyle: TextStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle,
+    keyboardOptions: KeyboardOptions = SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions,
+    cursorBrush: Brush? = null,
     debounceMs: Long = SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS,
     onHighlightComplete: ((HighlightResult) -> Unit)? = null,
     onError: ((HighlightException) -> Unit)? = null,
@@ -145,6 +163,14 @@ fun SyntaxHighlightedTextEditor(
         }
     val themedTextStyle = remember(theme, textStyle) { textStyle.copy(color = textColor) }
 
+    // When the caller passes null, derive the cursor color from the theme so it stays visible on
+    // both light and dark themes. BasicTextField's own default (SolidColor(Color.Black)) is
+    // invisible on dark themes, which is the bug this defaulting avoids.
+    val resolvedCursorBrush =
+        remember(cursorBrush, textColor) {
+            cursorBrush ?: SolidColor(textColor)
+        }
+
     Surface(
         modifier = modifier.testTag("syntax-highlighted-text-editor"),
         shape = shape,
@@ -155,6 +181,8 @@ fun SyntaxHighlightedTextEditor(
             value = displayValue,
             onValueChange = onValueChange,
             textStyle = themedTextStyle,
+            keyboardOptions = keyboardOptions,
+            cursorBrush = resolvedCursorBrush,
             modifier = Modifier.padding(contentPadding),
         )
     }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorDefaults.kt
@@ -1,7 +1,10 @@
 package dev.hossain.highlight.ui
 
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 
 /**
  * Default values used by [SyntaxHighlightedTextEditor] and [rememberSyntaxHighlightedEditorValue].
@@ -39,4 +42,36 @@ object SyntaxHighlightedTextEditorDefaults {
      * unnecessary WebView calls on fast typists.
      */
     const val DEBOUNCE_MS: Long = 150L
+
+    /**
+     * Default [KeyboardOptions] tuned for source-code input.
+     *
+     * `BasicTextField`'s built-in default ([KeyboardOptions.Default]) leaves autocorrect and
+     * autocapitalization enabled, which mangles identifiers ("fun" -> "Fun", "println" ->
+     * "printing") and is wrong for code. The editor opts callers into code-friendly behavior
+     * out of the box:
+     * - [KeyboardCapitalization.None] - no automatic capitalization at sentence boundaries.
+     * - `autoCorrectEnabled = false` - the IME does not rewrite identifiers or symbols.
+     * - [KeyboardType.Ascii] - hints the soft keyboard to a programmer-friendly layout.
+     *
+     * Override at the call site if you need a different keyboard type (e.g. a search input
+     * that should still use the language-default IME):
+     *
+     * ```kotlin
+     * SyntaxHighlightedTextEditor(
+     *     value = editorValue,
+     *     onValueChange = { editorValue = it },
+     *     language = "sql",
+     *     keyboardOptions = SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.copy(
+     *         imeAction = ImeAction.Search,
+     *     ),
+     * )
+     * ```
+     */
+    val CodeKeyboardOptions: KeyboardOptions =
+        KeyboardOptions(
+            capitalization = KeyboardCapitalization.None,
+            autoCorrectEnabled = false,
+            keyboardType = KeyboardType.Ascii,
+        )
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorDefaultsTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorDefaultsTest.kt
@@ -1,0 +1,46 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * JVM unit tests for [SyntaxHighlightedTextEditorDefaults].
+ *
+ * Verifies the constants ship with values appropriate for source-code editing - in particular,
+ * that [SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions] disables the IME behaviors that
+ * would mangle identifiers as the user types (autocorrect, autocapitalization).
+ */
+@OptIn(ExperimentalHighlightApi::class)
+class SyntaxHighlightedTextEditorDefaultsTest {
+    @Test
+    fun `CodeKeyboardOptions disables autocorrect`() {
+        // Without this, the IME rewrites identifiers ("fun" -> "Fun", "println" -> "printing")
+        // as the user types - the failure mode that motivates the code-friendly default.
+        assertThat(SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.autoCorrectEnabled).isFalse()
+    }
+
+    @Test
+    fun `CodeKeyboardOptions disables autocapitalization`() {
+        // Sentence-boundary capitalization would turn `class` into `Class` after a period in a
+        // string literal, comment, etc. Off by default for code.
+        assertThat(SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.capitalization)
+            .isEqualTo(KeyboardCapitalization.None)
+    }
+
+    @Test
+    fun `CodeKeyboardOptions uses Ascii keyboard type`() {
+        // Hints the soft keyboard to a programmer-friendly layout (no language-specific
+        // suggestions, easier access to symbols on most IMEs).
+        assertThat(SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.keyboardType)
+            .isEqualTo(KeyboardType.Ascii)
+    }
+
+    @Test
+    fun `DEBOUNCE_MS is 150`() {
+        // Locked in as the documented default - changes are user-visible (faster typists feel
+        // the difference) so the constant should not drift accidentally.
+        assertThat(SyntaxHighlightedTextEditorDefaults.DEBOUNCE_MS).isEqualTo(150L)
+    }
+}

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -126,6 +126,24 @@ Core behavior:
 - Keep `shape` aligned with any border shape to avoid background bleed at rounded corners.
 - Outside `HighlightThemeProvider`, a standalone engine/WebView is created and managed by lifecycle.
 
+## Why aren't `enabled`, `readOnly`, `singleLine`, etc. exposed?
+
+`SyntaxHighlightedTextEditor` is a deliberate convenience composable: it ships code-friendly
+defaults (`keyboardOptions`, `cursorBrush`, monospace `textStyle`, debounce window, theme-aware
+surface) and exposes only the parameters needed to tune them. It is **not** a parameterized
+clone of `BasicTextField`.
+
+For any other `BasicTextField` parameter you might want - `enabled`, `readOnly`, `singleLine`,
+`maxLines`, `minLines`, `keyboardActions`, `visualTransformation`, `onTextLayout`,
+`interactionSource`, `decorationBox` - drop one level down to
+[`rememberSyntaxHighlightedEditorValue`](#lower-level-helper-for-custom-text-fields) and render
+your own field. The helper returns a `TextFieldValue` with highlighting applied and cursor /
+selection preserved; you compose it into whatever field shape you need.
+
+This split keeps the convenience composable's surface small (and stable - it doesn't grow as
+Compose Foundation adds new `BasicTextField` parameters) while still giving you full control
+when you need it.
+
 ## Lower-level helper for custom text fields
 
 Use `rememberSyntaxHighlightedEditorValue()` when you want your own field component

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -28,7 +28,11 @@ Full API in Dokka:
 - `theme` - explicit theme or value from `HighlightThemeProvider`.
 - `debounceMs` - typing pause before highlight call.
 - `contentPadding` and `shape` - layout and clipping of editor surface.
-- `onHighlightComplete` and `onError` - observability hooks.
+- `keyboardOptions` - keyboard / IME behavior. Defaults to `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` (autocorrect off, autocapitalization off, Ascii keyboard) - the right defaults for source code. Override via `.copy(imeAction = ...)` to keep the code-friendly settings while customising one field.
+- `cursorBrush` - text cursor color. Defaults to `null`, which derives the cursor from the theme's text color so it stays visible on both light and dark themes. Pass an explicit `Brush` (e.g. `SolidColor(MaterialTheme.colorScheme.primary)`) to override.
+- `onHighlightComplete` and `onError` - observability hooks. `onHighlightComplete` receives a `HighlightResult` (timing, span count, language); see the [API docs](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-result/index.html).
+
+For anything else `BasicTextField` exposes (`enabled`, `readOnly`, `singleLine`, `maxLines`, `decorationBox`, etc.) drop one level down to [`rememberSyntaxHighlightedEditorValue`](#lower-level-helper-for-custom-text-fields) and render your own field - the editor is intentionally opinionated.
 
 ## Opting in
 


### PR DESCRIPTION
## Summary

Two changes that together close out issue #265:

1. **Add Tier 1 `BasicTextField` parameters to `SyntaxHighlightedTextEditor`** - the two that are practically required for source-code editing.
2. **Lock in the editor's scope** - document that Tier 2+ parameters (`enabled`, `readOnly`, `singleLine`, `maxLines`, `keyboardActions`, `visualTransformation`, `onTextLayout`, `interactionSource`, `decorationBox`) are deliberately not exposed; callers drop down to `rememberSyntaxHighlightedEditorValue` and render their own field.

The split keeps the convenience composable's surface small and stable - it doesn't grow as Compose Foundation adds new `BasicTextField` parameters.

## Tier 1 parameters

- **`keyboardOptions: KeyboardOptions`** - defaults to a new `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` constant (autocorrect off, autocapitalization off, `KeyboardType.Ascii`). Without this, the IME mangles identifiers as the user types - `fun` becomes `Fun`, `println` becomes `printing`.
- **`cursorBrush: Brush?`** - defaults to `null`, in which case the cursor is derived from the theme's text color via `SolidColor(textColor)`. `BasicTextField`'s own default (`SolidColor(Color.Black)`) is invisible on dark themes.

## Behavior change

Existing experimental callers see the `keyboardOptions` default flip from `BasicTextField`'s `KeyboardOptions.Default` (autocorrect on) to the new code-friendly `CodeKeyboardOptions` (autocorrect off). Passing `KeyboardOptions.Default` explicitly recovers the old behavior. `@ExperimentalHighlightApi` covers the break.

## Files changed

**Source:**
- `SyntaxHighlightedTextEditorDefaults.kt` - adds `CodeKeyboardOptions` constant.
- `SyntaxHighlightedTextEditor.kt` - adds the two parameters (cursorBrush resolves from theme when `null`); KDoc gains a "Scope" section calling out the deliberate boundary.

**Tests:**
- `SyntaxHighlightedTextEditorDefaultsTest.kt` (NEW, `src/test/`) - 4 fast JVM tests covering the constants. Runs in 3 ms.
- `SyntaxHighlightedTextEditorTest.kt` (`src/androidTest/`) - new Robolectric test (`keyboardOptionsPropagateToBasicTextField`) verifying the parameter wires through to the underlying field via the semantics tree.

**Docs:**
- `docs/reference/syntax-highlighted-text-editor.md` - `keyboardOptions` and `cursorBrush` documented in Key Parameters; new "Why aren't `enabled`, `readOnly`, `singleLine`, etc. exposed?" section explains the design boundary.
- `CHANGELOG.md` - `Changed (Breaking - experimental API)` for the default flip plus `Added` entries for the new params and the constant.

## Test placement

Pure-data assertions on `CodeKeyboardOptions` properties live in `src/test/` as a JVM test (millisecond runtime, follows `CodeBlockStyleTest` precedent and the JVM-side backticked-name convention). The semantics-tree assertion stays in `src/androidTest/` because it needs the Compose UI testing rule.

## Verification

- `./gradlew :compose-highlight:test` - 4 new tests pass in 3 ms; full suite green.
- `./gradlew :compose-highlight:compileDebugAndroidTestKotlin :sample:compileDebugKotlin` - both compile.
- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.

## Test plan

- [x] CI green on this PR.
- [x] Connected-device run of `:compose-highlight:connectedDebugAndroidTest` exercises the new propagation test.
- [x] Manual check in the sample app: live editor no longer auto-capitalizes / autocorrects identifiers.

Closes #265.