### PR TITLE
docs: add Jsoup baseline HTML parser benchmark data

### DIFF
--- a/resources/html-parser-benchmarks/README.md
+++ b/resources/html-parser-benchmarks/README.md
@@ -31,7 +31,7 @@ Six real-world highlight.js HTML outputs under
 `compose-highlight/src/test/resources/highlight-fixtures/`:
 
 | Fixture | Size |
-|---------|------|
+| --- | --- |
 | real-c.html | 76 KB |
 | real-rust.html | 63 KB |
 | real-kotlin.html | 57 KB |
@@ -41,47 +41,58 @@ Six real-world highlight.js HTML outputs under
 
 ## Reports
 
+### jsoup-baseline-run{1,2,3}.json
+
+**Date:** 2026-06-13
+**Parser:** Jsoup-based HTML parser (pre-custom parser).
+This was the original implementation that parsed the HTML using Jsoup's complete DOM tree
+and walked all nodes.
+
 ### baseline-pre-sax-optimization.json
 
 **Date:** 2026-06-13
-**Parser:** Two-phase pipeline - `parseHtml()` builds intermediate `CustomNode` tree,
-then `walkNode()` traverses the tree to build `AnnotatedString`.
-
-This is the baseline before the SAX-style optimization.
+**Parser:** Two-phase custom parser pipeline.
+`parseHtml()` builds an intermediate `CustomNode` tree, then `walkNode()` traverses the tree
+to build `AnnotatedString`.
 
 ### sax-optimized-run{1,2,3}.json
 
 **Date:** 2026-06-13
-**Parser:** SAX-style single-pass - `parseAndBuild()`/`parseAndBuildBoth()` parse HTML
-and build `AnnotatedString` simultaneously, eliminating the intermediate tree. Also
-includes substring avoidance, in-place attribute extraction, lazy entity decoding,
-and allocation-free numeric parsing.
+**Parser:** SAX-style single-pass custom parser.
+`parseAndBuild()`/`parseAndBuildBoth()` parse HTML and build `AnnotatedString` simultaneously,
+eliminating the intermediate tree. Also includes substring avoidance, in-place attribute
+extraction, lazy entity decoding, and allocation-free numeric parsing.
 
-Three consecutive runs to verify stability.
+Three consecutive runs are saved for both Jsoup and SAX-optimized versions to verify stability.
 
-### Summary comparison (best of 3 optimized runs vs baseline)
+## Three-Way Comparison (best of 3 runs vs baseline)
 
-| Benchmark | Baseline (us) | Optimized (us) | Improvement |
-|-----------|--------------|----------------|-------------|
-| convertKotlin | 419.64 | 178.91 | **-57%** |
-| convertGo | 205.22 | 94.21 | **-54%** |
-| convertRust | 353.91 | 192.67 | **-46%** |
-| convertCsharp | 42.92 | 23.02 | **-46%** |
-| convertSql | 160.04 | 104.68 | **-35%** |
-| convertC | 496.30 | 354.64 | **-29%** |
-| convertBothSql | 417.96 | 254.90 | **-39%** |
-| convertBothC | 504.26 | 331.89 | **-34%** |
-| convertBothGo | 223.12 | 151.85 | **-32%** |
-| convertBothCsharp | 60.98 | 42.00 | **-31%** |
-| convertBothRust | 211.98 | 159.74 | **-25%** |
-| convertBothKotlin | 294.72 | 278.72 | **-5%** |
+All values are in microseconds (us). Lower is better.
+
+| Benchmark | Jsoup (us) | Custom (us) | SAX (us) | Jsoup->SAX | Custom->SAX |
+| --- | --- | --- | --- | --- | --- |
+| convertBothC | 897.86 | 504.26 | 324.91 | **-63.8%** | **-35.6%** |
+| convertBothCsharp | 168.59 | 60.98 | 42.00 | **-75.1%** | **-31.1%** |
+| convertBothGo | 410.82 | 223.12 | 147.63 | **-64.1%** | **-33.8%** |
+| convertBothKotlin | 600.56 | 294.72 | 278.72 | **-53.6%** | **-5.4%** |
+| convertBothRust | 235.50 | 211.98 | 159.74 | **-32.2%** | **-24.6%** |
+| convertBothSql | 996.30 | 417.96 | 254.90 | **-74.4%** | **-39.0%** |
+| convertC | 1381.68 | 496.30 | 354.64 | **-74.3%** | **-28.5%** |
+| convertCsharp | 80.98 | 42.92 | 20.92 | **-74.2%** | **-51.3%** |
+| convertGo | 581.30 | 205.22 | 94.21 | **-83.8%** | **-54.1%** |
+| convertKotlin | 420.75 | 419.64 | 178.91 | **-57.5%** | **-57.4%** |
+| convertRust | 346.67 | 353.91 | 192.67 | **-44.4%** | **-45.6%** |
+| convertSql | 257.85 | 160.04 | 92.62 | **-64.1%** | **-42.1%** |
 
 ## Diffing reports
 
-Use `jq` to compare two reports side-by-side:
+Use `jq` to compare reports side-by-side:
 
 ```bash
 # Extract mean times as a sorted table
+jq -r '.benchmarks | sort_by(.name) | .[] | "\(.name)\t\(.meanUs)"' \
+  resources/html-parser-benchmarks/jsoup-baseline-run1.json
+
 jq -r '.benchmarks | sort_by(.name) | .[] | "\(.name)\t\(.meanUs)"' \
   resources/html-parser-benchmarks/baseline-pre-sax-optimization.json
 

--- a/resources/html-parser-benchmarks/jsoup-baseline-run1.json
+++ b/resources/html-parser-benchmarks/jsoup-baseline-run1.json
@@ -1,0 +1,20 @@
+{
+  "reportTimestamp": 1781389753663,
+  "timeUnit": "microseconds",
+  "warmupIterations": 100,
+  "measurementIterations": 50,
+  "benchmarks": [
+    {"name":"convertBothSql","warmupIterations":100,"measurementIterations":50,"meanUs":996.297,"stddevUs":201.424,"minUs":851.125,"maxUs":2271.584},
+    {"name":"convertRust","warmupIterations":100,"measurementIterations":50,"meanUs":346.670,"stddevUs":15.522,"minUs":311.125,"maxUs":405.250},
+    {"name":"convertC","warmupIterations":100,"measurementIterations":50,"meanUs":1407.892,"stddevUs":74.305,"minUs":1324.667,"maxUs":1692.000},
+    {"name":"convertGo","warmupIterations":100,"measurementIterations":50,"meanUs":581.305,"stddevUs":9.336,"minUs":567.667,"maxUs":612.292},
+    {"name":"convertBothRust","warmupIterations":100,"measurementIterations":50,"meanUs":235.495,"stddevUs":147.754,"minUs":207.875,"maxUs":1268.709},
+    {"name":"convertBothCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":169.634,"stddevUs":2.579,"minUs":165.708,"maxUs":175.708},
+    {"name":"convertBothKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":600.557,"stddevUs":35.595,"minUs":551.834,"maxUs":704.833},
+    {"name":"convertBothC","warmupIterations":100,"measurementIterations":50,"meanUs":897.858,"stddevUs":26.453,"minUs":862.500,"maxUs":939.750},
+    {"name":"convertBothGo","warmupIterations":100,"measurementIterations":50,"meanUs":421.014,"stddevUs":9.906,"minUs":413.375,"maxUs":459.834},
+    {"name":"convertCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":83.903,"stddevUs":1.213,"minUs":82.459,"maxUs":89.833},
+    {"name":"convertKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":431.351,"stddevUs":9.014,"minUs":422.833,"maxUs":475.166},
+    {"name":"convertSql","warmupIterations":100,"measurementIterations":50,"meanUs":299.889,"stddevUs":77.408,"minUs":254.250,"maxUs":786.292}
+  ]
+}

--- a/resources/html-parser-benchmarks/jsoup-baseline-run2.json
+++ b/resources/html-parser-benchmarks/jsoup-baseline-run2.json
@@ -1,0 +1,20 @@
+{
+  "reportTimestamp": 1781389807206,
+  "timeUnit": "microseconds",
+  "warmupIterations": 100,
+  "measurementIterations": 50,
+  "benchmarks": [
+    {"name":"convertBothSql","warmupIterations":100,"measurementIterations":50,"meanUs":1065.762,"stddevUs":256.995,"minUs":819.166,"maxUs":2454.792},
+    {"name":"convertRust","warmupIterations":100,"measurementIterations":50,"meanUs":350.609,"stddevUs":20.091,"minUs":281.042,"maxUs":391.000},
+    {"name":"convertC","warmupIterations":100,"measurementIterations":50,"meanUs":1381.678,"stddevUs":37.935,"minUs":1329.167,"maxUs":1510.208},
+    {"name":"convertGo","warmupIterations":100,"measurementIterations":50,"meanUs":592.100,"stddevUs":28.236,"minUs":568.458,"maxUs":712.042},
+    {"name":"convertBothRust","warmupIterations":100,"measurementIterations":50,"meanUs":239.024,"stddevUs":166.119,"minUs":203.375,"maxUs":1399.167},
+    {"name":"convertBothCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":175.383,"stddevUs":5.166,"minUs":170.208,"maxUs":201.458},
+    {"name":"convertBothKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":635.946,"stddevUs":13.879,"minUs":617.750,"maxUs":676.041},
+    {"name":"convertBothC","warmupIterations":100,"measurementIterations":50,"meanUs":935.350,"stddevUs":17.909,"minUs":906.834,"maxUs":977.667},
+    {"name":"convertBothGo","warmupIterations":100,"measurementIterations":50,"meanUs":410.820,"stddevUs":12.306,"minUs":402.958,"maxUs":473.584},
+    {"name":"convertCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":80.985,"stddevUs":0.971,"minUs":79.541,"maxUs":83.750},
+    {"name":"convertKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":420.753,"stddevUs":3.418,"minUs":414.625,"maxUs":429.584},
+    {"name":"convertSql","warmupIterations":100,"measurementIterations":50,"meanUs":257.853,"stddevUs":7.863,"minUs":251.459,"maxUs":289.250}
+  ]
+}

--- a/resources/html-parser-benchmarks/jsoup-baseline-run3.json
+++ b/resources/html-parser-benchmarks/jsoup-baseline-run3.json
@@ -1,0 +1,20 @@
+{
+  "reportTimestamp": 1781389854638,
+  "timeUnit": "microseconds",
+  "warmupIterations": 100,
+  "measurementIterations": 50,
+  "benchmarks": [
+    {"name":"convertBothSql","warmupIterations":100,"measurementIterations":50,"meanUs":1013.794,"stddevUs":226.839,"minUs":842.792,"maxUs":2455.542},
+    {"name":"convertRust","warmupIterations":100,"measurementIterations":50,"meanUs":433.788,"stddevUs":18.628,"minUs":375.083,"maxUs":486.792},
+    {"name":"convertC","warmupIterations":100,"measurementIterations":50,"meanUs":1487.583,"stddevUs":35.472,"minUs":1441.125,"maxUs":1613.625},
+    {"name":"convertGo","warmupIterations":100,"measurementIterations":50,"meanUs":635.091,"stddevUs":14.004,"minUs":617.458,"maxUs":703.000},
+    {"name":"convertBothRust","warmupIterations":100,"measurementIterations":50,"meanUs":312.823,"stddevUs":143.898,"minUs":282.625,"maxUs":1317.959},
+    {"name":"convertBothCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":168.592,"stddevUs":7.248,"minUs":160.375,"maxUs":191.917},
+    {"name":"convertBothKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":646.603,"stddevUs":20.185,"minUs":623.917,"maxUs":700.167},
+    {"name":"convertBothC","warmupIterations":100,"measurementIterations":50,"meanUs":1073.309,"stddevUs":14.709,"minUs":1060.417,"maxUs":1136.583},
+    {"name":"convertBothGo","warmupIterations":100,"measurementIterations":50,"meanUs":493.785,"stddevUs":13.645,"minUs":486.041,"maxUs":580.209},
+    {"name":"convertCsharp","warmupIterations":100,"measurementIterations":50,"meanUs":100.145,"stddevUs":1.987,"minUs":98.667,"maxUs":110.458},
+    {"name":"convertKotlin","warmupIterations":100,"measurementIterations":50,"meanUs":551.542,"stddevUs":82.903,"minUs":506.958,"maxUs":1129.625},
+    {"name":"convertSql","warmupIterations":100,"measurementIterations":50,"meanUs":323.768,"stddevUs":43.022,"minUs":308.792,"maxUs":619.417}
+  ]
+}


### PR DESCRIPTION
Adds the Jsoup baseline HTML parser benchmark data (pre-custom parser) to the resources directory, along with a three-way comparison table in the README comparing Jsoup vs Custom Parser vs SAX-Optimized parser implementations.