### PR TITLE
feat: implement static WebView warm-up API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Static WebView warm-up method** - Added `HighlightEngine.warmUp(context)` companion function to allow pre-warming
+  the background WebView and JS engine. This eliminates the cold-start WebView latency (150-800ms) on the first
+  highlight rendering. It is safe to call from any thread (e.g., inside `Application.onCreate`).
+
 ## [0.28.0] - 2026-06-06
 
 ### Changed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -772,6 +772,24 @@ class HighlightEngine(
             }
         }
     }
+
+    companion object {
+        /**
+         * Pre-warms the hidden WebView and starts loading the bridge page.
+         *
+         * Call this method early in your application lifecycle (e.g., in [android.app.Application.onCreate]
+         * or your main Activity's `onCreate`) to eliminate the cold-start WebView latency (which
+         * can take 150-800ms) when the first code highlighting is rendered.
+         *
+         * Safe to call from any thread - it automatically posts to the Main thread if needed.
+         *
+         * @param context Any [Context]; normalized to `applicationContext` internally.
+         */
+        @JvmStatic
+        fun warmUp(context: Context) {
+            WebViewManager.warmUp(context)
+        }
+    }
 }
 
 /**

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/WebViewManager.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/WebViewManager.kt
@@ -146,6 +146,28 @@ internal class WebViewManager(
         withContext(Dispatchers.Main) {
             if (webView != null) return@withContext
 
+            // Check if there is a pre-warmed WebView to consume.
+            // Under Dispatchers.Main, so we have exclusive serialized access to these variables.
+            val preWarmed = preWarmedWebView
+            val preWarmedDef = preWarmedDeferred
+            if (preWarmed != null && preWarmedDef != null) {
+                webView = preWarmed
+                readyDeferred = preWarmedDef
+                preWarmedWebView = null
+                preWarmedDeferred = null
+
+                if (readyDeferred.isCompleted) {
+                    _isInitialized.value = true
+                } else {
+                    readyDeferred.invokeOnCompletion { throwable ->
+                        if (throwable == null && !readyDeferred.isCancelled) {
+                            _isInitialized.value = true
+                        }
+                    }
+                }
+                return@withContext
+            }
+
             // Reset the deferred so re-initialization after destroy works correctly.
             // Capture as a local so the WebViewClient closure always completes *this* deferred.
             if (readyDeferred.isCompleted) {
@@ -215,5 +237,72 @@ internal class WebViewManager(
         readyDeferred = CompletableDeferred()
         // WebView.destroy() must be called on the thread that created it (Main).
         Handler(Looper.getMainLooper()).post { wv.destroy() }
+    }
+
+    companion object {
+        @Volatile
+        private var preWarmedWebView: WebView? = null
+
+        @Volatile
+        private var preWarmedDeferred: CompletableDeferred<WebView>? = null
+
+        /**
+         * Pre-warms the WebView and starts loading the bridge page.
+         * Safe to call from any thread - redirects to Main thread.
+         */
+        fun warmUp(context: Context) {
+            val mainLooper = Looper.getMainLooper()
+            if (Looper.myLooper() == mainLooper) {
+                warmUpInternal(context)
+            } else {
+                Handler(mainLooper).post {
+                    warmUpInternal(context)
+                }
+            }
+        }
+
+        private fun warmUpInternal(context: Context) {
+            if (preWarmedWebView != null) return
+
+            val appContext = context.applicationContext
+            val deferred = CompletableDeferred<WebView>()
+            preWarmedDeferred = deferred
+
+            val assetLoader =
+                WebViewAssetLoader
+                    .Builder()
+                    .setDomain("appassets.androidplatform.net")
+                    .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(appContext))
+                    .build()
+
+            val view =
+                try {
+                    WebView(appContext).apply {
+                        settings.javaScriptEnabled = true
+                        webViewClient =
+                            object : WebViewClient() {
+                                override fun shouldInterceptRequest(
+                                    view: WebView,
+                                    request: WebResourceRequest,
+                                ): WebResourceResponse? = assetLoader.shouldInterceptRequest(request.url)
+
+                                override fun onPageFinished(
+                                    view: WebView,
+                                    url: String,
+                                ) {
+                                    if (!deferred.isCompleted) {
+                                        deferred.complete(view)
+                                    }
+                                }
+                            }
+                        loadUrl("https://appassets.androidplatform.net/assets/compose-highlight/bridge.html")
+                    }
+                } catch (e: Exception) {
+                    deferred.completeExceptionally(HighlightException.WebViewInitFailed(e))
+                    null
+                }
+
+            preWarmedWebView = view
+        }
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/internal/WebViewManagerThreadingTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/internal/WebViewManagerThreadingTest.kt
@@ -165,4 +165,55 @@ class WebViewManagerThreadingTest {
             awaiterScope.cancel()
             manager.destroy()
         }
+
+    @Test
+    fun `warmUp creates prewarmed WebView and initialize consumes it`() =
+        runTest {
+            // Call warmUp (will post/run on main thread)
+            WebViewManager.warmUp(context)
+            ShadowLooper.idleMainLooper()
+
+            // Initialize a WebViewManager - it should consume the pre-warmed WebView
+            val manager = WebViewManager(context)
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+
+            val webView = manager.webViewForTest()
+            assertThat(webView).isNotNull()
+
+            val shadowWebView = Shadows.shadowOf(webView)
+            assertThat(shadowWebView.lastLoadedUrl).isEqualTo("https://appassets.androidplatform.net/assets/compose-highlight/bridge.html")
+
+            // Destroy and reinitialize without warmUp should yield a different WebView instance
+            val firstWv = webView
+            manager.destroy()
+            ShadowLooper.idleMainLooper()
+
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+            val secondWv = manager.webViewForTest()
+            assertThat(secondWv).isNotSameInstanceAs(firstWv)
+
+            manager.destroy()
+        }
+
+    @Test
+    fun `warmUp called from background thread posts to main thread and succeeds`() =
+        runTest {
+            val job =
+                launch(Dispatchers.Default) {
+                    WebViewManager.warmUp(context)
+                }
+            job.join()
+            ShadowLooper.idleMainLooper()
+
+            val manager = WebViewManager(context)
+            manager.initialize()
+            ShadowLooper.idleMainLooper()
+
+            val webView = manager.webViewForTest()
+            assertThat(webView).isNotNull()
+
+            manager.destroy()
+        }
 }


### PR DESCRIPTION
Exposes a static `HighlightEngine.warmUp(context)` method to allow pre-warming the hidden WebView in `Application.onCreate()` or a launcher activity to eliminate the cold-start WebView latency.