### PR TITLE
docs: update docs/changelog.md with 0.27.0 highlights

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -188,6 +188,8 @@ This script updates all five required files in one step:
 
 Never update these files manually one-by-one - always use the script to avoid missing files.
 
+**After running the script, update `docs/changelog.md`** - add a new `### X.Y.Z - Brief Title` section at the top of the "Recent highlights" block with 3-5 key bullet points extracted from the root `CHANGELOG.md` for that release. Remove the oldest entry to keep only the last 5 releases. See the "Docs Changelog Sync" section above for the exact format.
+
 After running the script, create a release branch, run all checks, commit, push, and open a PR into `main` (direct pushes to `main` are blocked by branch protection):
 ```bash
 git checkout -b release/<new-version>
@@ -209,14 +211,13 @@ git tag <new-version> && git push origin <new-version>
 
 Never tell the user "the publish workflow will trigger automatically" - it won't.
 
-**Release notes format** - when users ask for release notes, provide them in markdown format. Example:
+**Release notes format** - after a git tag is pushed, automatically provide brief release notes in markdown format without waiting for the user to ask. Keep it concise - 3-5 key bullet points max, focusing on user-facing changes. Example:
 ```markdown
 ## v0.22.1
 
 ### Bug Fixes
 - Fixed resource leak: InputStream in ThemeParser now properly closed when loading CSS assets
 - Fixed scroll position persistence when code snippet changes
-- Removed redundant code in HtmlToAnnotatedString
 
 ### Performance
 - Improved recomposition efficiency in LazyColumn scenarios by stabilizing internal lambda instances

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.27.0 - Editor keyboard options and cursor brush
+
+- `SyntaxHighlightedTextEditor` now defaults to code-friendly `keyboardOptions` (autocorrect off, Ascii keyboard)
+- Editor `onHighlightComplete` callback now receives `HighlightResult` instead of `AnnotatedString`
+- New `keyboardOptions` and `cursorBrush` parameters for `SyntaxHighlightedTextEditor`
+- `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` constant added
+- `ThemeParser` no longer silently swallows non-IO exceptions
+
 ### 0.26.0 - Selector coverage and parser efficiency
 
 - Expanded `HljsSelectors` with all official Highlight.js scopes, adding 22 missing selector constants
@@ -35,13 +43,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - 150 ms keystroke debounce with cursor and selection always preserved
 - New **Live Editor** demo tab in sample app showcasing 6 languages
 - Marked `@ExperimentalHighlightApi` for gradual API stabilization
-
-### 0.23.0 - Screenshot regression testing
-
-- 13 Roborazzi screenshot goldens covering themes, layout variants, languages, and error states
-- HTML token fixtures from bundled `highlight.min.js` for testing visual stability
-- `HighlightEngine.webViewForTest()` for cleaner test integration
-- Replaced regex CSS parser with recursive-descent implementation for robustness
 
 ---
 


### PR DESCRIPTION
Updates docs/changelog.md with 0.27.0 release highlights and removes 0.23.0 to keep the last 5 releases.