### PR TITLE
fix: add modifier parameters to CopyButton and LanguageLabel default slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 - **Remembered `SyntaxHighlightedTextEditor` modifiers** - `focusNavigationModifier` and
   `scrollModifier` are now remembered instead of being reconstructed on every recomposition,
   reducing allocation churn in the editor.
+- **Added `modifier` parameters to default slot helpers** - `SyntaxHighlightedCodeDefaults.CopyButton`
+  and `SyntaxHighlightedCodeDefaults.LanguageLabel` now accept a `modifier` parameter, allowing
+  callers to add padding, test tags, or other customisation to the default copy button and
+  language badge slots.
 - **Fixed ThemeParser handling of `!important`, relative font weights, and oblique** -
   declarations with `!important` are now parsed correctly, `bolder`/`lighter` map to
   bold/normal weight, and `font-style: oblique` is treated as italic. Fixes #326.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeDefaults.kt
@@ -127,6 +127,8 @@ object SyntaxHighlightedCodeDefaults {
      *
      * @param onClick Action invoked when the button is clicked. Wire this to the `onClick`
      *   parameter received from the `copyButton` slot.
+     * @param modifier Modifier applied to the root [IconButton]. Use this for padding, test tags,
+     *   or other positioning/customisation.
      * @param tint Icon color. Defaults to [LocalContentColor] at 70 % opacity, which resolves
      *   correctly when inside a [SyntaxHighlightedCode] block.
      * @param contentDescription Accessibility label for TalkBack and other assistive services.
@@ -136,6 +138,7 @@ object SyntaxHighlightedCodeDefaults {
     @Composable
     fun CopyButton(
         onClick: () -> Unit,
+        modifier: Modifier = Modifier,
         tint: Color = LocalContentColor.current.copy(alpha = 0.7f),
         contentDescription: String = "Copy code",
         size: Dp = copyButtonSize,
@@ -143,7 +146,7 @@ object SyntaxHighlightedCodeDefaults {
         IconButton(
             onClick = onClick,
             modifier =
-                Modifier
+                modifier
                     .size(size)
                     .semantics { this.contentDescription = contentDescription },
         ) {
@@ -180,6 +183,8 @@ object SyntaxHighlightedCodeDefaults {
      * ```
      *
      * @param language Text to display (typically the Highlight.js language identifier).
+     * @param modifier Modifier applied to the root [Text]. Use this for padding, test tags,
+     *   or other positioning/customisation.
      * @param color Label color. Defaults to [LocalContentColor] at 60 % opacity, which resolves
      *   correctly when inside a [SyntaxHighlightedCode] block.
      * @param fontSize Label font size. Defaults to 12 sp.
@@ -187,12 +192,14 @@ object SyntaxHighlightedCodeDefaults {
     @Composable
     fun LanguageLabel(
         language: String,
+        modifier: Modifier = Modifier,
         color: Color = LocalContentColor.current.copy(alpha = 0.6f),
         fontSize: TextUnit = 12.sp,
     ) {
         if (language.isNotBlank()) {
             Text(
                 text = language,
+                modifier = modifier,
                 style =
                     TextStyle(
                         fontFamily = FontFamily.Monospace,


### PR DESCRIPTION
This change adds a `modifier` parameter to the two default slot helpers in `SyntaxHighlightedCodeDefaults` so callers can customize the default copy button and language badge.

## Changes

- `CopyButton` now accepts `modifier: Modifier = Modifier` and applies it to the root `IconButton`.
- `LanguageLabel` now accepts `modifier: Modifier = Modifier` and applies it to the root `Text`.
- Both apply the caller-provided modifier first, then their intrinsic style modifiers (size, semantics, etc.).
- Added a changelog entry under `[Unreleased] > Fixed`.

## Why

Both helpers emit layout but previously provided no way for callers to add padding, test tags, or positioning. This aligns them with the Compose modifier convention without breaking existing callers (new parameter has a default).

## Verification

- `./gradlew formatKotlin lintKotlin :compose-highlight:assembleDebug :compose-highlight:test :sample:assembleDebug` passes.
- `npx markdownlint-cli CHANGELOG.md` passes.
- Existing call sites (sample app, tests, docs) use named arguments and are unaffected.