### PR TITLE
fix(docs): make Dokka nav link absolute to bypass instant navigation

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -46,7 +46,10 @@ nav = [
   ]},
   { "Changelog" = "changelog.md" },
   # Requires: ./gradlew :compose-highlight:dokkaGeneratePublicationHtml
-  { "Dokka API Docs" = "api/" },
+  # Absolute URL is intentional: navigation.instant would otherwise DOM-swap the
+  # Dokka subsite (which lacks Material's data-md-color-* palette nodes) into
+  # this shell and crash the palette switcher. External URLs bypass instant nav.
+  { "Dokka API Docs" = "https://hossain-khan.github.io/android-compose-highlight/api/" },
 ]
 
 [[project.extra_javascript]]


### PR DESCRIPTION
## Summary
- The Dokka subsite at `/api/` isn't built with Material/Zensical, so it has no `data-md-color-*` palette nodes.
- With a relative `api/` link, `navigation.instant` DOM-swapped the Dokka page into the Material shell and crashed the palette switcher (`Cannot read properties of undefined (reading 'getAttribute')`), leaving the docs site in a broken state on Back.
- Switching the nav entry to an absolute URL forces a real page load, sidestepping instant navigation entirely.

## Test plan
- [ ] Merge → wait for `Docs` workflow to deploy.
- [ ] From https://hossain-khan.github.io/android-compose-highlight/, click **Dokka API Docs** → confirm full page load (no instant-nav swap).
- [ ] Browser Back → docs shell renders correctly, no console errors.
- [ ] Toggle dark/light palette on the docs site after returning from Dokka → still works.