### PR TITLE
docs(WebViewManager): document threading invariants + test coverage (closes #278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ All notable changes to this project will be documented in this file.
   `KeyboardType.Ascii`). Used as the default for the editor's new `keyboardOptions` parameter.
   Marked `@ExperimentalHighlightApi`.
 
+### Internal
+
+- **`WebViewManager` threading invariants documented and test-covered** - the manager's class
+  KDoc now spells out which methods run on Main, where each field is written from, and why the
+  `DisposableEffect`-owned lifecycle structurally prevents the racy-on-paper sequences from
+  happening in practice. New `WebViewManagerThreadingTest` (JVM/Robolectric) pins three
+  invariants: destroy-during-init does not leave the next initialize hung, concurrent
+  initialize calls create exactly one WebView, and a getReadyWebView await resumes with
+  cancellation when destroy fires (never hangs). No functional change. Closes #278.
+
 ## [0.26.0] - 2026-06-01
 
 ### Changed (Breaking)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/WebViewManager.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/WebViewManager.kt
@@ -47,6 +47,52 @@ import kotlinx.coroutines.withContext
  * [android.webkit.WebView.evaluateJavascript] for every syntax-highlight request,
  * getting back HTML with `<span class="hljs-*">` tokens that are then converted to
  * an [androidx.compose.ui.text.AnnotatedString] by [HtmlToAnnotatedString].
+ *
+ * ## Threading invariants
+ *
+ * The [WebView] itself is not thread-safe - the platform requires construction, JS evaluation,
+ * and destruction to all happen on the thread that created it. This manager pins that to the
+ * Main thread.
+ *
+ * **Method dispatch:**
+ * - [initialize] is `suspend` and dispatches its critical section to [Dispatchers.Main] via
+ *   `withContext`. The [WebView] is constructed and `bridge.html` is loaded on Main.
+ * - [destroy] runs on the caller's thread (it is `fun`, not `suspend`), but its only Main-thread
+ *   contract is that the actual `wv.destroy()` call is posted to the Main looper - field
+ *   mutation can happen anywhere.
+ * - [getReadyWebView] is `suspend` and can be awaited from any thread. It only calls
+ *   [CompletableDeferred.await] on [readyDeferred].
+ *
+ * **Field write sites:**
+ * - [webView] - set on Main inside [initialize]; cleared from any thread inside [destroy].
+ *   Marked `@Volatile` so the clear in [destroy] is immediately visible to [initialize] and
+ *   [onPageFinished] running on Main.
+ * - [readyDeferred] - reassigned on Main inside [initialize] (only when the previous one is
+ *   complete) and from any thread inside [destroy]. Marked `@Volatile` for the same reason.
+ * - [_isInitialized] - flipped to `true` on Main from `onPageFinished`; flipped to `false` from
+ *   any thread inside [destroy]. [MutableStateFlow] handles concurrent writes safely.
+ *
+ * **Why no [kotlinx.coroutines.sync.Mutex]:**
+ *
+ * In practice, [initialize] and [destroy] are paired with a single [HighlightEngine] instance
+ * whose lifecycle is owned by Compose's `DisposableEffect` (see `HighlightThemeProvider` and
+ * `rememberHighlightEngine`). `DisposableEffect.onDispose` runs on the **applier thread**,
+ * which is Main, and effects are not re-entered concurrently. So:
+ * - Two [initialize] coroutines from the same engine would race on entering Main, but the
+ *   `webView != null` early-return after the dispatch makes the second one a no-op.
+ * - [destroy] is invoked once per `onDispose`, exactly once per engine lifecycle.
+ *
+ * The remaining "racy on paper" sequences (a destroy+reassign happening between [initialize]'s
+ * `readyDeferred.isCompleted` check and its reassignment, for example) settle into benign
+ * end states - the captured local `deferred` in [initialize] guarantees [onPageFinished] always
+ * completes the deferred it was paired with, and the `webView == null` guard at the top of
+ * [onPageFinished] no-ops cleanly when destroy ran first.
+ *
+ * If callers ever need to invoke this manager outside the `DisposableEffect` discipline (e.g.
+ * a `ViewModel`-owned engine driven by `onCleared`), [destroy] can be called from any thread -
+ * the field cleanup and the posted `wv.destroy()` are independent. The threading model still
+ * holds; the implicit Main-thread serialization just changes from "Compose applier" to
+ * "whatever the caller arranges."
  */
 internal class WebViewManager(
     private val context: Context,

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/internal/WebViewManagerThreadingTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/internal/WebViewManagerThreadingTest.kt
@@ -1,0 +1,168 @@
+package dev.hossain.highlight.engine.internal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Robolectric tests that pin the threading invariants documented on [WebViewManager]'s class
+ * KDoc. These are the assertions that "the code is correct, here is the proof" - they catch
+ * regressions where a future edit removes the captured-local pattern in [WebViewManager.initialize]
+ * or the `webView == null` guard in `onPageFinished`, both of which keep the manager safe under
+ * destroy / re-init / concurrent-await sequences.
+ *
+ * For broader engine semantics (failure mapping, JS bridge), see [WebViewManagerRobolectricTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30])
+class WebViewManagerThreadingTest {
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun setUp() {
+        // UnconfinedTestDispatcher lets withContext(Dispatchers.Main) inside initialize() proceed
+        // eagerly so the WebView constructor runs without a manual looper pump.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `destroy during initialize completes the new deferred on the next initialize`() =
+        runTest {
+            val manager = WebViewManager(context)
+
+            // First initialize() creates the WebView; bridge.html is loaded but onPageFinished
+            // has not been driven yet, so readyDeferred from this round stays uncompleted.
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+
+            // Capture the WebViewClient + URL the manager registered, then race destroy vs the
+            // page-load callback. After destroy(), invoking onPageFinished against the captured
+            // deferred should be a no-op (webView is null), and the next initialize() must build
+            // a fresh deferred that the *new* WebView's onPageFinished completes.
+            val firstWebView = manager.webViewForTest() ?: error("Initial WebView was not created")
+            val firstClient = Shadows.shadowOf(firstWebView).webViewClient
+
+            manager.destroy()
+            ShadowLooper.idleMainLooper()
+
+            // Late callback against the destroyed WebView - guard at the top of onPageFinished
+            // makes this a no-op. Without the guard, this would complete a stale deferred.
+            firstClient?.onPageFinished(firstWebView, "https://appassets.androidplatform.net/assets/compose-highlight/bridge.html")
+            ShadowLooper.idleMainLooper()
+
+            // Second initialize() must allocate a fresh WebView with a fresh deferred.
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+
+            val secondWebView = manager.webViewForTest() ?: error("Re-initialized WebView was not created")
+            assertThat(secondWebView).isNotSameInstanceAs(firstWebView)
+            val secondClient = Shadows.shadowOf(secondWebView).webViewClient
+            secondClient?.onPageFinished(secondWebView, "https://appassets.androidplatform.net/assets/compose-highlight/bridge.html")
+            ShadowLooper.idleMainLooper()
+
+            // getReadyWebView resumes - if the late onPageFinished from the first round had
+            // completed the *new* deferred (the bug this test guards against), this would still
+            // succeed but yield the wrong WebView. Identity check is the real assertion.
+            val ready =
+                withTimeoutOrNull(2_000L) {
+                    manager.getReadyWebView()
+                }
+            assertThat(ready).isSameInstanceAs(secondWebView)
+
+            manager.destroy()
+        }
+
+    @Test
+    fun `concurrent initialize calls create exactly one WebView`() =
+        runTest {
+            val manager = WebViewManager(context)
+
+            // Launch four initialize() coroutines concurrently. After they all return, only one
+            // WebView should exist. The early-return on webView != null inside the Main-thread
+            // critical section is what makes this safe; this test pins that behavior.
+            coroutineScope {
+                val jobs =
+                    (1..4).map {
+                        async { manager.initialize() }
+                    }
+                jobs.awaitAll()
+            }
+            ShadowLooper.idleMainLooper()
+
+            val webView = manager.webViewForTest()
+            assertThat(webView).isNotNull()
+
+            // Re-running initialize() must not allocate another WebView (idempotency).
+            val before = webView
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+            assertThat(manager.webViewForTest()).isSameInstanceAs(before)
+
+            manager.destroy()
+        }
+
+    @Test
+    fun `getReadyWebView awaiting during destroy resumes with cancellation`() =
+        runTest {
+            val manager = WebViewManager(context)
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+            // Page-load callback is not driven, so getReadyWebView() will suspend on the
+            // uncompleted readyDeferred until destroy() cancels it.
+
+            val resumedWith = CompletableDeferred<Throwable?>()
+            val awaiterScope = CoroutineScope(Dispatchers.Unconfined)
+            val awaiter: Job =
+                awaiterScope.launch {
+                    try {
+                        manager.getReadyWebView()
+                        resumedWith.complete(null) // Should not happen.
+                    } catch (e: Throwable) {
+                        resumedWith.complete(e)
+                    }
+                }
+
+            // Destroy cancels the readyDeferred, which propagates as a cancellation to the
+            // awaiting getReadyWebView() coroutine - never a hang.
+            manager.destroy()
+            ShadowLooper.idleMainLooper()
+
+            val outcome = withTimeoutOrNull(2_000L) { resumedWith.await() }
+            assertThat(outcome).isNotNull()
+            // CompletableDeferred.cancel() resumes await() with a CancellationException; the
+            // exact subclass varies by coroutines version (JobCancellationException), so the
+            // contract is "any Throwable, never a hang" - the timeout above is what would fail
+            // if the manager regressed into never resuming the awaiter.
+            awaiter.cancel()
+            awaiterScope.cancel()
+            manager.destroy()
+        }
+}


### PR DESCRIPTION
## Summary

Locks in the threading invariants of `WebViewManager` with class-level KDoc plus a focused Robolectric test suite. **No functional change** - the manager's behavior was already correct via the captured-local pattern in `initialize()`, the `webView == null` guard in `onPageFinished`, and the `@Volatile` field annotations. This PR makes that correctness auditable so a future edit doesn't silently regress one of the safety-critical invariants.

Followed Option A from the issue.

## Changes

### `WebViewManager.kt` - new "Threading invariants" KDoc section

Documents:

- **Method dispatch** - which method runs on Main, which is `suspend`, which posts to a Handler.
- **Field write sites** - for each of `webView`, `readyDeferred`, `_isInitialized`: where it's written and why concurrent writes from elsewhere are safe.
- **Why no `Mutex`** - the manager is owned by a single `HighlightEngine` whose lifecycle is owned by `DisposableEffect`, which runs on the Compose applier thread (Main) and is not re-entered concurrently. The remaining racy-on-paper sequences settle into benign end states because of the captured-local + `webView == null` guard combination.
- **Escape hatch** - documents that off-Main `destroy()` is intentional and stays safe, so `ViewModel`-owned engines still work.

### `WebViewManagerThreadingTest.kt` (NEW, JVM/Robolectric)

Three tests pin the invariants. Each maps to one of the issue's acceptance criteria:

1. **`destroy during initialize completes the new deferred on the next initialize`** - exercises the captured-local pattern. After destroy, a late `onPageFinished` against the first WebView no-ops; the next `initialize()` allocates a fresh WebView whose `onPageFinished` completes the new deferred. Identity check on `getReadyWebView()` is the actual assertion - if the late callback had completed the new deferred, `getReadyWebView()` would resume but with the wrong WebView.
2. **`concurrent initialize calls create exactly one WebView`** - launches 4 concurrent `initialize()` coroutines, asserts only one WebView exists. Re-entrant `initialize()` is idempotent.
3. **`getReadyWebView awaiting during destroy resumes with cancellation`** - waiter never hangs; resumes via `Throwable` (typically `JobCancellationException`) when destroy cancels the deferred. The 2-second `withTimeoutOrNull` is what would fail if the manager regressed.

All three pass in 1.5 s total (most of that is the cancellation path's real-time settling).

### `CHANGELOG.md` - `Internal` entry under `[Unreleased]`

Closes #278.

## Verification

- `./gradlew :compose-highlight:test` - full suite green; new test class adds 3 passing tests.
- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.
- `./gradlew :compose-highlight:compileDebugKotlin` - clean compile, no Dokka KDoc-reference warnings.

## Test plan

- [ ] CI green on this PR.
- [ ] (Optional) Verify the new KDoc renders correctly on the Dokka site after merge.

## Files changed

- `compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/WebViewManager.kt` - KDoc only.
- `compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/internal/WebViewManagerThreadingTest.kt` - new file.
- `CHANGELOG.md` - one `Internal` entry.