### PR TITLE
chore: prepare release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-02
+
 ### Changed (Breaking - experimental API)
 
 - **Editor ships code-friendly `keyboardOptions` by default** - `SyntaxHighlightedTextEditor`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.26.0")
+    implementation("dev.hossain:compose-highlight:0.27.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.26.0
+VERSION_NAME=0.27.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 31
-        versionName = "0.26.0"
+        versionCode = 32
+        versionName = "0.27.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## 0.27.0 Release

### Breaking (experimental API)
- Editor ships code-friendly `keyboardOptions` by default (autocorrect off, autocapitalization off, Ascii keyboard)
- Editor `onHighlightComplete` callback now receives `HighlightResult` instead of bare `AnnotatedString`

### Added
- `SyntaxHighlightedTextEditor.keyboardOptions` parameter
- `SyntaxHighlightedTextEditor.cursorBrush` parameter (theme-derived default for dark theme visibility)
- `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` constant

### Fixed
- `ThemeParser` silent overload narrowed to `catch (IOException)` so parser bugs propagate

### Performance
- `ThemeParser` regex hoisting - CSS declaration matcher and whitespace splitter hoisted to module-level constants

### Tests
- `cursorBrush` resolution test coverage (5 JVM tests)
- `WebViewManager` threading invariants (3 JVM/Robolectric tests)

### Sample app
- Live Editor section demos `cursorBrush` toggle and `keyboardOptions` customization