### PR TITLE
Fixed docs inconsistencies

### DIFF
--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightException.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightException.kt
@@ -44,7 +44,7 @@ sealed class HighlightException(
      */
     class ThemeNotFound(
         path: String,
-    ) : HighlightException("Theme CSS not found: $path")
+    ) : HighlightException("Theme CSS has no parseable color rules: $path")
 
     /**
      * Thrown when the HTML parser fails to parse the HTML returned by Highlight.js.

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHighlightedCode.kt
@@ -16,8 +16,10 @@ import dev.hossain.highlight.engine.ThemedHighlightResult
 /**
  * Pre-highlights [code] and remembers the resulting [AnnotatedString].
  *
- * Returns `null` while highlighting is in progress **or** if highlighting failed. Callers
- * should always render a plain-text fallback when the state is `null`.
+ * Returns `null` while highlighting is in progress **or** if highlighting failed.
+ *
+ * In preview / inspection mode, returns a plain-text `AnnotatedString(code)` immediately so
+ * `@Preview` composables can render without creating the WebView-backed engine.
  *
  * Re-runs automatically when [code], [language], or [theme] changes.
  *
@@ -80,6 +82,7 @@ import dev.hossain.highlight.engine.ThemedHighlightResult
  *   )
  *   ```
  * @return A [State] holding the highlighted [AnnotatedString], or `null` while loading / on error.
+ *   In inspection mode, the state is initialized to plain text immediately.
  */
 @Composable
 fun rememberHighlightedCode(

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightExceptionTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightExceptionTest.kt
@@ -70,6 +70,12 @@ class HighlightExceptionTest {
     }
 
     @Test
+    fun `ThemeNotFound message explains the parse failure`() {
+        val ex = HighlightException.ThemeNotFound("compose-highlight/themes/missing.css")
+        assertThat(ex.message).startsWith("Theme CSS has no parseable color rules")
+    }
+
+    @Test
     fun `ThemeNotFound has null cause`() {
         val ex = HighlightException.ThemeNotFound("any/path.css")
         assertThat(ex.cause).isNull()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,41 +8,57 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ### 0.31.0 - Scroll hoisting, preview fixes, and CI hardening
 
-- Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor` for programmatic scroll control
-- Fixed Compose Preview crashes by blocking WebView initialization in `@Preview` composables across the editor, read-only blocks, and theme provider
+- Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor`
+  for programmatic scroll control
+- Fixed Compose Preview crashes by blocking WebView initialization in `@Preview`
+  composables across the editor, read-only blocks, and theme provider
 - Fixed `HighlightResult.spanCount` semantics and CSS `#RRGGBBAA` color parsing order
-- Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers, and added `modifier` parameters to the default copy button and language badge slot helpers
-- Hardened CI with release builds, Maven publication smoke test, Compose compiler report verification, and a new HTML report visualizer
+- Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers,
+  and added `modifier` parameters to the default copy button and language badge slot helpers
+- Hardened CI with release builds, Maven publication smoke test, and Compose compiler
+  report verification
 
 ### 0.30.2 - Remove deprecated treeWalk timing
 
 - Removed the deprecated `treeWalk` timing property entirely from `HighlightTimings`
 - Cleaned up the timings usage in `HighlightEngine` and internally in `HtmlToAnnotatedString`
-- Updated the sample app performance breakdown screen and timing unit tests to remove the property
-- Syncing documentation across the guides to reflect the updated timing model
+- Updated the sample app performance breakdown screen and timing unit tests to
+  remove the property
+- Synced documentation across the guides to reflect the updated timing model
 
 ### 0.30.1 - Parser performance optimizations
 
-- Optimized HTML-to-AnnotatedString pipeline with SAX-style single-pass parsing, eliminating intermediate tree allocations
-- Added substring avoidance, in-place attribute extraction, lazy entity decoding, and allocation-free numeric parsing
-- Benchmarks show 29-57% faster single-theme and 5-39% faster dual-theme conversions across all fixtures
-- Saved Jsoup baseline and SAX optimized JSON reports under resources/html-parser-benchmarks/ for regression tracking
+- Optimized HTML-to-AnnotatedString pipeline with SAX-style single-pass parsing,
+  eliminating intermediate tree allocations
+- Added substring avoidance, in-place attribute extraction, lazy entity decoding, and
+  allocation-free numeric parsing
+- Benchmarks show 29-57% faster single-theme and 5-39% faster dual-theme conversions
+  across all fixtures
+- Saved Jsoup baseline and SAX optimized JSON reports under
+  `resources/html-parser-benchmarks/` for regression tracking
 
 ### 0.30.0 - Custom HTML parser replaces Jsoup
 
-- Replaced the JVM-only Jsoup dependency with a single-pass pure-Kotlin HTML tokenizer scoped to the hljs HTML subset
-- Sample APK measured 128.7 KB smaller post-R8 (-5.49%); dex drops 271 classes and 2,298 methods. 4 R8/ProGuard `-keep` rules removed from downstream consumers
-- Dual-theme highlight path is 1.27×-1.97× faster on real-world Kotlin/C/Rust/Go/C#/SQL fixtures
-- Added real-world language test coverage with extensive token-count assertions and an opt-in JVM microbenchmark (`HtmlParserBenchmark`)
-- Prepares the codebase for Kotlin Multiplatform (KMP)
+- Replaced the JVM-only Jsoup dependency with a single-pass pure-Kotlin HTML
+  tokenizer scoped to the hljs HTML subset
+- Sample APK measured 128.7 KB smaller post-R8 (-5.49%); dex drops 271 classes and
+  2,298 methods. Four R8/ProGuard `-keep` rules were removed from downstream consumers
+- Dual-theme highlight path is 1.27×-1.97× faster on real-world
+  Kotlin/C/Rust/Go/C#/SQL fixtures
+- Added real-world language test coverage with extensive token-count assertions and an
+  opt-in JVM microbenchmark (`HtmlParserBenchmark`)
+- Prepared the codebase for Kotlin Multiplatform (KMP)
 
 ### 0.29.0 - Tab and auto-indent support in text editor
 
-- Added `indentation`, `autoIndentEnabled`, and `tabKeyInterceptionEnabled` parameters to `SyntaxHighlightedTextEditor`
-- Tab key hardware interception to insert custom indentation instead of shifting focus
-- Auto-indentation to automatically copy the previous line's leading whitespace on hardware/virtual keyboards
+- Added `indentation`, `autoIndentEnabled`, and `tabKeyInterceptionEnabled`
+  parameters to `SyntaxHighlightedTextEditor`
+- Added Tab key hardware interception to insert custom indentation instead of
+  shifting focus
+- Added auto-indentation to copy the previous line's leading whitespace on
+  hardware and virtual keyboards
 - Intercepted arrow keys to prevent focus from escaping the editor boundaries
 
 ---
 
-[View full CHANGELOG on GitHub](https://github.com/hossain-khan/android-compose-highlight/blob/main/CHANGELOG.md){ .md-button }
+View the full CHANGELOG in the repo root.

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -24,6 +24,8 @@ Full API in Dokka:
 - `theme` - pass explicitly, or rely on `HighlightThemeProvider`.
 - `style` - controls code block visuals (`CodeBlockStyle`).
 - `showLineNumbers` - enables line-number gutter.
+- `scrollState` - hoisted horizontal scroll state. Pass one when you need to control or observe
+  horizontal position from outside the composable.
 - `languageLabel` and `copyButton` - slots for header customization, or `null` to hide.
 - `placeholder` - custom loading content while highlighting is in progress.
 - `onHighlightComplete` and `onError` - observability hooks for metrics and diagnostics.
@@ -169,6 +171,8 @@ Use these when you want custom rendering but still want the library's highlight 
 ### `rememberHighlightedCode`
 
 Returns highlighted text as `State<AnnotatedString?>`. Render a plain-text fallback while `null`.
+In preview / inspection mode, the helper returns plain text immediately so the composable can
+render without starting the WebView-backed engine.
 
 ```kotlin
 val highlighted by rememberHighlightedCode(code = snippet, language = "kotlin")

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -28,14 +28,33 @@ Full API in Dokka:
 - `theme` - explicit theme or value from `HighlightThemeProvider`.
 - `debounceMs` - typing pause before highlight call.
 - `contentPadding` and `shape` - layout and clipping of editor surface.
-- `keyboardOptions` - keyboard / IME behavior. Defaults to `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` (autocorrect off, autocapitalization off, Ascii keyboard) - the right defaults for source code. Override via `.copy(imeAction = ...)` to keep the code-friendly settings while customising one field.
-- `cursorBrush` - text cursor color. Defaults to `null`, which derives the cursor from the theme's text color so it stays visible on both light and dark themes. Pass an explicit `Brush` (e.g. `SolidColor(MaterialTheme.colorScheme.primary)`) to override.
-- `onHighlightComplete` and `onError` - observability hooks. `onHighlightComplete` receives a `HighlightResult` (timing, span count, language); see the [API docs](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-result/index.html).
-- `indentation` - indentation string to insert when the Tab key is pressed. Defaults to 4 spaces (`"    "`).
-- `autoIndentEnabled` - whether to automatically copy the leading indentation of the previous line when inserting a newline. Defaults to `true`.
-- `tabKeyInterceptionEnabled` - whether to intercept the hardware Tab key to insert spaces instead of shifting focus to the next view. Defaults to `true`. Note that arrow keys (Up, Down, Left, Right) are also intercepted to prevent focus from escaping the editor when boundaries are reached.
+- `horizontalScrollState` and `verticalScrollState` - hoisted scroll states for external control
+  or observation of editor scroll position.
+- `keyboardOptions` - keyboard / IME behavior. Defaults to
+  `SyntaxHighlightedTextEditorDefaults.CodeKeyboardOptions` (autocorrect off,
+  autocapitalization off, Ascii keyboard) - the right defaults for source code.
+  Override via `.copy(imeAction = ...)` to keep the code-friendly settings while
+  customising one field.
+- `cursorBrush` - text cursor color. Defaults to `null`, which derives the cursor
+  from the theme's text color so it stays visible on both light and dark themes.
+  Pass an explicit `Brush` (e.g. `SolidColor(MaterialTheme.colorScheme.primary)`) to
+  override.
+- `onHighlightComplete` and `onError` - observability hooks. `onHighlightComplete`
+  receives a `HighlightResult` (timing, span count, language); see the
+  [API docs](../api/compose-highlight/dev.hossain.highlight.engine/-highlight-result/index.html).
+- `indentation` - indentation string to insert when the Tab key is pressed. Defaults
+  to 4 spaces (`"    "`).
+- `autoIndentEnabled` - whether to automatically copy the leading indentation of the
+  previous line when inserting a newline. Defaults to `true`.
+- `tabKeyInterceptionEnabled` - whether to intercept the hardware Tab key to insert
+  spaces instead of shifting focus to the next view. Defaults to `true`. Note that
+  arrow keys (Up, Down, Left, Right) are also intercepted to prevent focus from
+  escaping the editor when boundaries are reached.
 
-For anything else `BasicTextField` exposes (`enabled`, `readOnly`, `singleLine`, `maxLines`, `decorationBox`, etc.) drop one level down to [`rememberSyntaxHighlightedEditorValue`](#lower-level-helper-for-custom-text-fields) and render your own field - the editor is intentionally opinionated.
+For anything else `BasicTextField` exposes (`enabled`, `readOnly`, `singleLine`,
+`maxLines`, `decorationBox`, etc.) drop one level down to
+[`rememberSyntaxHighlightedEditorValue`](#lower-level-helper-for-custom-text-fields)
+and render your own field - the editor is intentionally opinionated.
 
 ## Opting in
 


### PR DESCRIPTION
 What I fixed:

  - Aligned rememberHighlightedCode KDoc with the actual preview behavior in compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/ RememberHighlightedCode.kt.

  - Made HighlightException.ThemeNotFound message match its documented contract in compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ HighlightException.kt and added a regression check in compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightExceptionTest.kt.

  - Updated the curated docs changelog in docs/changelog.md.
  - Brought the human reference pages back in sync with the public API surface in docs/reference/syntax-highlighted-code.md and docs/reference/syntax-highlighted- text-editor.md.

  - Regenerated the Dokka API output locally with ./gradlew :compose-highlight:dokkaGeneratePublicationHtml. The generated files under docs/api/ were updated on disk, but that tree is gitignored in this repo.

  Validation:

  - ./gradlew formatKotlin
  - ./gradlew :compose-highlight:test
  - ./gradlew :compose-highlight:dokkaGeneratePublicationHtml
  - git diff --check
  - local markdown line-length scan on the touched docs