### PR TITLE
docs: fix broken snippets and stale guidance against source-of-truth

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,8 +92,8 @@ SyntaxHighlightedCode(
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 SyntaxHighlightedCode(
-    code                 = snippet,
-    language             = "kotlin",
+    code          = snippet,
+    language      = "kotlin",
     languageLabel = null,  // hide language badge
     copyButton    = null,  // hide copy button
 )

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -31,6 +31,26 @@ import dev.hossain.highlight.ui.SyntaxHighlightedCode
 SyntaxHighlightedCode(code = snippet, language = "kotlin", languageLabel = null)
 ```
 
+### Toggle the default label at runtime
+
+Use `SyntaxHighlightedCodeDefaults.LanguageLabel` to keep the default look while
+toggling visibility - no need to reconstruct the styling yourself:
+
+```kotlin
+import dev.hossain.highlight.ui.SyntaxHighlightedCode
+import dev.hossain.highlight.ui.SyntaxHighlightedCodeDefaults
+
+var showLabel by remember { mutableStateOf(true) }
+
+SyntaxHighlightedCode(
+    code     = snippet,
+    language = "kotlin",
+    languageLabel = if (showLabel) {
+        { SyntaxHighlightedCodeDefaults.LanguageLabel("kotlin") }
+    } else null,
+)
+```
+
 ## Copy button
 
 ### Custom icon

--- a/docs/guides/engine-only.md
+++ b/docs/guides/engine-only.md
@@ -92,18 +92,21 @@ engine.highlight(code, language, theme)
             when (error) {
                 is HighlightException.WebViewInitFailed -> /* WebView not available (Go edition, MDM-disabled, mid-update) */
                 is HighlightException.JsExecutionFailed -> /* JS evaluation error */
-                is HighlightException.ThemeNotFound     -> /* theme CSS found but contains no parseable color rules */
-                is HighlightException.HtmlParseFailed   -> /* jsoup parse error, or theme asset IOException (check cause) */
+                is HighlightException.HtmlParseFailed   -> /* jsoup parse error, or theme resolution failure (check cause) */
                 is HighlightException.Timeout           -> /* timed out waiting for WebView */
+                is HighlightException.ThemeNotFound     -> /* unreachable from highlight()/highlightBothThemes()/highlightAuto() - see note below */
             }
         }
     }
 ```
 
-!!! note "Missing asset files"
-    If a theme asset file is missing or unreadable, the `IOException` is wrapped in
-    `HtmlParseFailed` (since theme resolution happens during the HTML processing stage).
-    Check `error.cause` to distinguish asset I/O errors from jsoup parse failures.
+!!! note "Theme resolution failures are wrapped in `HtmlParseFailed`"
+    Failures during theme resolution - including a missing asset file (`IOException`),
+    a CSS file that contains no parseable color rules (`ThemeNotFound`), or any other
+    exception thrown while parsing the active theme - are caught alongside HTML parsing
+    and surfaced as `HighlightException.HtmlParseFailed`. Inspect `error.cause` to
+    distinguish the underlying failure. `ThemeNotFound` is never raised directly to
+    callers of `engine.highlight()` / `highlightBothThemes()` / `highlightAuto()`.
 
 ## Important rules
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -83,14 +83,14 @@ class CodeViewModel(application: Application) : AndroidViewModel(application) {
 Tokenization is the slow part. Running it twice for light + dark wastes time. Use `highlightBothThemes` to tokenize once and produce both variants:
 
 ```kotlin
-import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.engine.HighlightTheme
 
+// Outside Compose: use the non-@Composable HighlightTheme.tomorrow* factories.
 val result = engine.highlightBothThemes(
     code       = sourceCode,
     language   = "kotlin",
-    lightTheme = rememberTomorrowTheme(),
-    darkTheme  = rememberTomorrowNightTheme(),
+    lightTheme = HighlightTheme.tomorrow(),
+    darkTheme  = HighlightTheme.tomorrowNight(),
 )
 // Switch instantly at the call site - no re-highlighting needed
 result.onSuccess { themed ->
@@ -98,7 +98,9 @@ result.onSuccess { themed ->
 }
 ```
 
-Inside Compose, use `rememberHighlightedCodeBothThemes(code, language)`.
+Inside Compose, use `rememberHighlightedCodeBothThemes(code, language)` - or pass
+`rememberTomorrowTheme()` / `rememberTomorrowNightTheme()` to `highlightBothThemes`
+when you already have an `engine` from `rememberHighlightEngine()`.
 
 ## Timing callbacks
 
@@ -122,7 +124,7 @@ SyntaxHighlightedCode(
 )
 ```
 
-`HighlightTimings` has individual fields for each pipeline stage:
+[`HighlightTimings`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-timings/index.html) has individual fields for each pipeline stage:
 
 | Field | Type | Description |
 |---|---|---|

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -130,10 +130,14 @@ For zero-latency theme switching, tokenize once and apply both color maps. Use `
 
 ```kotlin
 import dev.hossain.highlight.ui.rememberHighlightEngine
+import dev.hossain.highlight.ui.rememberTomorrowNightTheme
+import dev.hossain.highlight.ui.rememberTomorrowTheme
 
-val engine = rememberHighlightEngine()
-val fallback = remember(code) { AnnotatedString(code) }
-val themedPair by produceState(fallback to fallback, code) {
+val engine     = rememberHighlightEngine()
+val lightTheme = rememberTomorrowTheme()
+val darkTheme  = rememberTomorrowNightTheme()
+val fallback   = remember(code) { AnnotatedString(code) }
+val themedPair by produceState(fallback to fallback, code, lightTheme, darkTheme) {
     engine.highlightBothThemes(
         code       = code,
         language   = "kotlin",

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -101,15 +101,24 @@ fun MyCodeBlock(code: String) {
 trigger another JS tokenization pass.
 
 ```kotlin
+import dev.hossain.highlight.engine.HighlightTheme
+
+// Outside Compose: use the non-@Composable factories on HighlightTheme.
 engine.highlightBothThemes(
     code       = sourceCode,
     language   = "typescript",
-    lightTheme = rememberTomorrowTheme(),
-    darkTheme  = rememberTomorrowNightTheme(),
+    lightTheme = HighlightTheme.tomorrow(),
+    darkTheme  = HighlightTheme.tomorrowNight(),
 ).onSuccess { result ->
     val display = if (isDark) result.dark else result.light
 }
 ```
+
+!!! note
+    Inside `@Composable` functions, prefer `rememberTomorrowTheme()` /
+    `rememberTomorrowNightTheme()` so the theme is remembered across recompositions.
+    The `HighlightTheme.tomorrow()` and `HighlightTheme.tomorrowNight()` factories above
+    are the non-composable equivalents - safe to call from a ViewModel or repository.
 
 ## Language lookup and auto-detection
 

--- a/docs/reference/highlight-language.md
+++ b/docs/reference/highlight-language.md
@@ -52,3 +52,87 @@ SyntaxHighlightedCode(
 - Passing extension with dot (`".kt"`) instead of `"kt"`.
 - Assuming the helper mirrors every upstream highlight.js alias at all times.
 - Forgetting a fallback path (`?: "plaintext"`) for unknown extensions.
+
+## Supported extensions
+
+The current extension-to-language map (source: [`HighlightLanguage.kt`](https://github.com/hossain-khan/android-compose-highlight/blob/main/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightLanguage.kt)).
+
+| Language | Extensions |
+|---|---|
+| `kotlin` | `kt`, `kts` |
+| `java` | `java` |
+| `python` | `py`, `pyw`, `pyi` |
+| `javascript` | `js`, `mjs`, `cjs`, `jsx` |
+| `typescript` | `ts`, `mts`, `cts`, `tsx` |
+| `c` | `c`, `h` |
+| `cpp` | `cpp`, `cc`, `cxx`, `hpp`, `hh` |
+| `csharp` | `cs` |
+| `rust` | `rs` |
+| `go` | `go` |
+| `swift` | `swift` |
+| `ruby` | `rb`, `rbw` |
+| `php` | `php`, `phtml` |
+| `scala` | `scala` |
+| `groovy` | `groovy` |
+| `gradle` | `gradle` |
+| `dart` | `dart` |
+| `elixir` | `ex`, `exs` |
+| `erlang` | `erl`, `hrl` |
+| `haskell` | `hs`, `lhs` |
+| `fsharp` | `fs`, `fsi`, `fsx` |
+| `ocaml` | `ml`, `mli` |
+| `clojure` | `clj`, `cljs`, `cljc` |
+| `lua` | `lua` |
+| `r` | `r` |
+| `objectivec` | `m`, `mm` |
+| `perl` | `pl`, `pm` |
+| `bash` | `sh`, `bash`, `zsh` |
+| `powershell` | `ps1`, `psm1`, `psd1` |
+| `sql` | `sql` |
+| `html` | `html`, `htm` |
+| `xml` | `xhtml`, `xml`, `svg`, `xsl` |
+| `css` | `css` |
+| `scss` | `scss` |
+| `less` | `less` |
+| `json` | `json`, `jsonc` |
+| `yaml` | `yaml`, `yml` |
+| `toml` | `toml` |
+| `markdown` | `md`, `markdown` |
+| `dockerfile` | `dockerfile` |
+| `makefile` | `makefile`, `mk` |
+| `latex` | `tex`, `latex` |
+| `diff` | `diff`, `patch` |
+| `ini` | `ini`, `cfg`, `conf` |
+| `properties` | `properties` |
+| `vim` | `vim` |
+| `cmake` | `cmake` |
+| `protobuf` | `proto` |
+| `glsl` | `glsl` |
+| `dos` | `bat`, `cmd` |
+| `x86asm` | `asm`, `s` |
+| `graphql` | `graphql`, `gql` |
+| `plaintext` | `txt` |
+| `julia` | `jl` |
+| `nim` | `nim`, `nims` |
+| `vbnet` | `vb` |
+| `vbscript` | `vbs` |
+| `coffeescript` | `coffee` |
+| `wasm` | `wat` |
+| `haml` | `haml` |
+| `handlebars` | `hbs`, `handlebars` |
+| `stylus` | `styl` |
+| `crystal` | `cr` |
+| `elm` | `elm` |
+| `haxe` | `hx` |
+| `scheme` | `scm`, `ss` |
+| `qml` | `qml` |
+| `d` | `d` |
+| `fortran` | `f`, `f90`, `f95`, `for` |
+| `awk` | `awk` |
+| `tcl` | `tcl`, `tk` |
+| `lisp` | `lisp`, `lsp` |
+| `applescript` | `applescript`, `scpt` |
+| `nix` | `nix` |
+| `nginx` | `nginx` |
+| `pgsql` | `pgsql` |
+| `prolog` | `pro` |

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -69,8 +69,8 @@ SyntaxHighlightedCode(
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 
 SyntaxHighlightedCode(
-    code                 = snippet,
-    language             = "json",
+    code          = snippet,
+    language      = "json",
     languageLabel = null,  // hide language badge
     copyButton    = null,  // hide copy button
 )

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -106,6 +106,31 @@ fun SqlEditor() {
 }
 ```
 
+### Customize the editor text style
+
+`SyntaxHighlightedTextEditorDefaults.DefaultTextStyle` is the pre-allocated singleton
+the editor uses by default (monospace family). Build on top of it with `.copy(...)`
+to override only what you need - using the singleton avoids allocating a fresh
+`TextStyle` on every recomposition while typing.
+
+```kotlin
+import dev.hossain.highlight.ui.SyntaxHighlightedTextEditorDefaults
+
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun LargerEditor() {
+    var editorValue by remember { mutableStateOf(TextFieldValue("")) }
+    val editorStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle.copy(fontSize = 15.sp)
+
+    SyntaxHighlightedTextEditor(
+        value         = editorValue,
+        onValueChange = { editorValue = it },
+        language      = "kotlin",
+        textStyle     = editorStyle,
+    )
+}
+```
+
 ## How the highlight pipeline behaves
 
 `SyntaxHighlightedTextEditor` delegates pipeline logic to
@@ -150,14 +175,19 @@ Use `rememberSyntaxHighlightedEditorValue()` when you want your own field compon
 (`OutlinedTextField`, third-party editor, etc.) and only need highlighted `TextFieldValue` output.
 
 ```kotlin
-val displayValue = rememberSyntaxHighlightedEditorValue(
-    value    = editorValue,
-    language = "kotlin",
-)
+@OptIn(ExperimentalHighlightApi::class)
+@Composable
+fun MyCustomEditor() {
+    var editorValue by remember { mutableStateOf(TextFieldValue("")) }
+    val displayValue = rememberSyntaxHighlightedEditorValue(
+        value    = editorValue,
+        language = "kotlin",
+    )
 
-OutlinedTextField(
-    value         = displayValue,
-    onValueChange = { editorValue = it },
-    label         = { Text("Code") },
-)
+    OutlinedTextField(
+        value         = displayValue,
+        onValueChange = { editorValue = it },
+        label         = { Text("Code") },
+    )
+}
 ```


### PR DESCRIPTION
## Summary
Audited every authored doc page under `/docs/` against the library source under `compose-highlight/src/main/kotlin/dev/hossain/highlight/`. Fixed every finding that would break a copy-pasted snippet, plus stale guidance and two coverage gaps.

### Broken / would not compile
- `guides/language-selection.md:42` linked to `../reference/highlight-language#supported-extensions` — that anchor didn't exist. Added a "Supported extensions" section to `reference/highlight-language.md` mirroring the actual `extensionMap` in `HighlightLanguage.kt`.
- `reference/syntax-highlighted-text-editor.md` — lower-level `rememberSyntaxHighlightedEditorValue` example was missing `@OptIn(ExperimentalHighlightApi::class)`; the function is annotated `@ExperimentalHighlightApi` (`RememberSyntaxHighlightedEditorValue.kt:98`).
- `guides/engine-only.md` — claimed `HighlightException.ThemeNotFound` was a reachable branch when calling `engine.highlight()`. `internal/EngineErrorHandling.kt:49-56` wraps theme resolution failures into `HtmlParseFailed` before they reach callers. Branch now annotated as unreachable (kept for exhaustiveness on the sealed class) and the note rewritten.
- `reference/highlight-engine.md` and `guides/performance.md` — `highlightBothThemes` ViewModel-shaped examples called `@Composable rememberTomorrowTheme()` / `rememberTomorrowNightTheme()` from non-composable scope. Switched to `HighlightTheme.tomorrow()` / `HighlightTheme.tomorrowNight()` (the non-composable factories on the companion).

### Stale / cosmetic
- `guides/theming.md` — `produceState` snippet referenced undeclared `lightTheme`/`darkTheme`. Now declares them via the `remember*` helpers and adds them as `produceState` keys so theme swaps re-trigger.
- `reference/syntax-highlighted-code.md` and `getting-started.md` — keyword-arg column alignment.

### Coverage gaps surfaced
- `guides/performance.md` — `HighlightTimings` table now links to its Dokka page.
- `guides/customization.md` — documents `SyntaxHighlightedCodeDefaults.LanguageLabel` for the runtime-toggle pattern.
- `reference/syntax-highlighted-text-editor.md` — documents `SyntaxHighlightedTextEditorDefaults.DefaultTextStyle` as the singleton to `.copy(...)` from for editor `textStyle` overrides.

## Test plan
- [ ] Merge → `Docs` workflow rebuilds & deploys.
- [ ] Visit `/guides/language-selection/`, click the "extension map" link → lands on the new "Supported extensions" section (no broken anchor).
- [ ] Spot-check the changed snippets render correctly on the live site.
- [ ] (Optional) Paste each updated `@OptIn`-tagged snippet into a scratch composable to verify it compiles against the published artifact.