### PR TITLE
fix(ThemeParser): narrow silent overload's catch to IOException (closes #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ All notable changes to this project will be documented in this file.
   `KeyboardType.Ascii`). Used as the default for the editor's new `keyboardOptions` parameter.
   Marked `@ExperimentalHighlightApi`.
 
+### Fixed
+
+- **`ThemeParser` silent overload no longer swallows parser bugs** - the internal
+  `ThemeParser.parse(context, cssAssetPath)` overload (used by benchmarks and a single test)
+  previously caught **any** `Exception`, conflating "missing asset" with "parser regression".
+  Narrowed to `catch (IOException)` so I/O errors still return the documented empty map, but
+  any other exception (e.g. a parser bug raising `IllegalStateException`) propagates instead
+  of masquerading as `ThemeNotFound` at the `HighlightTheme.fromAsset` layer. No production
+  behavior change - production goes through `ThemeParser.parseAsset` which already throws
+  on I/O. Closes #275.
+
 ## [0.26.0] - 2026-06-01
 
 ### Changed (Breaking)

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import java.io.IOException
 import kotlin.math.roundToInt
 
 /**
@@ -31,8 +32,13 @@ internal object ThemeParser {
      * Parses a CSS theme file from assets into a color map.
      * Results are not cached here - callers should use [lazy] to cache per theme.
      *
-     * Silently returns an empty map on any error. Use [parseAsset] if you need to
-     * distinguish between a missing file and an empty/unparseable theme.
+     * Silently returns an empty map on **I/O error or missing asset** (any [IOException] from
+     * [android.content.res.AssetManager.open] or the read). Parser bugs - any exception thrown
+     * by [parse] itself - propagate so they surface in tests and instrumented runs instead of
+     * being silently swallowed.
+     *
+     * Use [parseAsset] if you need to distinguish between a missing file and an
+     * empty/unparseable theme.
      */
     fun parse(
         context: Context,
@@ -45,7 +51,10 @@ internal object ThemeParser {
                     .bufferedReader()
                     .use { it.readText() }
             parse(css)
-        } catch (e: Exception) {
+        } catch (e: IOException) {
+            // Missing or unreadable asset - documented silent path. Anything else
+            // (e.g. a parser bug raising IllegalStateException) propagates so it cannot
+            // masquerade as ThemeNotFound at the HighlightTheme.fromAsset layer.
             emptyMap()
         }
 

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -1,5 +1,7 @@
 package dev.hossain.highlight.engine
 
+import android.content.ContextWrapper
+import android.content.res.AssetManager
 import androidx.compose.ui.graphics.Color
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -57,6 +59,39 @@ class ThemeParserAssetTest {
     fun `parse with context returns empty map for missing file`() {
         val result = ThemeParser.parse(context, "nonexistent.css")
         assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `parse with context propagates non-IOException instead of swallowing as empty map`() {
+        // Issue #275 - the silent overload's catch was previously `catch (Exception)`, which
+        // would swallow parser bugs and asset-system errors as "empty map", masquerading at the
+        // HighlightTheme.fromAsset layer as ThemeNotFound. After the narrow to `catch (IOException)`,
+        // anything that isn't an IOException must propagate.
+        //
+        // Easiest way to inject a non-IOException is a ContextWrapper that throws from getAssets()
+        // before AssetManager.open() is even reached. IllegalStateException is not an IOException,
+        // so post-fix the narrow catch lets it through; pre-fix the broad catch would have caught it.
+        val brokenContext =
+            object : ContextWrapper(context) {
+                override fun getAssets(): AssetManager = throw IllegalStateException("simulated non-IO failure")
+            }
+        try {
+            ThemeParser.parse(brokenContext, "tomorrow.css")
+            org.junit.Assert.fail("Expected IllegalStateException to propagate, but the silent overload swallowed it")
+        } catch (e: IllegalStateException) {
+            assertThat(e).hasMessageThat().contains("simulated non-IO failure")
+        }
+    }
+
+    @Test
+    fun `parse silent overload returns the same map as parseAsset for valid input`() {
+        // Confirms the catch narrow didn't accidentally turn the silent overload into an
+        // unconditional emptyMap() - parsing still happens for the happy path. If a future
+        // edit moved the catch to wrap parse(css) too broadly, this would fail.
+        val silent = ThemeParser.parse(context, "compose-highlight/themes/tomorrow.css")
+        val throwing = ThemeParser.parseAsset(context, "compose-highlight/themes/tomorrow.css")
+        assertThat(silent).isEqualTo(throwing)
+        assertThat(silent).isNotEmpty()
     }
 
     // ----- Regression tests: ::selection must not overwrite the real .hljs background -----


### PR DESCRIPTION
## Summary

`ThemeParser.parse(context, cssAssetPath)` previously caught **any** `Exception` from the open + read + parse pipeline and returned `emptyMap()`. This conflated the documented "missing asset" case with parser bugs or asset-system errors - which then surfaces at the `HighlightTheme.fromAsset` layer as `ThemeNotFound`, masking the real cause.

Narrowed the catch to `IOException`, so the documented contract still holds (missing or unreadable asset returns an empty map) but anything else (parser exception, asset-system `SecurityException`, etc.) propagates instead of being silently swallowed.

## Production impact

**None.** Production goes through `ThemeParser.parseAsset` (the throwing overload), which is unchanged. The silent overload at `ThemeParser.parse(context, …)` is used by:

- The benchmark module (`compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/benchmark/HtmlToAnnotatedStringBenchmark.kt`) - benchmarks don't care about errors.
- One test (`ThemeParserAssetTest.parse with context returns empty map for missing file`) - explicitly relies on missing-file → empty-map. `FileNotFoundException` is an `IOException`, so this still passes.

## Files changed

- `compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt`:
  - `catch (Exception)` → `catch (IOException)` (line 48-area).
  - Added `import java.io.IOException`.
  - KDoc updated: removed "any error" wording, says "I/O error or missing asset" and notes that parser bugs propagate.
  - Inline comment explains the narrow rationale.
- `compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt`:
  - New: `parse with context propagates non-IOException instead of swallowing as empty map` - injects an `IllegalStateException` via a `ContextWrapper` whose `getAssets()` throws; asserts it propagates.
  - New: `parse silent overload returns the same map as parseAsset for valid input` - confirms the catch narrow didn't accidentally turn the silent overload into an unconditional `emptyMap()`.
- `CHANGELOG.md`: new `Fixed` entry under `[Unreleased]`.

19 tests in the file (was 17), all passing in 75 ms total.

## Verification

Locally:
- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.
- `./gradlew :compose-highlight:lintKotlin` - clean.
- `./gradlew :compose-highlight:test` - full JVM test suite green; both new tests pass.
- `./gradlew :compose-highlight:assembleDebug` - AAR builds.

## Test plan

- [ ] CI green on this PR.

Closes #275.