### PR TITLE
docs/ci: 1.0 readiness - lint fixes, AGENTS update, and Compose compiler report verification

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,7 +146,12 @@ human-readable signal; the modifier is the enforcement. Dokka suppresses
 
 ## Key conventions
 
-**Public vs internal:** Only `ui/` and `engine/{HighlightEngine,HighlightTheme,HighlightException}.kt` are public API. All `engine/` helpers (`WebViewManager`, `ThemeParser`, `HtmlToAnnotatedString`, `unescapeJsString`) are `internal`. Note that `unescapeJsString` is a package-level `internal fun` (not a member of `HighlightEngine`) so it can be tested directly from JVM unit tests without a real `Context`.
+**Public vs internal:** Public API consists of the `ui/` package plus the public `engine/` declarations used by it:
+`HighlightEngine`, `HighlightTheme`, `HighlightException`, `HighlightResult`, `ThemedHighlightResult`,
+`AutoHighlightResult`, `HtmlHighlightResult`, `HighlightTimings`, `HighlightLanguage`, `HighlightLanguageInfo`,
+and `HljsSelectors`. All implementation helpers under `engine/internal/` (`WebViewManager`, `ThemeParser`,
+`HtmlToAnnotatedString`, `JsStringEscape`, `EngineErrorHandling`) and `ui/internal/` are `internal` and not
+part of the supported public surface.
 
 **`android.util.Log` is banned from the library.** Any `Log.*` call in code paths executed by JVM unit tests causes `RuntimeException: Method d in android.util.Log not mocked`. Remove all debug logging before committing.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,9 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: ./gradlew :sample:assembleDebug
 
-      - name: Assemble library (release)
+      - name: Assemble library (release) and generate Compose compiler reports
         if: steps.changes.outputs.code == 'true'
-        run: ./gradlew :compose-highlight:assembleRelease
+        run: ./gradlew :compose-highlight:assembleRelease -PcomposeReports=true
 
       - name: Assemble sample app (release)
         if: steps.changes.outputs.code == 'true'
@@ -196,6 +196,17 @@ jobs:
       - name: Smoke test Maven publication
         if: steps.changes.outputs.code == 'true'
         run: ./gradlew :compose-highlight:publishToMavenLocal
+
+      - name: Upload Compose compiler reports
+        if: steps.changes.outputs.code == 'true' || failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: compose-compiler-reports
+          path: compose-highlight/build/compose_compiler/
+
+      - name: Verify Compose compiler skippability
+        if: steps.changes.outputs.code == 'true'
+        run: ./scripts/verify-compose-compiler-reports.sh
 
       - name: Upload test results
         if: steps.changes.outputs.code == 'true' || failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this project will be documented in this file.
   `:compose-highlight:assembleRelease`, `:sample:assembleRelease`, and
   `:compose-highlight:publishToMavenLocal` on every code change, catching release-only
   R8/ProGuard, packaging, and publishing misconfigurations before release day.
+- **Added Compose compiler report verification to CI** - Release builds now generate Compose
+  compiler stability reports, upload them as CI artifacts, and verify that every public UI
+  composable is skippable with stable parameters.
 - **Upgraded compileSdk to 37 and androidxCore to 1.19.0** - Updated the project to compile against Android SDK 37 to
   support upgrading the `androidx.core:core` and `core-ktx` libraries to version 1.19.0.
 - **Removed opencode GitHub Actions workflow** - Deleted `.github/workflows/opencode.yml` since

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,11 +99,11 @@ All notable changes to this project will be documented in this file.
   - **Removes 4 R8/ProGuard `-keep` rules** from `consumer-rules.pro` (`org.jsoup.Jsoup`,
     `org.jsoup.parser.**`, `org.jsoup.nodes.**`, `org.jsoup.select.**`). One fewer transitive
     library for downstream R8/ProGuard pipelines to analyze; one fewer source of shrinker bugs.
-  - **Sample APK is 128.7 KB smaller (-5.49%)** post-R8 — measured by diffing the published
+  - **Sample APK is 128.7 KB smaller (-5.49%)** post-R8 - measured by diffing the published
     sample APKs for 0.29.0 vs 0.30.0 with `diffuse`. The dex shrunk by 268 KB uncompressed
     (-271 classes, -2,298 methods); other APK sections (resources, manifest, assets) are
-    byte-identical. The library AAR itself grows by ~7 KB (546 KB → 553 KB) because the
-    parser code now ships in the module — but the AAR never bundled Jsoup, so the net
+    byte-identical. The library AAR itself grows by ~7 KB (546 KB -> 553 KB) because the
+    parser code now ships in the module - but the AAR never bundled Jsoup, so the net
     consumer-side footprint is meaningfully lighter.
   - **Prepares the codebase for Kotlin Multiplatform (KMP)** - Jsoup is JVM-only; the new
     parser is pure Kotlin with no JVM-specific APIs.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-[![CI](https://github.com/hossain-khan/android-compose-highlight/actions/workflows/ci.yml/badge.svg)](https://github.com/hossain-khan/android-compose-highlight/actions/workflows/ci.yml) [![codecov](https://codecov.io/github/hossain-khan/android-compose-highlight/graph/badge.svg?token=MHCCHQVSLX)](https://codecov.io/github/hossain-khan/android-compose-highlight) [![release](https://badgen.net/github/release/hossain-khan/android-compose-highlight?icon=github&color=purple)](https://github.com/hossain-khan/android-compose-highlight/releases/latest) [![Maven Central](https://img.shields.io/maven-central/v/dev.hossain/compose-highlight?color=brown)](https://central.sonatype.com/artifact/dev.hossain/compose-highlight) [![Android Weekly](https://androidweekly.net/issues/issue-727/badge)](https://androidweekly.net/issues/issue-727)
+# Compose Highlight for Android
 
+![Compose Code Highlight Logo](docs/assets/images/logo-plain.png)
 
-# <img src="docs/assets/images/logo-plain.png" height="26" alt="Compose Code Highlight Logo"> Compose Highlight for Android
+[![CI](https://github.com/hossain-khan/android-compose-highlight/actions/workflows/ci.yml/badge.svg)](https://github.com/hossain-khan/android-compose-highlight/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/hossain-khan/android-compose-highlight/graph/badge.svg?token=MHCCHQVSLX)](https://codecov.io/github/hossain-khan/android-compose-highlight)
+[![release](https://badgen.net/github/release/hossain-khan/android-compose-highlight?icon=github&color=purple)](https://github.com/hossain-khan/android-compose-highlight/releases/latest)
+[![Maven Central](https://img.shields.io/maven-central/v/dev.hossain/compose-highlight?color=brown)](https://central.sonatype.com/artifact/dev.hossain/compose-highlight)
+[![Android Weekly](https://androidweekly.net/issues/issue-727/badge)](https://androidweekly.net/issues/issue-727)
 
-A Jetpack Compose library for beautiful syntax highlighting - powered by [Highlight.js](https://highlightjs.org/) running in a hidden WebView, converting tokenised HTML to native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers to maintain.
+A Jetpack Compose library for beautiful syntax highlighting - powered by
+[Highlight.js](https://highlightjs.org/) running in a hidden WebView, converting tokenised HTML to
+native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers to maintain.
 
 **[📚 Full documentation →](https://hossain-khan.github.io/android-compose-highlight/)**
 
@@ -32,10 +39,11 @@ HighlightThemeProvider(
 
 ## Demo
 
+<!-- markdownlint-disable MD013 MD033 -->
 | Sample App | All Themes |
 | ---- | ----- |
 | <video src="https://github.com/user-attachments/assets/5dc18969-396a-45de-849b-0f8e3e9ffd26"> | <video src="https://github.com/user-attachments/assets/ed155002-be9b-4ba4-898b-35597cced0da"> |
-
+<!-- markdownlint-enable MD013 MD033 -->
 
 ## Links
 

--- a/scripts/verify-compose-compiler-reports.sh
+++ b/scripts/verify-compose-compiler-reports.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Verifies the Compose compiler stability report for the public UI surface.
+# Fails if any public UI composable is non-skippable or has unstable parameters.
+#
+# Intended to run in CI after:
+#   ./gradlew :compose-highlight:assembleRelease -PcomposeReports=true
+#
+
+set -euo pipefail
+
+REPORT="compose-highlight/build/compose_compiler/compose-highlight-composables.txt"
+
+if [ ! -f "$REPORT" ]; then
+    echo "::error::Compose compiler report not found: $REPORT"
+    exit 1
+fi
+
+echo "Verifying Compose compiler report: $REPORT"
+
+awk -v RS='' -v ORS='\n\n' '
+    / fun dev\.hossain\.highlight\.ui\./ {
+        if ($0 ~ /^restartable/ && $0 !~ / skippable /) {
+            print "::error::Non-skippable public UI composable"
+            print $0
+            exit_code = 1
+        }
+        if ($0 ~ /\n  unstable /) {
+            print "::error::Public UI composable has unstable parameter"
+            print $0
+            exit_code = 1
+        }
+    }
+    END { exit (exit_code ? 1 : 0) }
+' "$REPORT"
+
+echo "Compose compiler report verification passed."


### PR DESCRIPTION
This PR addresses several 1.0-readiness housekeeping items.

## Changes

### Documentation
- Fixed em-dash characters in `CHANGELOG.md` (replaced with regular hyphens).
- Fixed `README.md` markdown lint issues:
  - Added a top-level heading as the first line.
  - Split badge line across multiple lines.
  - Removed extra blank lines.
  - Replaced inline `<img>` with Markdown image syntax.
  - Wrapped long description line.
  - Wrapped the demo video table with `markdownlint-disable MD013 MD033` comments so inline `<video>` tags can stay for rendered playback.
- Updated `AGENTS.md` public-API description to reflect the full public engine surface (`HighlightResult`, `ThemedHighlightResult`, `AutoHighlightResult`, `HtmlHighlightResult`, `HighlightTimings`, `HighlightLanguage`, `HighlightLanguageInfo`, `HljsSelectors`).

### CI / Compose compiler reports
- Modified the release assembly step to also generate Compose compiler reports (`-PcomposeReports=true`).
- Added an artifact upload step for `compose-highlight/build/compose_compiler/`.
- Added `scripts/verify-compose-compiler-reports.sh` which parses `compose-highlight-composables.txt` and fails CI if any public UI composable is non-skippable or has unstable parameters.
- Added a CI step that runs the verification script.
- Added changelog entries under `[Unreleased] > Infrastructure`.

## Verification

- `npx markdownlint-cli CHANGELOG.md README.md` passes.
- CI YAML syntax validated.
- `./gradlew formatKotlin lintKotlin :compose-highlight:assembleRelease -PcomposeReports=true :sample:assembleRelease :compose-highlight:publishToMavenLocal` passes.
- `./scripts/verify-compose-compiler-reports.sh` passes.

The Compose compiler reports confirm all public UI composables are `restartable skippable` with stable parameters.