### PR TITLE
ci: add release builds and publishToMavenLocal smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
         with:
           path: |
             ~/.android/avd
-            ~/Android/Sdk/system-images
+            ${{ env.ANDROID_HOME }}/system-images
+            ${{ env.ANDROID_HOME }}/emulator
           key: managed-device-pixel2api30-aosp-atd-${{ runner.os }}
 
       - name: Check Kotlin formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,18 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: ./gradlew :sample:assembleDebug
 
+      - name: Assemble library (release)
+        if: steps.changes.outputs.code == 'true'
+        run: ./gradlew :compose-highlight:assembleRelease
+
+      - name: Assemble sample app (release)
+        if: steps.changes.outputs.code == 'true'
+        run: ./gradlew :sample:assembleRelease
+
+      - name: Smoke test Maven publication
+        if: steps.changes.outputs.code == 'true'
+        run: ./gradlew :compose-highlight:publishToMavenLocal
+
       - name: Upload test results
         if: steps.changes.outputs.code == 'true' || failure()
         uses: actions/upload-artifact@v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ All notable changes to this project will be documented in this file.
 
 ### Infrastructure
 
+- **Added release build and Maven publication smoke test to CI** - CI now runs
+  `:compose-highlight:assembleRelease`, `:sample:assembleRelease`, and
+  `:compose-highlight:publishToMavenLocal` on every code change, catching release-only
+  R8/ProGuard, packaging, and publishing misconfigurations before release day.
 - **Upgraded compileSdk to 37 and androidxCore to 1.19.0** - Updated the project to compile against Android SDK 37 to
   support upgrading the `androidx.core:core` and `core-ktx` libraries to version 1.19.0.
 - **Removed opencode GitHub Actions workflow** - Deleted `.github/workflows/opencode.yml` since

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,14 @@ All notable changes to this project will be documented in this file.
   support upgrading the `androidx.core:core` and `core-ktx` libraries to version 1.19.0.
 - **Removed opencode GitHub Actions workflow** - Deleted `.github/workflows/opencode.yml` since
   the project no longer uses the opencode comment-triggered automation.
-- **Hardened CI/CD workflows** - Updated core GitHub Actions versions, fixed the managed-device
-  system image cache path to use `$ANDROID_HOME`, added Dokka and Android Lint validation to CI,
-  added explicit permissions to `publish.yml`, and replaced raw `curl`/`jq` release asset upload
-  with `gh release upload`. Fixes #331.
+- **Hardened CI/CD workflows** - Updated core GitHub Actions versions, added Dokka and Android
+  Lint validation to CI, added explicit permissions to `publish.yml`, and replaced raw `curl`/`jq`
+  release asset upload with `gh release upload`. Fixes #331.
+- **Fixed managed-device system image cache path in CI** - The cache now points to
+  `${{ env.ANDROID_HOME }}/system-images` and also caches `${{ env.ANDROID_HOME }}/emulator`,
+  matching where Gradle Managed Device actually installs the AOSP ATD image and Android Emulator
+  on GitHub-hosted runners. This prevents the system image from being re-downloaded on every CI
+  run.
 - **Cleaned up build configuration** - Moved hardcoded dependencies to the version catalog,
   removed the unused `android.test` plugin, cleaned up unnecessary repositories, removed
   redundant unit test coverage flags from release builds, resolved Gradle auto-provisioning


### PR DESCRIPTION
This PR hardens CI so release-only failures and managed-device caching issues are caught before release day.

## Changes

- Added `:compose-highlight:assembleRelease` to CI.
- Added `:sample:assembleRelease` to CI.
- Added `:compose-highlight:publishToMavenLocal` smoke test to CI.
- Fixed the managed-device system image cache path to use `${{ env.ANDROID_HOME }}/system-images` and added `${{ env.ANDROID_HOME }}/emulator` to the cache.
- Updated `CHANGELOG.md` to reflect the CI fixes and corrected the earlier inaccurate cache-path note.

## Why

- Debug builds do not exercise R8/ProGuard consumer rules, release AAR packaging, or the Maven publication pipeline.
- `publishToMavenLocal` validates POM, sources/javadoc jars, AAR, coordinates, and the vanniktech plugin config without uploading anywhere.
- The previous cache path (`~/Android/Sdk/system-images`) did not match the actual install location on GitHub-hosted runners (`/usr/local/lib/android/sdk/system-images`), causing the AOSP ATD image to be re-downloaded every run.
- Signing is conditional (`signAllPublications()` only runs when `signingInMemoryKey` is present), so the smoke test works without secrets.

## Verification

Ran the release and publish commands locally:

```bash
./gradlew :compose-highlight:assembleRelease :sample:assembleRelease :compose-highlight:publishToMavenLocal
```

Result: `BUILD SUCCESSFUL`.

`npx markdownlint-cli CHANGELOG.md` passes. CI YAML syntax validated with Python PyYAML.