### PR TITLE
chore: demo Tier 1 editor params in sample app + test cursorBrush resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ All notable changes to this project will be documented in this file.
   `PSEUDO_CLASS_REGEX` pattern in the same file). Pure refactor; same regex semantics, fewer
   allocations on first-highlight latency for asset/CSS-backed themes. Closes #276.
 
+### Tests
+
+- **`cursorBrush` resolution test coverage** - extracted the editor's null-fallback resolver to
+  an `internal fun resolveEditorCursorBrush(cursorBrush, textColor)` so the contract can be
+  pinned by JVM unit tests instead of needing a Compose UI harness. Five tests cover: null
+  falls back to `SolidColor(textColor)` on both light and dark themes (fixing the
+  `BasicTextField` default of `SolidColor(Color.Black)` that's invisible on dark themes),
+  explicit `SolidColor` is returned verbatim, explicit `Brush.horizontalGradient(...)` passes
+  through unchanged, and `Color.Unspecified` falls through without crashing. No behavior change.
+
 ### Internal
 
 - **`WebViewManager` threading invariants documented and test-covered** - the manager's class
@@ -73,6 +83,13 @@ All notable changes to this project will be documented in this file.
   invariants: destroy-during-init does not leave the next initialize hung, concurrent
   initialize calls create exactly one WebView, and a getReadyWebView await resumes with
   cancellation when destroy fires (never hangs). No functional change. Closes #278.
+
+- **Sample app's Live Editor section now demos the Tier 1 editor params from #265** - adds a
+  "Custom cursor color" toggle chip that flips `cursorBrush` between `null` (theme-derived
+  default) and `SolidColor(MaterialTheme.colorScheme.primary)`. The editor's `keyboardOptions`
+  is now set to `CodeKeyboardOptions.copy(imeAction = ImeAction.Done)`, demonstrating the
+  recommended `.copy(...)` pattern for customising one IME field while keeping autocorrect /
+  autocapitalization off. Sample-only change.
 
 ## [0.26.0] - 2026-06-01
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -197,7 +197,7 @@ fun SyntaxHighlightedTextEditor(
     // invisible on dark themes, which is the bug this defaulting avoids.
     val resolvedCursorBrush =
         remember(cursorBrush, textColor) {
-            cursorBrush ?: SolidColor(textColor)
+            resolveEditorCursorBrush(cursorBrush, textColor)
         }
 
     Surface(
@@ -216,3 +216,17 @@ fun SyntaxHighlightedTextEditor(
         )
     }
 }
+
+/**
+ * Resolves the editor's effective cursor brush: caller-supplied [cursorBrush] when non-null,
+ * otherwise a [SolidColor] of the theme-derived [textColor] so the cursor stays visible on
+ * both light and dark themes.
+ *
+ * Extracted as `internal` so the null-fallback contract can be unit-tested without standing up a
+ * full Compose UI test harness. Behavior is intentionally trivial; the test exists to lock in
+ * the contract, not to exercise a complex algorithm.
+ */
+internal fun resolveEditorCursorBrush(
+    cursorBrush: Brush?,
+    textColor: Color,
+): Brush = cursorBrush ?: SolidColor(textColor)

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorCursorBrushTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorCursorBrushTest.kt
@@ -1,0 +1,87 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * JVM unit tests for [resolveEditorCursorBrush].
+ *
+ * Pins the contract that `SyntaxHighlightedTextEditor`'s `cursorBrush` parameter:
+ * - `null` (the default) falls back to a [SolidColor] of the theme-derived text color so the
+ *   cursor stays visible on both light and dark themes.
+ * - A caller-supplied [Brush] passes through verbatim - the editor never overrides an explicit
+ *   brush.
+ *
+ * `BasicTextField`'s built-in default is `SolidColor(Color.Black)`, which is invisible on
+ * dark themes. The fallback in this resolver is what protects the editor against that bug -
+ * if a future edit removes it, these tests fail.
+ */
+@OptIn(ExperimentalHighlightApi::class)
+class SyntaxHighlightedTextEditorCursorBrushTest {
+    @Test
+    fun `null cursorBrush resolves to SolidColor of textColor`() {
+        // Light theme - text color is dark gray. Cursor must use the same color or it disappears.
+        val textColor = Color(0xFF24292E)
+        val resolved = resolveEditorCursorBrush(cursorBrush = null, textColor = textColor)
+        assertThat(resolved).isEqualTo(SolidColor(textColor))
+    }
+
+    @Test
+    fun `null cursorBrush on dark theme uses light textColor (fixes BasicTextField default)`() {
+        // Dark theme - text color is near-white. BasicTextField's own default
+        // (SolidColor(Color.Black)) would be invisible here. The resolver must propagate the
+        // theme's text color so the cursor stays visible.
+        val darkThemeTextColor = Color(0xFFE0E0E0)
+        val resolved = resolveEditorCursorBrush(cursorBrush = null, textColor = darkThemeTextColor)
+        assertThat(resolved).isEqualTo(SolidColor(darkThemeTextColor))
+    }
+
+    @Test
+    fun `explicit cursorBrush is returned unchanged - resolver does not override`() {
+        // When the caller passes an explicit Brush, the resolver returns it verbatim - the
+        // editor never overrides a deliberate caller choice (e.g. matching the host app's
+        // accent color via SolidColor(MaterialTheme.colorScheme.primary)).
+        val customBrush: Brush = SolidColor(Color(0xFF6200EE))
+        val resolved =
+            resolveEditorCursorBrush(
+                cursorBrush = customBrush,
+                textColor = Color(0xFF24292E), // Would be the fallback - must NOT be used.
+            )
+        assertThat(resolved).isSameInstanceAs(customBrush)
+    }
+
+    @Test
+    fun `explicit non-SolidColor brush is returned unchanged`() {
+        // A linear-gradient Brush should also pass through. The resolver doesn't inspect the
+        // brush type; "non-null" is the only condition.
+        val gradient: Brush =
+            Brush.horizontalGradient(
+                colors = listOf(Color.Red, Color.Blue),
+            )
+        val resolved =
+            resolveEditorCursorBrush(
+                cursorBrush = gradient,
+                textColor = Color.Black,
+            )
+        assertThat(resolved).isSameInstanceAs(gradient)
+    }
+
+    @Test
+    fun `null cursorBrush with Color Unspecified textColor still produces a valid Brush`() {
+        // Defensive: the editor's textColor is itself a fallback chain (theme.defaultTextColor
+        // ?: style.fallbackTextColor), but if both somehow failed and Color.Unspecified slipped
+        // through, the resolver must still hand back a non-null Brush. SolidColor of an
+        // unspecified color is technically valid; this test pins that the resolver doesn't
+        // crash or null-out in that path.
+        val resolved =
+            resolveEditorCursorBrush(
+                cursorBrush = null,
+                textColor = Color.Unspecified,
+            )
+        assertThat(resolved).isNotNull()
+        assertThat(resolved).isInstanceOf(SolidColor::class.java)
+    }
+}

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt
@@ -22,13 +22,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hossain.highlight.ui.ExperimentalHighlightApi
 import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
+import dev.hossain.highlight.ui.SyntaxHighlightedTextEditorDefaults
 
 private val DEMO_LANGUAGES =
     listOf(
@@ -134,9 +137,19 @@ LIMIT 10;
 @Composable
 internal fun LiveEditorSection() {
     var selectedLanguage by rememberSaveable { mutableStateOf("kotlin") }
+    var customCursorColor by rememberSaveable { mutableStateOf(false) }
     var editorValue by remember(selectedLanguage) {
         mutableStateOf(TextFieldValue(INITIAL_CODE_BY_LANGUAGE[selectedLanguage] ?: ""))
     }
+
+    // Resolve the cursor brush in composition so MaterialTheme.colorScheme is in scope.
+    // null falls back to the editor's theme-derived default (SolidColor of theme.defaultTextColor),
+    // which keeps the cursor visible on light and dark themes without any extra config.
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val cursorBrush =
+        remember(customCursorColor, primaryColor) {
+            if (customCursorColor) SolidColor(primaryColor) else null
+        }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         SubSectionHeader("Live Syntax Highlighting Editor")
@@ -172,7 +185,24 @@ internal fun LiveEditorSection() {
             }
         }
 
-        // Live editor
+        // Customization toggle - flips cursorBrush between the editor's theme-aware default
+        // (null) and an explicit primary-color SolidColor so users can see the difference.
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FilterChip(
+                selected = customCursorColor,
+                onClick = { customCursorColor = !customCursorColor },
+                label = { Text("Custom cursor color") },
+            )
+        }
+
+        // Live editor.
+        // - keyboardOptions: copy of CodeKeyboardOptions (autocorrect off, Ascii keyboard) with
+        //   imeAction set to Done. The .copy(...) pattern keeps the code-friendly defaults while
+        //   customizing one field.
+        // - cursorBrush: null lets the editor derive a visible cursor from the current theme;
+        //   the toggle above swaps in an explicit SolidColor.
         SyntaxHighlightedTextEditor(
             value = editorValue,
             onValueChange = { editorValue = it },
@@ -193,6 +223,10 @@ internal fun LiveEditorSection() {
                     fontFamily = FontFamily.Monospace,
                     fontSize = 13.sp,
                 ),
+            keyboardOptions =
+                SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions
+                    .copy(imeAction = ImeAction.Done),
+            cursorBrush = cursorBrush,
         )
     }
 }


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #281's Tier 1 editor parameters (`keyboardOptions`, `cursorBrush`):

1. **Sample app demos both new params.** PR #281 added them but the sample's `LiveEditorSection` didn't exercise either - they were invisible to anyone running the sample. Now showcased.
2. **`cursorBrush` resolver gets test coverage.** PR #281 added the null-fallback logic (`cursorBrush ?: SolidColor(textColor)`) but didn't test it. Extracted to an `internal fun` and pinned with 5 JVM tests.

Identified during the post-0.26.0 pre-1.0 re-audit. Neither was blocking 1.0, but both are quick wins that improve discoverability and lock in the contract.

## Changes

### `LiveEditorSection.kt` (sample)

- Imports `SolidColor`, `ImeAction`, `SyntaxHighlightedTextEditorDefaults`.
- New "Custom cursor color" `FilterChip` that flips `cursorBrush` between `null` (theme-derived default) and `SolidColor(MaterialTheme.colorScheme.primary)`.
- `keyboardOptions = SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions.copy(imeAction = ImeAction.Done)` - demonstrates the recommended `.copy(...)` pattern for customising one IME field while keeping autocorrect / autocapitalization off.
- Inline comments explain why `null` is intentional and why the `.copy(...)` pattern matters.

### `SyntaxHighlightedTextEditor.kt`

- Pulled the null-fallback resolution out of the body into:
  ```kotlin
  internal fun resolveEditorCursorBrush(cursorBrush: Brush?, textColor: Color): Brush =
      cursorBrush ?: SolidColor(textColor)
  ```
- Body now calls the helper inside the existing `remember(cursorBrush, textColor) { ... }`. Identical runtime behavior.
- KDoc on the helper explains the contract for future maintainers.

### `SyntaxHighlightedTextEditorCursorBrushTest.kt` (NEW)

5 JVM unit tests covering:
1. `null cursorBrush resolves to SolidColor of textColor` - the basic light-theme case.
2. `null cursorBrush on dark theme uses light textColor (fixes BasicTextField default)` - the bug the resolver guards against; `BasicTextField`'s built-in default `SolidColor(Color.Black)` is invisible on dark themes.
3. `explicit cursorBrush is returned unchanged - resolver does not override` - asserts the resolver hands back the **same instance** (`isSameInstanceAs`), proving no copy / wrap.
4. `explicit non-SolidColor brush is returned unchanged` - `Brush.horizontalGradient` passes through, proving the resolver doesn't inspect the brush type.
5. `null cursorBrush with Color Unspecified textColor still produces a valid Brush` - defensive: confirms the resolver never returns null.

Runs in 3 ms total.

### `CHANGELOG.md`

Two new entries under `[Unreleased]`:
- `Tests` - cursorBrush resolver test coverage.
- `Internal` - sample app demos.

## Verification

Locally on this branch:

- `./gradlew :compose-highlight:formatKotlin` - applied, no diff after.
- `./gradlew :compose-highlight:lintKotlin :compose-highlight:lintDebug` - clean.
- `./gradlew :compose-highlight:test` - full JVM suite green; all 5 new tests pass.
- `./gradlew :compose-highlight:assembleDebug :compose-highlight:compileDebugAndroidTestKotlin :sample:assembleDebug` - all build.

## Test plan

- [ ] CI green on this PR.
- [ ] Manual: install the sample app, navigate to Live Editor, toggle "Custom cursor color" - cursor color flips between theme text color and primary color.

## Files changed

- `sample/src/main/kotlin/dev/hossain/highlight/sample/sections/LiveEditorSection.kt`
- `compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt`
- `compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorCursorBrushTest.kt` (new)
- `CHANGELOG.md`

No public API change. No issue closed (these were items from the post-merge re-audit, not tracked as separate issues).