### PR TITLE
chore: prepare release 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-14
+
 ### Added
 
 - **Added scroll support and scroll-state hoisting to code block and editor** - Callers can now

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.30.2")
+    implementation("dev.hossain:compose-highlight:0.31.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.31.0 - Scroll state hoisting and CI hardening
+
+- Added scroll support and scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor`
+- Fixed preview crashes by preventing WebView initialization in Compose Previews across editor, read-only blocks, and theme provider
+- Fixed 8-digit CSS hex color parsing to follow CSS Color Module Level 4 (`#RRGGBBAA`)
+- Added release builds, Maven publication smoke test, and Compose compiler report verification to CI
+- Added `scripts/compose-compiler-report.html` to visualize Compose compiler stability reports
+
 ### 0.30.2 - Remove deprecated treeWalk timing
 
 - Removed the deprecated `treeWalk` timing property entirely from `HighlightTimings`
@@ -34,14 +42,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - Tab key hardware interception to insert custom indentation instead of shifting focus
 - Auto-indentation to automatically copy the previous line's leading whitespace on hardware/virtual keyboards
 - Intercepted arrow keys to prevent focus from escaping the editor boundaries
-
-### 0.28.0 - Vector copy icon and sample app polish
-
-- Default copy icon replaced with vector drawable (`copy_code_block.xml`) with proportional scaling
-- Info banner added to sample app Languages tab with library version and "Open Docs" button
-- `LIB_VERSION_NAME` build config field keeps displayed version in sync with published artifact
-- `EngineInfoSection` search box outline now matches other info cards, language chips use vector icons
-- KDoc updated for `CopyButton` to describe vector icon behavior
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.30.2")
+    implementation("dev.hossain:compose-highlight:0.31.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.30.2")
+    implementation("dev.hossain:compose-highlight:0.31.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.30.2
+VERSION_NAME=0.31.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 37
-        versionName = "0.30.2"
+        versionCode = 38
+        versionName = "0.31.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Prepare release 0.31.0.

## Changes

- Bumped `VERSION_NAME` to `0.31.0`.
- Updated dependency snippets in `README.md`, `docs/index.md`, and `docs/getting-started.md`.
- Incremented sample app `versionCode` (37 -> 38) and `versionName`.
- Updated `pyproject.toml` version.
- Renamed `[Unreleased]` to `## [0.31.0] - 2026-06-14` in `CHANGELOG.md`.
- Updated `docs/changelog.md` with 0.31.0 highlights and removed the oldest entry to maintain the last-5-releases limit.

## Verification

- `./gradlew formatKotlin` passes.
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug` passes.
- `./gradlew :compose-highlight:test` passes.
- `npx markdownlint-cli CHANGELOG.md` passes.

## After merge

- Pull `main`, tag `0.31.0`, and push the tag.
- Trigger the Maven Central publish workflow in dry-run mode first, then for real.