### PR TITLE
chore: narrow consumer keep rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ All notable changes to this project will be documented in this file.
   removed the unused `android.test` plugin, cleaned up unnecessary repositories, removed
   redundant unit test coverage flags from release builds, resolved Gradle auto-provisioning
   warnings by configuring the Foojay resolver in `buildSrc`, and silenced JDK native-access warnings. Fixes #332.
+- **Narrowed consumer ProGuard keep rules to public API packages** - The library now keeps only
+  the top-level `ui` and `engine` public API surface, allowing downstream R8 to keep shrinking
+  and optimizing `*.internal*` implementation packages.
 
 ## [0.30.2] - 2026-06-13
 

--- a/compose-highlight/consumer-rules.pro
+++ b/compose-highlight/consumer-rules.pro
@@ -1,3 +1,7 @@
-# Keep public API of compose-highlight library
--keep public class dev.hossain.highlight.** { public *; }
--keep public interface dev.hossain.highlight.** { *; }
+# Keep the library's public API surface only.
+# Internal implementation packages are intentionally excluded so downstream R8 can
+# still shrink and optimize those classes.
+-keep public class dev.hossain.highlight.ui.* { public *; }
+-keep public interface dev.hossain.highlight.ui.* { *; }
+-keep public class dev.hossain.highlight.engine.* { public *; }
+-keep public interface dev.hossain.highlight.engine.* { *; }


### PR DESCRIPTION
## What changed

- Narrowed `compose-highlight/consumer-rules.pro` from a recursive `dev.hossain.highlight.**` keep rule to the top-level public API packages only.
- Excluded internal implementation packages from consumer keep rules so downstream R8 can continue shrinking and optimizing them.
- Added an `Unreleased` changelog entry for the keep-rule optimization.

## Why

The previous recursive keep rule was broader than the documented public API surface. Because Kotlin `internal` still compiles to public bytecode, that rule could preserve implementation-only classes under `engine.internal` and `ui.internal`, reducing shrinking and optimization for consumers.

## Validation

- `./gradlew formatKotlin :compose-highlight:assembleRelease :sample:assembleRelease`
- `npx --yes markdownlint-cli CHANGELOG.md`

The release build completed successfully through the R8 minification path.
