### PR TITLE
perf(ThemeParser): hoist per-call Regex allocations to module level (closes #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ All notable changes to this project will be documented in this file.
   `KeyboardType.Ascii`). Used as the default for the editor's new `keyboardOptions` parameter.
   Marked `@ExperimentalHighlightApi`.
 
+### Performance
+
+- **`ThemeParser` regex hoisting** - the `[\w-]+: [^;]+` declaration matcher and the `\s+`
+  whitespace splitter used in modern `rgb(R G B)` parsing were being allocated as fresh
+  `Regex` instances on every CSS rule and every space-separated color value. Hoisted both to
+  module-level `private val` constants (matching the existing `HLJS_SELECTOR_REGEX` and
+  `PSEUDO_CLASS_REGEX` pattern in the same file). Pure refactor; same regex semantics, fewer
+  allocations on first-highlight latency for asset/CSS-backed themes. Closes #276.
+
 ## [0.26.0] - 2026-06-01
 
 ### Changed (Breaking)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
@@ -151,6 +151,16 @@ internal object ThemeParser {
     // Matches a single colon followed by a pseudo-class identifier, but NOT `::` (pseudo-element).
     private val PSEUDO_CLASS_REGEX = Regex(""":(?!:)[a-zA-Z]""")
 
+    // Matches one CSS declaration: `<property>: <value>` up to the next `;` or end of block.
+    // Used in [parseDeclarations] - kept module-level so a fresh Regex isn't compiled per rule
+    // (a typical theme has dozens of rules and this would otherwise allocate one Regex each).
+    private val PROP_PATTERN = Regex("""([\w-]+)\s*:\s*([^;]+)""")
+
+    // Whitespace splitter for the modern `rgb(R G B / A)` and `rgb(R G B)` color forms. Hoisted
+    // to module level so [parseSpaceSeparatedRgb] doesn't compile a fresh Regex on every color
+    // value parsed.
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
     /** A single CSS rule: comma-separated selector list and the raw declarations block. */
     private data class CssRule(
         val selectors: List<String>,
@@ -394,8 +404,7 @@ internal object ThemeParser {
         var fontStyle: FontStyle? = null
         var background: Color? = null
 
-        val propPattern = Regex("""([\w-]+)\s*:\s*([^;]+)""")
-        propPattern.findAll(declarations).forEach { match ->
+        PROP_PATTERN.findAll(declarations).forEach { match ->
             val prop = match.groupValues[1].trim()
             val value = match.groupValues[2].trim()
             when (prop) {
@@ -536,11 +545,11 @@ internal object ThemeParser {
             val slashIdx = inner.indexOf("/")
             val colorPart = inner.substring(0, slashIdx).trim()
             val alphaPart = inner.substring(slashIdx + 1).trim()
-            val parts = colorPart.split(Regex("\\s+")).filter { it.isNotEmpty() }
+            val parts = colorPart.split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
             if (parts.size != 3) return null
             colorFromRgbStrings(parts[0], parts[1], parts[2], alpha = alphaPart)
         } else {
-            val parts = inner.split(Regex("\\s+")).filter { it.isNotEmpty() }
+            val parts = inner.split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
             if (parts.size != 3) return null
             colorFromRgbStrings(parts[0], parts[1], parts[2], alpha = null)
         }


### PR DESCRIPTION
## Summary

Two `Regex` instances inside `ThemeParser` were being allocated per call. Hoisted both to module-level `private val` constants, matching the convention already established by `HLJS_SELECTOR_REGEX` and `PSEUDO_CLASS_REGEX` at lines 149/152 of the same file.

## Changes

`compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt`:

| Old (per-call) | New (module-level) | Hot path |
|---|---|---|
| `Regex(\"\"\"([\\w-]+)\\s*:\\s*([^;]+)\"\"\")` at L397 inside `parseDeclarations()` | `PROP_PATTERN` at L157 | Once per CSS rule (typical theme: 30-50 rules) |
| `Regex(\"\\\\s+\")` at L539 + L543 inside `parseSpaceSeparatedRgb()` | `WHITESPACE_REGEX` at L162 | Once or twice per modern-form `rgb(R G B [/A])` color value |

`CHANGELOG.md`: new `Performance` entry under `[Unreleased]`.

Both regex semantics are identical - this is a pure refactor.

## Verification

- `./gradlew :compose-highlight:test` - full suite green; all ThemeParser tests (200+ across `ThemeParserTest`, `HljsSelectorsParserTest`, `ThemeParserAssetTest`) pass unchanged.
- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.
- `grep -n \"Regex(\" ThemeParser.kt` - now reports only 4 lines, all module-level `private val`.

## Test plan

- [ ] CI green on this PR.
- [ ] (Optional) Run the `ThemeParserBenchmark` on a connected device for a before/after - this is hygiene more than a hot-path optimization, so a measurable delta isn't expected at the per-theme granularity, but eliminating fresh regex compiles on first-highlight is the right shape.

## Files changed

- `compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt`
- `CHANGELOG.md`

Closes #276.