### PR TITLE
fix: remember focus and scroll modifiers in SyntaxHighlightedTextEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to this project will be documented in this file.
   `onPreviewKeyEvent` callbacks are now built once with `rememberUpdatedState`, preventing
   unnecessary recompositions on every keystroke while still reading the latest editor state.
   Fixes #329.
+- **Remembered `SyntaxHighlightedTextEditor` modifiers** - `focusNavigationModifier` and
+  `scrollModifier` are now remembered instead of being reconstructed on every recomposition,
+  reducing allocation churn in the editor.
 - **Fixed ThemeParser handling of `!important`, relative font weights, and oblique** -
   declarations with `!important` are now parsed correctly, `bolder`/`lighter` map to
   bold/normal weight, and `font-style: oblique` is treated as italic. Fixes #326.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -326,17 +326,21 @@ fun SyntaxHighlightedTextEditor(
         }
 
     val focusNavigationModifier =
-        Modifier.focusProperties {
-            up = FocusRequester.Cancel
-            down = FocusRequester.Cancel
-            left = FocusRequester.Cancel
-            right = FocusRequester.Cancel
+        remember {
+            Modifier.focusProperties {
+                up = FocusRequester.Cancel
+                down = FocusRequester.Cancel
+                left = FocusRequester.Cancel
+                right = FocusRequester.Cancel
+            }
         }
 
     val scrollModifier =
-        Modifier
-            .then(if (verticalScrollState != null) Modifier.verticalScroll(verticalScrollState) else Modifier)
-            .then(if (horizontalScrollState != null) Modifier.horizontalScroll(horizontalScrollState) else Modifier)
+        remember(verticalScrollState, horizontalScrollState) {
+            Modifier
+                .then(if (verticalScrollState != null) Modifier.verticalScroll(verticalScrollState) else Modifier)
+                .then(if (horizontalScrollState != null) Modifier.horizontalScroll(horizontalScrollState) else Modifier)
+        }
 
     Surface(
         modifier = modifier.testTag("syntax-highlighted-text-editor"),


### PR DESCRIPTION
After running the Compose compiler stability reports and reviewing the public UI surface, two modifiers in SyntaxHighlightedTextEditor were being reconstructed on every recomposition:

- focusNavigationModifier — built inline every frame.
- scrollModifier — built inline every frame even though it only depends on verticalScrollState and horizontalScrollState.

Changes:
- Wrapped focusNavigationModifier in remember { ... }.
- Wrapped scrollModifier in remember(verticalScrollState, horizontalScrollState) { ... }.
- Added a changelog entry.

Verification:
- ./gradlew formatKotlin lintKotlin :compose-highlight:assembleDebug :compose-highlight:test passes.
- npx markdownlint-cli CHANGELOG.md passes.

All public UI composables are already restartable skippable with stable parameters; this change removes unnecessary Modifier allocation churn in the editor.