### PR TITLE
docs: pin literal version in install snippets, bump via release script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:<version>")
+    implementation("dev.hossain:compose-highlight:0.27.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,11 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:<version>")
+    implementation("dev.hossain:compose-highlight:0.27.0")
 }
 ```
 
-Replace `<version>` with the [latest release](https://github.com/hossain-khan/android-compose-highlight/releases).
+Check the [latest release](https://github.com/hossain-khan/android-compose-highlight/releases) or [Maven Central](https://central.sonatype.com/artifact/dev.hossain/compose-highlight) for newer versions.
 
 ---
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -8,6 +8,8 @@
 # Files updated:
 #   - gradle.properties        (VERSION_NAME)
 #   - README.md                (dependency snippet)
+#   - docs/index.md            (dependency snippet)
+#   - docs/getting-started.md  (dependency snippet)
 #   - sample/build.gradle.kts  (versionName, versionCode auto-incremented)
 #   - pyproject.toml           (version)
 #   - CHANGELOG.md             ([Unreleased] renamed to [<version>] - <date>)
@@ -55,6 +57,14 @@ echo "- gradle.properties updated"
 # 2. README.md
 sed -i '' "s/compose-highlight:$CURRENT_VERSION/compose-highlight:$NEW_VERSION/" "$REPO_ROOT/README.md"
 echo "- README.md updated"
+
+# 2b. docs/index.md
+sed -i '' "s/compose-highlight:$CURRENT_VERSION/compose-highlight:$NEW_VERSION/" "$REPO_ROOT/docs/index.md"
+echo "- docs/index.md updated"
+
+# 2c. docs/getting-started.md
+sed -i '' "s/compose-highlight:$CURRENT_VERSION/compose-highlight:$NEW_VERSION/" "$REPO_ROOT/docs/getting-started.md"
+echo "- docs/getting-started.md updated"
 
 # 3. sample/build.gradle.kts - versionName
 sed -i '' "s/versionName = \"$CURRENT_VERSION\"/versionName = \"$NEW_VERSION\"/" "$REPO_ROOT/sample/build.gradle.kts"


### PR DESCRIPTION
## Summary
Resolves audit item #15 (raised in [#291's audit](https://github.com/hossain-khan/android-compose-highlight/pull/291)) — the install snippets in `docs/index.md` and `docs/getting-started.md` used a `<version>` placeholder while `README.md` pinned the literal current version. This PR aligns docs with README (literal wins) and extends `scripts/prepare-release.sh` so the literal stays in sync on every release without an extra manual step.

### Changes
- **`docs/index.md`** — install snippet now shows `dev.hossain:compose-highlight:0.27.0`. Surrounding prose rewritten to point at both [Maven Central](https://central.sonatype.com/artifact/dev.hossain/compose-highlight) and the releases page rather than instructing the reader to substitute a placeholder.
- **`docs/getting-started.md`** — same install-snippet pin. The existing "Check Maven Central…" prose at line 13 already directs readers to newer versions, no prose change needed.
- **`scripts/prepare-release.sh`** — added two `sed -i ''` lines that bump `compose-highlight:$CURRENT_VERSION` → `compose-highlight:$NEW_VERSION` in `docs/index.md` and `docs/getting-started.md`, mirroring the existing `README.md` step. Header comment updated to list the two new files.

### Why this approach
- Placeholder forced every reader to click out before they could copy-paste. Literal removes that step.
- The release flow already has a single command (`./scripts/prepare-release.sh <version>`) that bumps every version site atomically. Extending it costs two `sed` lines and zero CI churn — vs. templating, which would need a Zensical-aware build step.
- The sed pattern matches `compose-highlight:$CURRENT_VERSION`, which only appears in install snippets — `docs/changelog.md` history is left alone (verified below).

### Dry-run validation
```
$ ./scripts/prepare-release.sh 0.27.99
Bumping 0.27.0 -> 0.27.99 (date: 2026-06-05)
- gradle.properties updated
- README.md updated
- docs/index.md updated
- docs/getting-started.md updated
- sample/build.gradle.kts versionName updated
- sample/build.gradle.kts versionCode: 32 -> 33
- CHANGELOG.md [Unreleased] -> [0.27.99] - 2026-06-05
- pyproject.toml version updated

$ git diff --stat
 CHANGELOG.md               |  2 ++
 README.md                  |  2 +-
 docs/getting-started.md    |  2 +-
 docs/index.md              |  4 ++--
 gradle.properties          |  2 +-
 pyproject.toml             |  2 +-
 sample/build.gradle.kts    |  4 ++--
```
`docs/changelog.md` had no diff — confirming the sed scope is correct.

## Test plan
- [ ] Merge → `Docs` workflow rebuilds & deploys.
- [ ] Visit `/` and `/getting-started/` on the live site, confirm the snippet shows `0.27.0`.
- [ ] On the next release, run `./scripts/prepare-release.sh <new-version>` as usual; verify the diff includes both doc files alongside `README.md`.