### PR TITLE
fix: extend ThemeParser CSS declaration handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - **Fixed live editor state reset on rotation in sample app** - `LiveEditorSection` now uses
   `rememberSaveable` with `TextFieldValue.Saver`, so typed content survives configuration
   changes and stays scoped to the selected language. Fixes #325.
+- **Fixed ThemeParser handling of `!important`, relative font weights, and oblique** -
+  declarations with `!important` are now parsed correctly, `bolder`/`lighter` map to
+  bold/normal weight, and `font-style: oblique` is treated as italic. Fixes #326.
 
 ## [0.30.2] - 2026-06-13
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
@@ -415,7 +415,11 @@ internal object ThemeParser {
 
         PROP_PATTERN.findAll(declarations).forEach { match ->
             val prop = match.groupValues[1].trim()
-            val value = match.groupValues[2].trim()
+            val value =
+                match.groupValues[2]
+                    .trim()
+                    .removeSuffix("!important")
+                    .trim()
             when (prop) {
                 "color" -> {
                     color = parseColor(value)
@@ -428,13 +432,18 @@ internal object ThemeParser {
                 "font-weight" -> {
                     val numericWeight = value.toIntOrNull()
                     when {
-                        value == "bold" || (numericWeight != null && numericWeight >= 600) -> fontWeight = FontWeight.Bold
-                        value == "normal" || (numericWeight != null && numericWeight < 600) -> fontWeight = FontWeight.Normal
+                        value == "bold" || value == "bolder" || (numericWeight != null && numericWeight >= 600) -> {
+                            fontWeight = FontWeight.Bold
+                        }
+
+                        value == "normal" || value == "lighter" || (numericWeight != null && numericWeight < 600) -> {
+                            fontWeight = FontWeight.Normal
+                        }
                     }
                 }
 
                 "font-style" -> {
-                    if (value == "italic") fontStyle = FontStyle.Italic
+                    if (value == "italic" || value == "oblique") fontStyle = FontStyle.Italic
                 }
             }
         }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/ThemeParser.kt
@@ -415,11 +415,13 @@ internal object ThemeParser {
 
         PROP_PATTERN.findAll(declarations).forEach { match ->
             val prop = match.groupValues[1].trim()
+            val rawValue = match.groupValues[2].trim()
             val value =
-                match.groupValues[2]
-                    .trim()
-                    .removeSuffix("!important")
-                    .trim()
+                if (rawValue.endsWith("!important", ignoreCase = true)) {
+                    rawValue.substring(0, rawValue.length - "!important".length).trim()
+                } else {
+                    rawValue
+                }
             when (prop) {
                 "color" -> {
                     color = parseColor(value)

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -526,6 +526,14 @@ class ThemeParserTest {
         assertThat(result[HljsSelectors.TITLE]?.fontStyle).isEqualTo(FontStyle.Italic)
     }
 
+    @Test
+    fun `parse handles case-insensitive important keyword`() {
+        val css = ".hljs-title { color: #78bb65 !IMPORTANT; font-weight: bold !Important }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF78BB65))
+        assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
     // ----- CSS4 rgb() space-separated syntax -----
 
     @Test

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
  * - Basic hex color parsing (`#rrggbb`, 3-digit `#rgb`, 4-digit `#rgba`, 8-digit `#rrggbbaa`)
  * - `rgb()` and `rgba()` color values including decimal alpha (e.g. `rgba(149,165,166,.8)`)
  * - CSS named colors (e.g. `color: red`)
- * - `font-weight: bold` / `700` and `font-style: italic`
+ * - `font-weight: bold` / `700` / `bolder` / `lighter` and `font-style: italic` / `oblique`
  * - Comma-separated selector lists (e.g. `.hljs-keyword, .hljs-type`)
  * - Compound dot-joined selectors (e.g. `.hljs-title.function_`)
  * - Descendant selectors with two `.hljs-*` tokens skipped (e.g. `.hljs-meta .hljs-keyword`)
@@ -242,6 +242,27 @@ class ThemeParserTest {
         val css = ".hljs-comment { font-weight: normal; color: #888 }"
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.COMMENT]?.fontWeight).isEqualTo(FontWeight.Normal)
+    }
+
+    @Test
+    fun `parse treats font-weight bolder keyword as bold`() {
+        val css = ".hljs-strong { font-weight: bolder }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.STRONG]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
+    @Test
+    fun `parse treats font-weight lighter keyword as normal`() {
+        val css = ".hljs-comment { font-weight: lighter; color: #888 }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.COMMENT]?.fontWeight).isEqualTo(FontWeight.Normal)
+    }
+
+    @Test
+    fun `parse treats font-style oblique as italic`() {
+        val css = ".hljs-emphasis { font-style: oblique }"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.EMPHASIS]?.fontStyle).isEqualTo(FontStyle.Italic)
     }
 
     @Test
@@ -489,6 +510,20 @@ class ThemeParserTest {
         val result = ThemeParser.parse(css)
         assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF78BB65))
         assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
+    }
+
+    @Test
+    fun `parse handles important relative font weight and oblique together`() {
+        val css =
+            ".hljs-title{" +
+                "color:#78bb65 !important;" +
+                "font-weight:bolder !important;" +
+                "font-style:oblique !important" +
+                "}"
+        val result = ThemeParser.parse(css)
+        assertThat(result[HljsSelectors.TITLE]?.color).isEqualTo(Color(0xFF78BB65))
+        assertThat(result[HljsSelectors.TITLE]?.fontWeight).isEqualTo(FontWeight.Bold)
+        assertThat(result[HljsSelectors.TITLE]?.fontStyle).isEqualTo(FontStyle.Italic)
     }
 
     // ----- CSS4 rgb() space-separated syntax -----


### PR DESCRIPTION
## What changed

- Updated `ThemeParser` to strip `!important` before parsing declaration values.
- Mapped `font-weight: bolder` to bold and `font-weight: lighter` to normal.
- Treated `font-style: oblique` as italic.
- Added focused `ThemeParserTest` coverage for each new construct and a combined case.
- Added an `Unreleased` changelog entry for the parser fix.

## Why

Some real-world and custom themes use `!important`, relative font weights, and `oblique`. These were previously ignored by the runtime theme parser, which caused incorrect styling.

Fixes #326

## Validation

- `./gradlew formatKotlin`
- `./gradlew :compose-highlight:test`
- `npx --yes markdownlint-cli CHANGELOG.md`
