### PR TITLE
fix: parse CSS 8-digit hex colors in RRGGBBAA order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed 8-digit CSS hex color parsing order** - `ThemeParser` now interprets `#RRGGBBAA`
+  as specified by CSS Color Module Level 4, instead of the Android-style `#AARRGGBB`
+  order. Fixes #321.
+
 ## [0.30.2] - 2026-06-13
 
 ### Removed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
@@ -516,10 +516,10 @@ internal object ThemeParser {
 
                 8 -> {
                     Color(
-                        red = cleaned.substring(2, 4).toInt(16),
-                        green = cleaned.substring(4, 6).toInt(16),
-                        blue = cleaned.substring(6, 8).toInt(16),
-                        alpha = cleaned.substring(0, 2).toInt(16),
+                        red = cleaned.substring(0, 2).toInt(16),
+                        green = cleaned.substring(2, 4).toInt(16),
+                        blue = cleaned.substring(4, 6).toInt(16),
+                        alpha = cleaned.substring(6, 8).toInt(16),
                     )
                 }
 

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
  * JVM unit tests for [ThemeParser.parse] using inline CSS strings (no Android context required).
  *
  * These tests cover the core parsing logic and edge cases:
- * - Basic hex color parsing (`#rrggbb`, 3-digit `#rgb`, 4-digit `#rgba`, 8-digit `#aarrggbb`)
+ * - Basic hex color parsing (`#rrggbb`, 3-digit `#rgb`, 4-digit `#rgba`, 8-digit `#rrggbbaa`)
  * - `rgb()` and `rgba()` color values including decimal alpha (e.g. `rgba(149,165,166,.8)`)
  * - CSS named colors (e.g. `color: red`)
  * - `font-weight: bold` / `700` and `font-style: italic`
@@ -246,11 +246,13 @@ class ThemeParserTest {
 
     @Test
     fun `parse handles 8-digit hex color`() {
-        // 8-digit hex: first two digits are alpha (AARRGGBB), rest are RGB
-        val css = ".hljs-comment { color: #ff8e908c }"
+        // CSS 8-digit hex uses #RRGGBBAA order.
+        // #ff000080 = red 255, green 0, blue 0, alpha 128.
+        val css = ".hljs-comment { color: #ff000080 }"
         val result = ThemeParser.parse(css)
         val style = result[HljsSelectors.COMMENT]
         assertThat(style).isNotNull()
+        assertThat(style!!.color).isEqualTo(Color(255, 0, 0, 128))
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Fixed 8-digit hex parsing in `ThemeParser` to follow CSS Color Module Level 4 `#RRGGBBAA` order.
- Updated the unit test to assert the actual parsed color value for an 8-digit CSS hex example.
- Kept existing 3-digit and 6-digit hex behavior unchanged.

## Why

The parser was reading 8-digit CSS hex colors as Android-style `#AARRGGBB`, which produced the wrong channels and alpha for valid CSS theme colors.

Fixes #321

## Validation

- `./gradlew formatKotlin`
- `./gradlew :compose-highlight:test`
