### PR TITLE
docs: update KDoc for CopyButton to reflect vector icon usage

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
@@ -105,9 +105,10 @@ object SyntaxHighlightedCodeDefaults {
     /**
      * Default copy-to-clipboard button used by [SyntaxHighlightedCode]'s `copyButton` slot.
      *
-     * Renders a simple `⧉` text icon inside an [IconButton]. Tint and size default to values
-     * that blend naturally with the code block background when placed inside a
-     * [SyntaxHighlightedCode] block.
+     * Renders a vector copy icon inside an [IconButton]. The icon size scales proportionally
+     * to the button [size] (60 % of the touch target) so that callers who customize the button
+     * size get a matching icon automatically. Tint and size default to values that blend naturally
+     * with the code block background when placed inside a [SyntaxHighlightedCode] block.
      *
      * Pass to `copyButton` to retain the default look while customising other parameters:
      *

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -31,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -261,14 +263,23 @@ private fun LanguageChip(
                     color = if (isCopied) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
         )
-        Text(
-            text = if (isCopied) "✓" else "⧉",
-            modifier = Modifier.width(18.dp),
-            style =
-                TextStyle(
-                    fontSize = 14.sp,
-                    color = if (isCopied) MaterialTheme.colorScheme.primary else LocalContentColor.current.copy(alpha = 0.4f),
-                ),
-        )
+        if (isCopied) {
+            Text(
+                text = "✓",
+                modifier = Modifier.width(18.dp),
+                style =
+                    TextStyle(
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.primary,
+                    ),
+            )
+        } else {
+            Icon(
+                painter = painterResource(R.drawable.copy_content_alt_rounded),
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = LocalContentColor.current.copy(alpha = 0.4f),
+            )
+        }
     }
 }

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -264,14 +264,11 @@ private fun LanguageChip(
                 ),
         )
         if (isCopied) {
-            Text(
-                text = "✓",
-                modifier = Modifier.width(18.dp),
-                style =
-                    TextStyle(
-                        fontSize = 14.sp,
-                        color = MaterialTheme.colorScheme.primary,
-                    ),
+            Icon(
+                painter = painterResource(R.drawable.check_24dp),
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = MaterialTheme.colorScheme.primary,
             )
         } else {
             Icon(

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -14,12 +14,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -186,28 +188,38 @@ private fun LanguageSearchAndList(
 
     SubSectionHeader("Tap to copy language identifier")
 
-    OutlinedTextField(
-        value = query,
-        onValueChange = { query = it },
-        modifier = Modifier.fillMaxWidth(),
-        placeholder = { Text("Filter ${languages.size} languages…") },
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.search_24dp),
-                contentDescription = null,
-            )
-        },
-        trailingIcon = {
-            if (query.isNotEmpty()) {
-                Text(
-                    text = "✕",
-                    modifier = Modifier.clickable { query = "" }.padding(8.dp),
-                    style = TextStyle(fontSize = 16.sp, color = LocalContentColor.current.copy(alpha = 0.6f)),
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        TextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("Filter ${languages.size} languages…") },
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.search_24dp),
+                    contentDescription = null,
                 )
-            }
-        },
-        singleLine = true,
-    )
+            },
+            trailingIcon = {
+                if (query.isNotEmpty()) {
+                    Text(
+                        text = "✕",
+                        modifier = Modifier.clickable { query = "" }.padding(8.dp),
+                        style = TextStyle(fontSize = 16.sp, color = LocalContentColor.current.copy(alpha = 0.6f)),
+                    )
+                }
+            },
+            singleLine = true,
+            colors =
+                TextFieldDefaults.colors(
+                    focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                    unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                    disabledIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                    focusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                    unfocusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                ),
+        )
+    }
 
     OutlinedCard(modifier = Modifier.fillMaxWidth().height(360.dp)) {
         if (filtered.isEmpty() && query.isNotBlank()) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/EngineInfoSection.kt
@@ -279,14 +279,14 @@ private fun LanguageChip(
             Icon(
                 painter = painterResource(R.drawable.check_24dp),
                 contentDescription = null,
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(18.dp),
                 tint = MaterialTheme.colorScheme.primary,
             )
         } else {
             Icon(
                 painter = painterResource(R.drawable.copy_content_alt_rounded),
                 contentDescription = null,
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(18.dp),
                 tint = LocalContentColor.current.copy(alpha = 0.4f),
             )
         }

--- a/sample/src/main/res/drawable/check_24dp.xml
+++ b/sample/src/main/res/drawable/check_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M382,720 L154,492l57,-57 171,171 367,-367 57,57 -424,424Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
### Changed

- Updated `SyntaxHighlightedCodeDefaults.CopyButton` KDoc to describe the vector copy icon instead of the old `⧉` text character
- Clarified that the icon size scales proportionally (60% of button size) for callers who customize the touch target