### PR TITLE
docs: address Copilot review on #291 - remember + suspend wrappers

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -86,15 +86,18 @@ Tokenization is the slow part. Running it twice for light + dark wastes time. Us
 import dev.hossain.highlight.engine.HighlightTheme
 
 // Outside Compose: use the non-@Composable HighlightTheme.tomorrow* factories.
-val result = engine.highlightBothThemes(
-    code       = sourceCode,
-    language   = "kotlin",
-    lightTheme = HighlightTheme.tomorrow(),
-    darkTheme  = HighlightTheme.tomorrowNight(),
-)
-// Switch instantly at the call site - no re-highlighting needed
-result.onSuccess { themed ->
-    val annotated = if (isDark) themed.dark else themed.light
+// highlightBothThemes is a suspend fun, so call it from a coroutine.
+viewModelScope.launch {
+    val result = engine.highlightBothThemes(
+        code       = sourceCode,
+        language   = "kotlin",
+        lightTheme = HighlightTheme.tomorrow(),
+        darkTheme  = HighlightTheme.tomorrowNight(),
+    )
+    // Switch instantly at the call site - no re-highlighting needed
+    result.onSuccess { themed ->
+        val annotated = if (isDark) themed.dark else themed.light
+    }
 }
 ```
 

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -104,13 +104,16 @@ trigger another JS tokenization pass.
 import dev.hossain.highlight.engine.HighlightTheme
 
 // Outside Compose: use the non-@Composable factories on HighlightTheme.
-engine.highlightBothThemes(
-    code       = sourceCode,
-    language   = "typescript",
-    lightTheme = HighlightTheme.tomorrow(),
-    darkTheme  = HighlightTheme.tomorrowNight(),
-).onSuccess { result ->
-    val display = if (isDark) result.dark else result.light
+// highlightBothThemes is a suspend fun, so call it from a coroutine.
+viewModelScope.launch {
+    engine.highlightBothThemes(
+        code       = sourceCode,
+        language   = "typescript",
+        lightTheme = HighlightTheme.tomorrow(),
+        darkTheme  = HighlightTheme.tomorrowNight(),
+    ).onSuccess { result ->
+        val display = if (isDark) result.dark else result.light
+    }
 }
 ```
 

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -120,7 +120,12 @@ import dev.hossain.highlight.ui.SyntaxHighlightedTextEditorDefaults
 @Composable
 fun LargerEditor() {
     var editorValue by remember { mutableStateOf(TextFieldValue("")) }
-    val editorStyle = SyntaxHighlightedTextEditorDefaults.DefaultTextStyle.copy(fontSize = 15.sp)
+    // Wrap in remember so typing recompositions don't allocate a fresh TextStyle
+    // every frame. Add keys (e.g. remember(fontSize) { ... }) when the derived
+    // style depends on changing inputs.
+    val editorStyle = remember {
+        SyntaxHighlightedTextEditorDefaults.DefaultTextStyle.copy(fontSize = 15.sp)
+    }
 
     SyntaxHighlightedTextEditor(
         value         = editorValue,


### PR DESCRIPTION
## Summary
Three follow-ups to the [GitHub Copilot review on #291](https://github.com/hossain-khan/android-compose-highlight/pull/291#pullrequestreview-4435710643).

- **`reference/syntax-highlighted-text-editor.md`** — the `LargerEditor` snippet I added in #291 recommended using `DefaultTextStyle` to avoid per-recomposition allocations, then immediately allocated a fresh `TextStyle` via `.copy(...)` on every recompose. Wrapped the derived style in `remember { ... }` and added a comment noting when keys are needed.
- **`reference/highlight-engine.md`** & **`guides/performance.md`** — the outside-Compose `highlightBothThemes` snippets called the `suspend` function from a top-level (non-suspending) scope, so a copy-paste wouldn't compile. Wrapped both in `viewModelScope.launch { ... }` and added an inline note that the function is suspending.

## Test plan
- [ ] Merge → `Docs` workflow rebuilds & deploys.
- [ ] Visit the three changed pages on the live site, confirm the updated snippets render.
- [ ] (Optional) Paste each updated snippet into an Android project to confirm it compiles against `dev.hossain:compose-highlight:0.27.0`.