### PR TITLE
chore: remove dead legacy parseHtml + CustomNode tree types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- **Removed dead legacy `parseHtml` + `CustomNode` tree types from `HtmlParser.kt`** -
+  The SAX-style `parseAndBuild`/`parseAndBuildBoth` rewrite in 0.30.1 made the legacy
+  tree-building parser path obsolete, but the dead code (sealed interface `CustomNode`,
+  classes `CustomElement` and `CustomTextNode`, function `parseHtml`, plus the
+  `WHITESPACE_CHARS` constant) was retained in case tests needed it. No test references
+  it, so the entire path is removed (-200 LOC). AAR `classes.jar` shrinks from 109 to 98
+  class entries. Recovers most of the Codecov badge drop introduced when the legacy path
+  was first sidelined: local JVM unit-test line coverage on `HtmlParserKt` rises from
+  71.3% to 87.5%, and on the `engine/internal` package from 78.5% to 86.0%.
+
 ## [0.31.0] - 2026-06-14
 
 ### Added

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/HtmlParser.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/HtmlParser.kt
@@ -3,196 +3,28 @@ package dev.hossain.highlight.engine.internal
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 
-/**
- * A lightweight, custom HTML tokenizer and parser for highlight.js HTML output.
- *
- * **Legacy tree node:** This sealed interface and its implementations ([CustomElement],
- * [CustomTextNode]) are used only by [parseHtml] to build an intermediate tree. The library's
- * production hot path no longer uses these - it uses the SAX-style [parseAndBuild] and
- * [parseAndBuildBoth] functions instead, which parse HTML and build [AnnotatedString] in a
- * single pass without allocating tree nodes. These types are retained for unit tests that
- * validate the parser's tree structure in isolation.
- *
- * ## Rationale: Why we do not use Jsoup
- *
- * 1. **Kotlin Multiplatform (KMP) Readiness**: Jsoup is a JVM-only library. Moving to a pure
- *    Kotlin custom parser enables future support for Kotlin Multiplatform.
- * 2. **Binary Footprint**: Jsoup is a heavy dependency. By implementing a lightweight parser,
- *    we reduce the library's binary footprint.
- * 3. **R8/Proguard Optimization**: Removing Jsoup eliminates complex consumer-side Proguard
- *    rules and potential shrinking bugs.
- * 4. **Single-Purpose Efficiency**: Jsoup is designed for full DOM parsing, sanitization, and
- *    querying. highlight.js outputs a very narrow, safe subset of HTML (nested `span` elements
- *    with `class` attributes, comments, and text). A single-pass tokenizer scoped to that subset
- *    avoids the allocation and CPU cost of a full DOM parser.
- */
-internal sealed interface CustomNode
-
-/**
- * Represents an HTML element node (e.g. `<span>`).
- *
- * **Legacy:** Not used on the library's hot path. See [CustomNode] for details.
- *
- * @property tagName The lowercase name of the HTML tag.
- * @property className The value of the class attribute.
- * @property childNodes The child nodes nested within this element.
- */
-internal class CustomElement(
-    val tagName: String,
-    val className: String,
-    val childNodes: List<CustomNode>,
-) : CustomNode
-
-/**
- * Represents a text node containing raw or entity-decoded text.
- *
- * **Legacy:** Not used on the library's hot path. See [CustomNode] for details.
- *
- * @property wholeText The text content of the node.
- */
-internal class CustomTextNode(
-    val wholeText: String,
-) : CustomNode
-
-// Hoisted to module scope to avoid per-call allocation (Phase 3.4).
-private val WHITESPACE_CHARS = charArrayOf(' ', '\t', '\r', '\n')
-
-/**
- * Parses a simple HTML fragment into a lightweight tree of [CustomNode]s.
- *
- * **Legacy:** This tree-building function is no longer used on the library's production hot path.
- * [HtmlToAnnotatedString] uses the more efficient SAX-style [parseAndBuild] and
- * [parseAndBuildBoth] functions instead, which parse HTML and build [AnnotatedString] in a single
- * pass without allocating intermediate tree nodes. This function is retained for unit tests that
- * validate the parser's tree output in isolation.
- *
- * Supports nested elements with class attributes, HTML comments, and the six most common named
- * entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&nbsp;`) plus numeric character
- * references (`&#NN;` and `&#xNN;`). Unknown named entities pass through as literal text.
- *
- * Recovery from malformed input favors leniency: unmatched closing tags bubble up to enclosing
- * scopes (HTML5-style implicit close), stray closers at the document root are silently skipped,
- * and a `<` with no matching `>` is treated as literal text.
- *
- * @param html HTML fragment (not a full document with `<html>`/`<body>` wrappers).
- * @return A list of parsed [CustomNode]s representing the root-level elements and text.
- */
-internal fun parseHtml(html: String): List<CustomNode> {
-    var index = 0
-    val length = html.length
-
-    fun peek(offset: Int = 0): Char? {
-        val i = index + offset
-        return if (i < length) html[i] else null
-    }
-
-    fun parseNodes(parentTag: String?): List<CustomNode> {
-        val nodes = mutableListOf<CustomNode>()
-        while (index < length) {
-            val c = peek() ?: break
-            if (c == '<') {
-                if (html.startsWith("<!--", index)) {
-                    val endComment = html.indexOf("-->", index + 4)
-                    if (endComment != -1) {
-                        index = endComment + 3
-                    } else {
-                        index = length
-                    }
-                    continue
-                }
-
-                if (peek(1) == '/') {
-                    val tagEnd = html.indexOf('>', index + 2)
-                    if (tagEnd == -1) {
-                        index = length
-                        break
-                    }
-                    // Compare closing tag name against parentTag in-place to avoid substring
-                    // allocation. Only allocate a String if the match fails and we need to
-                    // bubble up.
-                    if (parentTag != null && regionMatchesTrimmedLowercase(html, index + 2, tagEnd, parentTag)) {
-                        // Matching closer for our parent: consume it and return.
-                        index = tagEnd + 1
-                        break
-                    }
-                    if (parentTag == null) {
-                        // Stray closer at the document root - silently skip it.
-                        index = tagEnd + 1
-                        continue
-                    }
-                    // Mismatched closer for a nested element. Bubble up: leave the closer in place
-                    // (do NOT advance index) and break out so the enclosing parseNodes() call gets
-                    // a chance to match it. This mirrors the HTML5 implicit-close behavior Jsoup
-                    // produced for inputs like `<span><b>x</span>`: <b> closes when </span> appears.
-                    break
-                }
-
-                val tagEnd = findTagEnd(html, index + 1, length)
-                if (tagEnd == -1) {
-                    val text = html.substring(index)
-                    nodes.add(CustomTextNode(decodeEntities(text)))
-                    index = length
-                    break
-                }
-
-                // Parse tag content without allocating substrings for tagName/className
-                // when possible. The tag content is in html[index+1 .. tagEnd-1].
-                val contentStart = skipWhitespace(html, index + 1, tagEnd)
-                var contentEnd = tagEnd
-                // Check for self-closing
-                val isSelfClosing = contentEnd > contentStart && html[contentEnd - 1] == '/'
-                if (isSelfClosing) {
-                    contentEnd = skipWhitespaceReverse(html, contentStart, contentEnd - 1)
-                }
-
-                val firstSpace = indexOfWhitespace(html, contentStart, contentEnd)
-                val tagNameStart = contentStart
-                val tagNameEnd = if (firstSpace != -1) firstSpace else contentEnd
-
-                // Extract tagName - we need a String for CustomElement storage and recursive calls.
-                // Skip .lowercase() allocation if already lowercase (hljs always emits lowercase).
-                val tagName = lowercaseSubstring(html, tagNameStart, tagNameEnd)
-
-                var className = ""
-                if (firstSpace != -1) {
-                    className = extractClassAttrInPlace(html, firstSpace + 1, contentEnd)
-                }
-
-                index = tagEnd + 1
-
-                if (isSelfClosing) {
-                    nodes.add(CustomElement(tagName, className, emptyList()))
-                } else {
-                    val children = parseNodes(tagName)
-                    nodes.add(CustomElement(tagName, className, children))
-                }
-            } else {
-                val nextTag = html.indexOf('<', index)
-                val textEnd: Int
-                val sawAmpersand: Boolean
-                if (nextTag != -1) {
-                    textEnd = nextTag
-                    sawAmpersand = containsChar(html, index, nextTag, '&')
-                } else {
-                    textEnd = length
-                    sawAmpersand = containsChar(html, index, length, '&')
-                }
-                if (textEnd > index) {
-                    val text = html.substring(index, textEnd)
-                    nodes.add(CustomTextNode(if (sawAmpersand) decodeEntities(text) else text))
-                }
-                index = textEnd
-            }
-        }
-        return nodes
-    }
-
-    return parseNodes(null)
-}
+// A lightweight, custom HTML tokenizer and parser for highlight.js HTML output.
+//
+// The library's production hot path uses the SAX-style parseAndBuild and parseAndBuildBoth
+// functions, which parse HTML and emit spans directly into one or two AnnotatedString.Builder
+// instances in a single pass - no intermediate tree allocation.
+//
+// ## Rationale: Why we do not use Jsoup
+//
+// 1. Kotlin Multiplatform (KMP) Readiness: Jsoup is a JVM-only library. Moving to a pure Kotlin
+//    custom parser enables future support for Kotlin Multiplatform.
+// 2. Binary Footprint: Jsoup is a heavy dependency. By implementing a lightweight parser, we
+//    reduce the library's binary footprint.
+// 3. R8/Proguard Optimization: Removing Jsoup eliminates complex consumer-side Proguard rules
+//    and potential shrinking bugs.
+// 4. Single-Purpose Efficiency: Jsoup is designed for full DOM parsing, sanitization, and
+//    querying. highlight.js outputs a very narrow, safe subset of HTML (nested span elements
+//    with class attributes, comments, and text). A single-pass tokenizer scoped to that subset
+//    avoids the allocation and CPU cost of a full DOM parser.
 
 /**
  * SAX-style single-pass parse and build: parses the HTML and directly emits spans into a
- * single [AnnotatedString.Builder], eliminating the intermediate [CustomNode] tree.
+ * single [AnnotatedString.Builder] without allocating an intermediate tree.
  *
  * The caller is responsible for pushing/popping the base `.hljs` style outside this function.
  *
@@ -393,7 +225,7 @@ internal fun parseAndBuildBoth(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Internal helper functions - shared between parseHtml and SAX-style builders
+// Internal helper functions used by the SAX-style builders
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Module-level constants shared by the SAX builders and HtmlToAnnotatedString. */

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/HtmlToAnnotatedString.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/internal/HtmlToAnnotatedString.kt
@@ -13,13 +13,8 @@ import kotlin.time.measureTimedValue
 /**
  * Converts Highlight.js HTML output into a Compose [AnnotatedString].
  *
- * Uses a lightweight, custom HTML tokenizer/parser. When called via [convertTimed] or
- * [convertBothThemesTimed], uses a SAX-style single-pass approach that parses the HTML and
- * builds the [AnnotatedString] simultaneously, eliminating the intermediate tree of
- * [CustomNode] objects.
- *
- * The tree-building [parseHtml] function is still available for unit testing the parser
- * in isolation.
+ * Uses a lightweight, custom HTML tokenizer/parser with a SAX-style single-pass approach: the
+ * HTML is parsed and the [AnnotatedString] is built simultaneously, with no intermediate tree.
  */
 internal object HtmlToAnnotatedString {
     /**
@@ -41,10 +36,8 @@ internal object HtmlToAnnotatedString {
     /**
      * Converts highlighted HTML to [AnnotatedString] with per-stage timing data.
      *
-     * Uses a SAX-style single-pass approach: the HTML is parsed and the [AnnotatedString]
-     * is built simultaneously, eliminating the intermediate [CustomNode] tree. The
-     * `htmlParseDuration` field in the returned [TimedConvertResult] represents the combined
-     * parse+build time.
+     * The `htmlParseDuration` field in the returned [TimedConvertResult] represents the
+     * combined parse+build time of the SAX-style single pass.
      *
      * @param html HTML fragment output from highlight.js (not a full document)
      * @param colorMap Map of hljs class names to [SpanStyle], from [ThemeParser]


### PR DESCRIPTION
## Summary

Removes ~200 lines of dead code that's been lingering since PR #314 (`perf/parser-optimizations` in 0.30.1) — the legacy tree-building parser path that the SAX-style `parseAndBuild`/`parseAndBuildBoth` rewrite made obsolete.

The KDoc on `parseHtml` since 0.30.1 said the function was "retained for unit tests that validate the parser's tree output in isolation" — but no test actually references it.

## Why now: this was the cause of the Codecov badge drop

While investigating "why did the Codecov badge drop from ~76% to ~71%", I traced the regression to a single PR — #314 — which added the SAX path while keeping the legacy tree path around. Codecov reads `0%` coverage on the dead code and counts it against the total.

Coverage trajectory across recent main commits:

| Commit | Coverage | Note |
| --- | --- | --- |
| `7190e6f` (PR #313) | 76.38% | last commit before PR #314 |
| `0939e0e` (PR #314) | **71.72%** | SAX rewrite landed; legacy tree retained |
| ... slow drift ... | | |
| `589fd9f` (today) | 70.30% | accumulated drift |

This PR removes the dead path, which should restore most of that 4.7pp drop on the badge.

## Deletes

- `sealed interface CustomNode`
- `class CustomElement`
- `class CustomTextNode`
- `fun parseHtml` and its inner recursion
- `private val WHITESPACE_CHARS` (only used by `parseHtml`)

Plus stale references in:
- `HtmlParser.kt` file-level KDoc (drops the "Legacy tree node:" framing)
- `HtmlToAnnotatedString.kt` class KDoc + `convertTimed` KDoc

## Verification before deleting

```
grep -rnE '\bparseHtml\b|\bCustomNode\b|\bCustomElement\b|\bCustomTextNode\b' \
     compose-highlight/src/main compose-highlight/src/test \
     compose-highlight/src/androidTest
```

All hits were inside `HtmlParser.kt` itself — zero callers in production code, zero references in any test or fixture.

## Coverage impact (JVM unit tests, local `:jacocoTestReport`)

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `HtmlParserKt` LINE | 71.3% (246/345) | **87.5% (245/280)** | **+16.2pp** |
| `engine/internal` package LINE | 78.5% | **86.0%** | **+7.5pp** |
| Module total LINE | 44.5% | **46.0%** | **+1.5pp** |
| Module total INSTRUCTION | 32.4% | **33.0%** | +0.6pp |

Codecov badge combines unit + instrumented coverage; the gain there will be larger than the JVM-only numbers above and is expected to recover most of the -4.7pp drop introduced by PR #314.

## AAR size impact

- `classes.jar` entries: **109 → 98** (−11 classes — the 3 deleted top-level types plus the 8 anonymous-lambda closures from `parseHtml`'s `parseNodes` recursion).
- Compressed AAR size went from 565,890 → 572,480 bytes (small bump from R8 reorganization, not a regression — happens when class count changes).

## Test plan

- [x] `./gradlew :compose-highlight:formatKotlin` clean
- [x] `./gradlew :compose-highlight:lintKotlin` clean
- [x] `./gradlew :compose-highlight:testDebugUnitTest` — 602 tests, 0 failures, 12 expected skips (opt-in benchmark)
- [x] `./gradlew :compose-highlight:assembleDebug` succeeds
- [x] `./gradlew :compose-highlight:assembleRelease` succeeds
- [x] Local `jacocoTestReport` confirms the coverage gain shown above
- [x] CI green on this PR
- [x] Codecov delta visible on this PR