### PR TITLE
fix: support JSON backspace and form feed escapes

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/JsStringEscape.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/JsStringEscape.kt
@@ -7,7 +7,7 @@ package dev.hossain.highlight.engine.internal
  * including cases like `\\n` (JSON for a literal backslash followed by 'n') that sequential
  * [String.replace] calls cannot handle correctly (the `\\` and `\n` replacements interfere).
  *
- * Supported escape sequences: `\"`, `\\`, `\/`, `\n`, `\r`, `\t`, `\uXXXX`.
+ * Supported escape sequences: `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, `\uXXXX`.
  *
  * UTF-16 surrogate pairs (two consecutive `\uXXXX` sequences where the first is a high surrogate
  * U+D800-U+DBFF and the second is a low surrogate U+DC00-U+DFFF) are combined into a single
@@ -40,6 +40,16 @@ internal fun unescapeJsString(jsonString: String): String {
 
                 '/' -> {
                     sb.append('/')
+                    i += 2
+                }
+
+                'b' -> {
+                    sb.append('\b')
+                    i += 2
+                }
+
+                'f' -> {
+                    sb.append('\u000C')
                     i += 2
                 }
 

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightEngineUnescapeTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightEngineUnescapeTest.kt
@@ -62,6 +62,21 @@ class HighlightEngineUnescapeTest {
     }
 
     @Test
+    fun `backslash-b is unescaped to backspace`() {
+        assertThat(unescapeJsString("\"a\\bb\"")).isEqualTo("a\u0008b")
+    }
+
+    @Test
+    fun `backslash-f is unescaped to form feed`() {
+        assertThat(unescapeJsString("\"a\\fb\"")).isEqualTo("a\u000Cb")
+    }
+
+    @Test
+    fun `backspace and form feed in one string are both unescaped`() {
+        assertThat(unescapeJsString("\"\\b\\f\"")).isEqualTo("\u0008\u000C")
+    }
+
+    @Test
     fun `unicode escape u003C decodes to less-than`() {
         assertThat(unescapeJsString("\"\\u003C\"")).isEqualTo("<")
     }


### PR DESCRIPTION
## What changed

- Added `\b` and `\f` handling to `unescapeJsString`.
- Added regression tests for each escape and a combined escape case.

## Why

`evaluateJavascript()` returns standard JSON escape sequences, and `unescapeJsString` previously left `\b` and `\f` as literal text instead of decoding them to backspace and form feed.

## Validation

- `./gradlew formatKotlin`
- `./gradlew :compose-highlight:assembleDebug`
- `./gradlew :sample:assembleDebug`
- `./gradlew :compose-highlight:test`
