### PR TITLE
chore: prepare release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-06
+
 ### Changed
 
 - **Default copy icon replaced with vector drawable** - `SyntaxHighlightedCodeDefaults.CopyButton`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Jetpack Compose library for beautiful syntax highlighting - powered by [Highli
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.27.0")
+    implementation("dev.hossain:compose-highlight:0.28.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.28.0 - Vector copy icon and sample app polish
+
+- Default copy icon replaced with vector drawable (`copy_code_block.xml`) with proportional scaling
+- Info banner added to sample app Languages tab with library version and "Open Docs" button
+- `LIB_VERSION_NAME` build config field keeps displayed version in sync with published artifact
+- `EngineInfoSection` search box outline now matches other info cards, language chips use vector icons
+- KDoc updated for `CopyButton` to describe vector icon behavior
+
 ### 0.27.0 - Editor keyboard options and cursor brush
 
 - `SyntaxHighlightedTextEditor` now defaults to code-friendly `keyboardOptions` (autocorrect off, Ascii keyboard)
@@ -36,13 +44,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - Added `onHighlightComplete` callback to `SyntaxHighlightedTextEditor` for deterministic testing
 - New public helper `rememberSyntaxHighlightedEditorValue()` for custom editor layouts with syntax highlighting
 - Eliminated stale `LaunchedEffect` for span clearing; stale detection now happens in-composition
-
-### 0.24.0 - Live code editor support
-
-- New `SyntaxHighlightedTextEditor` composable with live syntax highlighting as you type
-- 150 ms keystroke debounce with cursor and selection always preserved
-- New **Live Editor** demo tab in sample app showcasing 6 languages
-- Marked `@ExperimentalHighlightApi` for gradual API stabilization
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.27.0")
+    implementation("dev.hossain:compose-highlight:0.28.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.27.0")
+    implementation("dev.hossain:compose-highlight:0.28.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.27.0
+VERSION_NAME=0.28.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 32
-        versionName = "0.27.0"
+        versionCode = 33
+        versionName = "0.28.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
### 0.28.0 - 2026-06-06

### Changed

- Default copy icon replaced with vector drawable (`copy_code_block.xml`) with proportional scaling (60% of touch target)

### Added

- Info banner in sample app Languages tab with library version (`BuildConfig.LIB_VERSION_NAME`) and "Open Docs" button
- `LIB_VERSION_NAME` build config field keeps displayed version in sync with published artifact

### Sample app

- `TogglesSection` updated with `copy_content_alt_rounded` icon and large 56.dp demo
- `EngineInfoSection` search box outline now matches other info cards, language chips use vector icons at 18.dp

### Docs

- KDoc updated for `CopyButton` to describe vector icon behavior
- `docs/changelog.md` updated with 0.28.0 highlights