### PR TITLE
add: bundle GitHub and Dracula theme pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Added four more built-in bundled themes** - Added `github` and `alucard` for light mode,
+  plus `github-dark` and `dracula` for dark mode. These themes are now precompiled at build
+  time like the existing built-ins, exposed via `HighlightTheme.*()` factories and
+  `remember*Theme()` Compose helpers, and covered by parser parity tests.
+
 ### Removed
 
 - **Removed dead legacy `parseHtml` + `CustomNode` tree types from `HtmlParser.kt`** -

--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -1,7 +1,7 @@
 # buildSrc
 
 Build-time logic for the `compose-highlight` library. Currently houses the theme precompilation
-pipeline that turns the four bundled hljs CSS files into a Kotlin source map at build time, so
+pipeline that turns the bundled hljs CSS files into a Kotlin source map at build time, so
 the runtime parser is never invoked for built-in themes.
 
 > **Important:** read [`compose-highlight/MODULE.md`](../compose-highlight/MODULE.md#themes) for
@@ -11,7 +11,7 @@ the runtime parser is never invoked for built-in themes.
 ## Why this exists
 
 The runtime `ThemeParser` lives in `compose-highlight/src/main/kotlin/.../engine/ThemeParser.kt`
-and parses CSS into `Map<String, SpanStyle>`. For the four bundled themes shipped with the
+and parses CSS into `Map<String, SpanStyle>`. For the bundled themes shipped with the
 library, that work was happening on the device on first theme access:
 
 1. Open asset stream
@@ -22,7 +22,7 @@ library, that work was happening on the device on first theme access:
 
 That cost is small per theme but completely unnecessary for content the library already controls
 at build time. This module shifts that work into the Gradle build so the runtime cost for the
-four built-ins drops to "read a static field."
+built-ins drops to "read a static field."
 
 ## What it produces
 
@@ -44,7 +44,7 @@ internal object GeneratedThemes {
         "hljs-comment" to SpanStyle(color = Color(0xFF8E908C)),
         // ~40 more entries per theme
     )
-    // x4 themes
+    // x8 themes
 }
 ```
 
@@ -69,7 +69,7 @@ GeneratedThemes.class   classes.jar inside the published AAR
 ```
 
 The CSS files still ship in the AAR (about 4 KB total) so the runtime `fromAsset(...)` path
-keeps working if anyone references those asset paths directly. None of the four built-in factory
+keeps working if anyone references those asset paths directly. None of the built-in factory
 methods reads them at runtime.
 
 ## Module layout
@@ -95,7 +95,7 @@ A duplicate of the runtime parser's logic. It cannot share code with the runtime
   parser produces an intermediate (`ParsedStyle`) that the emitter renders as Kotlin source.
 
 The duplication is intentional and load-bearing. Both parsers must produce semantically identical
-output for the four bundled themes. The parity test
+output for the bundled themes. The parity test
 (`compose-highlight/.../GeneratedThemesParityTest.kt`) is the only thing keeping them in sync.
 
 ### `ThemeSourceEmitter`
@@ -217,7 +217,7 @@ ship via `fromAsset`.
 keeping the buildSrc parser and the runtime parser in sync. It runs as part of
 `testDebugUnitTest` and asserts:
 
-1. **Color map equality.** For each of the four bundled themes, `ThemeParser.parseAsset(...)` at
+1. **Color map equality.** For each of the bundled themes, `ThemeParser.parseAsset(...)` at
    test time produces a `Map<String, SpanStyle>` byte-identical to the precompiled
    `GeneratedThemes.*` constant.
 2. **Identity hash equality.** Each built-in factory's `HighlightTheme` equals

--- a/buildSrc/src/main/kotlin/dev/hossain/highlight/build/GenerateThemesTask.kt
+++ b/buildSrc/src/main/kotlin/dev/hossain/highlight/build/GenerateThemesTask.kt
@@ -11,10 +11,10 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Gradle task that reads the four bundled hljs theme CSS files and generates a Kotlin
+ * Gradle task that reads the bundled hljs theme CSS files and generates a Kotlin
  * source file containing precompiled `Map<String, SpanStyle>` constants.
  *
- * Inputs: the four CSS files (declared with [PathSensitivity.RELATIVE] so up-to-date
+ * Inputs: the CSS files (declared with [PathSensitivity.RELATIVE] so up-to-date
  * checks survive moves of the project root).
  *
  * Output: a single `GeneratedThemes.kt` under [outputDir].
@@ -63,6 +63,10 @@ abstract class GenerateThemesTask : DefaultTask() {
             "TOMORROW_NIGHT" to "tomorrow-night.css",
             "ATOM_ONE_DARK" to "atom-one-dark.css",
             "ATOM_ONE_LIGHT" to "atom-one-light.css",
+            "GITHUB" to "github.css",
+            "GITHUB_DARK" to "github-dark.css",
+            "DRACULA" to "dracula.css",
+            "ALUCARD" to "alucard.css",
         )
     }
 }

--- a/compose-highlight/MODULE.md
+++ b/compose-highlight/MODULE.md
@@ -33,7 +33,7 @@ Engine layer (public)
 Internal implementation
   |- WebViewManager                     Hidden WebView lifecycle + bridge page
   |- ThemeParser                        CSS selector to SpanStyle parsing (recursive descent)
-  |- GeneratedThemes                    Build-time precompiled color maps for the four built-ins
+  |- GeneratedThemes                    Build-time precompiled color maps for the bundled built-ins
   |- HtmlToAnnotatedString / HtmlParser  Custom HTML parsing and AnnotatedString conversion
   \- escapeForJs() / unescapeJsString() and related helpers
 ```
@@ -41,7 +41,7 @@ Internal implementation
 **How highlighting works:**
 1. `WebViewManager` loads `bridge.html` from `assets/compose-highlight/` into a hidden `WebView` on the Main thread.
 2. `HighlightEngine` serializes JS calls with a `Mutex` and invokes Highlight.js through `evaluateJavascript()`.
-3. `HighlightTheme` resolves its color map. The four built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) read from precompiled `GeneratedThemes` constants and never touch the runtime parser. Custom themes loaded through `HighlightTheme.fromAsset` or `HighlightTheme.fromCss` lazily parse their CSS via `ThemeParser` on first `colorMap` access.
+3. `HighlightTheme` resolves its color map. The built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `github`, `githubDark`, `dracula`, `alucard`) read from precompiled `GeneratedThemes` constants and never touch the runtime parser. Custom themes loaded through `HighlightTheme.fromAsset` or `HighlightTheme.fromCss` lazily parse their CSS via `ThemeParser` on first `colorMap` access.
 4. `HtmlToAnnotatedString` walks the returned HTML and applies theme styles to build a Compose `AnnotatedString`.
 
 **Shared engine via `HighlightThemeProvider`:** one provider creates one `HighlightEngine`, which means one hidden `WebView` for the entire subtree. `rememberHighlightEngine()` reuses that shared engine inside the provider and creates a standalone engine only when used outside one.
@@ -54,12 +54,12 @@ Three runtime paths produce a `HighlightTheme`. Pick the one that matches where 
 
 | Factory | Takes `Context`? | When to use |
 |---|---|---|
-| `HighlightTheme.tomorrow()` etc. | no | One of the four bundled themes. Precompiled at build time, no runtime CSS parsing. |
+| `HighlightTheme.tomorrow()` etc. | no | One of the bundled themes. Precompiled at build time, no runtime CSS parsing. |
 | `HighlightTheme.fromAsset(context, assetPath, name)` | yes | CSS file shipped in the consumer app's `assets/` folder. Parsed lazily on first `colorMap` access. |
 | `HighlightTheme.fromCss(cssText, name)` | no | CSS string fetched at runtime (network, generated, etc.). Parsed lazily. |
 | `HighlightTheme.fromColorMap(name, colorMap, ...)` | no | Theme built programmatically (Material 3 dynamic color, custom palettes, etc.). No parsing. |
 
-The four built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`) and their `remember*Theme()` Compose helpers do not require a `Context` because their color maps are baked into compiled bytecode at build time.
+The built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `github`, `githubDark`, `dracula`, `alucard`) and their `remember*Theme()` Compose helpers do not require a `Context` because their color maps are baked into compiled bytecode at build time.
 
 ### Built-in theme precompilation pipeline
 
@@ -78,7 +78,7 @@ GeneratedThemes.kt (gitignored)           build/generated/source/themes/main/...
 GeneratedThemes.class                     classes.jar inside the published AAR
 ```
 
-The four CSS files are still shipped in the AAR (about 4 KB total) so the runtime `fromAsset(...)` path keeps working for anyone who references those asset paths directly. None of the four built-in factory methods reads them at runtime.
+The bundled CSS files are still shipped in the AAR so the runtime `fromAsset(...)` path keeps working for anyone who references those asset paths directly. None of the built-in factory methods reads them at runtime.
 
 A parity test (`GeneratedThemesParityTest`) compares each precompiled map against `ThemeParser.parseAsset(...)` output for the matching CSS file, and asserts that the embedded `*_IDENTITY` hash equals what runtime `contentDigest64("asset", path)` would compute. The two parsers cannot be unified (the runtime parser depends on `androidx.compose.ui` types unavailable to a Gradle build classpath), so the parity test is the only thing keeping them in sync. If the test fails after editing the runtime parser, regenerate the file with `./gradlew :compose-highlight:generateThemes`. If it fails after editing the buildSrc parser, the buildSrc parser has drifted and that drift is the bug.
 
@@ -86,7 +86,7 @@ A parity test (`GeneratedThemesParityTest`) compares each precompiled map agains
 
 The codegen task (`buildSrc/.../GenerateThemesTask.kt`) does not auto-discover CSS files. It iterates a hardcoded `THEME_INPUTS` list, so dropping a CSS file into the assets folder ships it in the AAR but does not produce a precompiled constant or factory.
 
-To add a fifth built-in (replace `dracula` with the actual theme name):
+To add another built-in (replace `dracula` with the actual theme name):
 
 1. Drop the CSS at `compose-highlight/src/main/assets/compose-highlight/themes/dracula.css`.
 2. Add an entry to `THEME_INPUTS` in `buildSrc/src/main/kotlin/dev/hossain/highlight/build/GenerateThemesTask.kt`:
@@ -102,7 +102,7 @@ To add a fifth built-in (replace `dracula` with the actual theme name):
            contentIdentity = GeneratedThemes.DRACULA_IDENTITY,
        )
    ```
-4. Add `rememberDraculaTheme()` in `HighlightThemeProvider.kt` (the file holds both the provider composable and the four `rememberXxxTheme()` factories).
+4. Add `rememberDraculaTheme()` in `HighlightThemeProvider.kt` (the file holds both the provider composable and the `rememberXxxTheme()` factories).
 5. Add a parity test entry in `GeneratedThemesParityTest.kt`.
 
 The friction is intentional. A new built-in is an API decision, not "I dropped a file in the folder." Themes that should be available to consumers but do not warrant a built-in factory can stay as plain CSS in the assets folder and ship via `fromAsset`.
@@ -115,7 +115,7 @@ The friction is intentional. A new built-in is an API decision, not "I dropped a
 
 **`android.util.Log` is banned in library code paths used by JVM tests.** Android logging calls in JVM-tested paths trigger "Method ... in android.util.Log not mocked" failures.
 
-**Always prefer `applicationContext`.** `HighlightEngine` retains a `Context` through `WebViewManager`, and CSS-backed `HighlightTheme` factories (`fromAsset`) retain one through lazy providers. Internals defensively normalize to `applicationContext`, but call sites should still pass `context.applicationContext`. The four built-in theme factories (`tomorrow()` etc.) take no `Context` since they read from precompiled constants.
+**Always prefer `applicationContext`.** `HighlightEngine` retains a `Context` through `WebViewManager`, and CSS-backed `HighlightTheme` factories (`fromAsset`) retain one through lazy providers. Internals defensively normalize to `applicationContext`, but call sites should still pass `context.applicationContext`. The built-in theme factories (`tomorrow()` etc.) take no `Context` since they read from precompiled constants.
 
 **WebView work stays on the Main thread.** `WebViewManager` initialization, destruction, and JS evaluation are all dispatched to the Main thread. Theme parsing and HTML-to-`AnnotatedString` conversion run off the Main thread on `Dispatchers.Default`.
 

--- a/compose-highlight/SCREENSHOT_TESTS.md
+++ b/compose-highlight/SCREENSHOT_TESTS.md
@@ -10,13 +10,13 @@ a side-by-side diff image.
 
 | Suite | File | Goldens |
 |---|---|---|
-| Built-in themes | `BuiltInThemesScreenshotTest.kt` | 4 |
+| Built-in themes | `BuiltInThemesScreenshotTest.kt` | 8 |
 | Layout variants | `LayoutVariantsScreenshotTest.kt` | 4 |
 | Language breadth | `LanguageBreadthScreenshotTest.kt` | 3 |
 | Error fallback + custom placeholder | `ErrorAndPlaceholderScreenshotTest.kt` | 2 |
 | Editor (`SyntaxHighlightedTextEditor`) | `SyntaxHighlightedTextEditorScreenshotTest.kt` | 4 |
 
-The suite is intentionally small. It covers the four built-in themes, the four most-used layout
+The suite is intentionally small. It covers the eight built-in themes, the four most-used layout
 knobs (line numbers, headerless, label-only header, default), three languages that exercise
 breadth of token classes (Kotlin, Python, JSON), the two non-happy-path render states (error
 fallback, custom placeholder), and the editor's editor-specific surface (default light/dark

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/engine/HighlightThemeBuiltInTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/engine/HighlightThemeBuiltInTest.kt
@@ -27,14 +27,32 @@ class HighlightThemeBuiltInTest {
     }
 
     @Test
-    fun allFourThemesHaveDistinctNames() {
+    fun githubAndGitHubDarkHaveDifferentBackgroundColors() {
+        val light = HighlightTheme.github()
+        val dark = HighlightTheme.githubDark()
+        assertThat(light.backgroundColor).isNotEqualTo(dark.backgroundColor)
+    }
+
+    @Test
+    fun alucardAndDraculaHaveDifferentBackgroundColors() {
+        val light = HighlightTheme.alucard()
+        val dark = HighlightTheme.dracula()
+        assertThat(light.backgroundColor).isNotEqualTo(dark.backgroundColor)
+    }
+
+    @Test
+    fun allBuiltInThemesHaveDistinctNames() {
         val names =
             listOf(
                 HighlightTheme.tomorrow().name,
                 HighlightTheme.tomorrowNight().name,
                 HighlightTheme.atomOneDark().name,
                 HighlightTheme.atomOneLight().name,
+                HighlightTheme.github().name,
+                HighlightTheme.githubDark().name,
+                HighlightTheme.dracula().name,
+                HighlightTheme.alucard().name,
             )
-        assertThat(names.toSet()).hasSize(4)
+        assertThat(names.toSet()).hasSize(8)
     }
 }

--- a/compose-highlight/src/main/assets/compose-highlight/themes/alucard.css
+++ b/compose-highlight/src/main/assets/compose-highlight/themes/alucard.css
@@ -1,0 +1,102 @@
+/*!
+  Theme: Alucard Classic
+  Description: Light theme based on the official Dracula syntax highlighting specification.
+  Source: https://draculatheme.com/spec
+*/
+
+.hljs {
+  color: #1f1f1f;
+  background: #fffbeb;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula,
+.hljs-quote {
+  color: #6c664b;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-doctag,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #a3144d;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_,
+.hljs-function .hljs-title,
+.hljs-section {
+  color: #14710a;
+}
+
+.hljs-class .hljs-title,
+.hljs-built_in,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-selector-pseudo,
+.hljs-regexp {
+  color: #036a96;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-property,
+.hljs-tag {
+  color: #036a96;
+}
+
+.hljs-string,
+.hljs-meta .hljs-string,
+.hljs-addition {
+  color: #846e15;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id,
+.hljs-variable.constant_ {
+  color: #a34d14;
+}
+
+.hljs-variable,
+.hljs-params,
+.hljs-subst,
+.hljs-punctuation,
+.hljs-operator {
+  color: #1f1f1f;
+}
+
+.hljs-meta,
+.hljs-link {
+  color: #644ac9;
+}
+
+.hljs-deletion {
+  color: #cb3a2a;
+}
+
+.hljs-emphasis {
+  color: #644ac9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  color: #1f1f1f;
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}
+

--- a/compose-highlight/src/main/assets/compose-highlight/themes/dracula.css
+++ b/compose-highlight/src/main/assets/compose-highlight/themes/dracula.css
@@ -1,0 +1,102 @@
+/*!
+  Theme: Dracula Classic
+  Description: Dark theme based on the official Dracula syntax highlighting specification.
+  Source: https://draculatheme.com/spec
+*/
+
+.hljs {
+  color: #f8f8f2;
+  background: #282a36;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula,
+.hljs-quote {
+  color: #6272a4;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-doctag,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #ff79c6;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_,
+.hljs-function .hljs-title,
+.hljs-section {
+  color: #50fa7b;
+}
+
+.hljs-class .hljs-title,
+.hljs-built_in,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-selector-pseudo,
+.hljs-regexp {
+  color: #8be9fd;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-property,
+.hljs-tag {
+  color: #8be9fd;
+}
+
+.hljs-string,
+.hljs-meta .hljs-string,
+.hljs-addition {
+  color: #f1fa8c;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id,
+.hljs-variable.constant_ {
+  color: #ffb86c;
+}
+
+.hljs-variable,
+.hljs-params,
+.hljs-subst,
+.hljs-punctuation,
+.hljs-operator {
+  color: #f8f8f2;
+}
+
+.hljs-meta,
+.hljs-link {
+  color: #bd93f9;
+}
+
+.hljs-deletion {
+  color: #ff5555;
+}
+
+.hljs-emphasis {
+  color: #bd93f9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  color: #f8f8f2;
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}
+

--- a/compose-highlight/src/main/assets/compose-highlight/themes/github-dark.css
+++ b/compose-highlight/src/main/assets/compose-highlight/themes/github-dark.css
@@ -1,0 +1,103 @@
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+
+.hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #ff7b72;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: #d2a8ff;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #79c0ff;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: #a5d6ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  color: #ffa657;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: #8b949e;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: #7ee787;
+}
+
+.hljs-subst {
+  color: #c9d1d9;
+}
+
+.hljs-section {
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  color: #f2cc60;
+}
+
+.hljs-emphasis {
+  color: #c9d1d9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  color: #c9d1d9;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.hljs-deletion {
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+

--- a/compose-highlight/src/main/assets/compose-highlight/themes/github.css
+++ b/compose-highlight/src/main/assets/compose-highlight/themes/github.css
@@ -1,0 +1,103 @@
+/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+
+.hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #d73a49;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: #6f42c1;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #005cc5;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: #032f62;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  color: #e36209;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: #6a737d;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: #22863a;
+}
+
+.hljs-subst {
+  color: #24292e;
+}
+
+.hljs-section {
+  color: #005cc5;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  color: #735c0f;
+}
+
+.hljs-emphasis {
+  color: #24292e;
+  font-style: italic;
+}
+
+.hljs-strong {
+  color: #24292e;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.hljs-deletion {
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -20,17 +20,21 @@ import kotlin.time.measureTimedValue
  *
  * ## Built-in themes
  *
- * The four built-in themes are precompiled at build time - they do not parse CSS at
+ * The built-in themes are precompiled at build time - they do not parse CSS at
  * runtime and do not require a [Context]:
  *
  * ```kotlin
  * // Light themes
  * HighlightTheme.tomorrow()
  * HighlightTheme.atomOneLight()
+ * HighlightTheme.github()
+ * HighlightTheme.alucard()
  *
  * // Dark themes
  * HighlightTheme.tomorrowNight()
  * HighlightTheme.atomOneDark()
+ * HighlightTheme.githubDark()
+ * HighlightTheme.dracula()
  * ```
  *
  * ## Custom theme from an asset file
@@ -248,6 +252,66 @@ class HighlightTheme private constructor(
                 name = "atom-one-light",
                 colorMapProvider = { GeneratedThemes.ATOM_ONE_LIGHT },
                 contentIdentity = GeneratedThemes.ATOM_ONE_LIGHT_IDENTITY,
+            )
+
+        /**
+         * Built-in GitHub light theme.
+         *
+         * Uses a precompiled color map generated at build time from the bundled
+         * `github.css` - the runtime CSS parser is never invoked. No [Context] is required.
+         *
+         * @return A [HighlightTheme] backed by the bundled `github.css`.
+         */
+        fun github(): HighlightTheme =
+            HighlightTheme(
+                name = "github",
+                colorMapProvider = { GeneratedThemes.GITHUB },
+                contentIdentity = GeneratedThemes.GITHUB_IDENTITY,
+            )
+
+        /**
+         * Built-in GitHub Dark theme.
+         *
+         * Uses a precompiled color map generated at build time from the bundled
+         * `github-dark.css` - the runtime CSS parser is never invoked. No [Context] is required.
+         *
+         * @return A [HighlightTheme] backed by the bundled `github-dark.css`.
+         */
+        fun githubDark(): HighlightTheme =
+            HighlightTheme(
+                name = "github-dark",
+                colorMapProvider = { GeneratedThemes.GITHUB_DARK },
+                contentIdentity = GeneratedThemes.GITHUB_DARK_IDENTITY,
+            )
+
+        /**
+         * Built-in Dracula Classic dark theme.
+         *
+         * Uses a precompiled color map generated at build time from the bundled
+         * `dracula.css` - the runtime CSS parser is never invoked. No [Context] is required.
+         *
+         * @return A [HighlightTheme] backed by the bundled `dracula.css`.
+         */
+        fun dracula(): HighlightTheme =
+            HighlightTheme(
+                name = "dracula",
+                colorMapProvider = { GeneratedThemes.DRACULA },
+                contentIdentity = GeneratedThemes.DRACULA_IDENTITY,
+            )
+
+        /**
+         * Built-in Alucard Classic light theme.
+         *
+         * Uses a precompiled color map generated at build time from the bundled
+         * `alucard.css` - the runtime CSS parser is never invoked. No [Context] is required.
+         *
+         * @return A [HighlightTheme] backed by the bundled `alucard.css`.
+         */
+        fun alucard(): HighlightTheme =
+            HighlightTheme(
+                name = "alucard",
+                colorMapProvider = { GeneratedThemes.ALUCARD },
+                contentIdentity = GeneratedThemes.ALUCARD_IDENTITY,
             )
 
         /**

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
@@ -264,6 +264,78 @@ fun rememberAtomOneDarkTheme(): HighlightTheme = remember { HighlightTheme.atomO
 @Composable
 fun rememberAtomOneLightTheme(): HighlightTheme = remember { HighlightTheme.atomOneLight() }
 
+/**
+ * Creates and remembers the built-in GitHub light [HighlightTheme].
+ *
+ * Backed by a precompiled color map generated at build time, so no CSS parsing happens at
+ * runtime and no [android.content.Context] is needed.
+ *
+ * ```kotlin
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = rememberGitHubTheme(),
+ *     darkHighlightTheme  = rememberGitHubDarkTheme(),
+ * ) { ... }
+ * ```
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ */
+@Composable
+fun rememberGitHubTheme(): HighlightTheme = remember { HighlightTheme.github() }
+
+/**
+ * Creates and remembers the built-in GitHub Dark [HighlightTheme].
+ *
+ * Backed by a precompiled color map generated at build time, so no CSS parsing happens at
+ * runtime and no [android.content.Context] is needed.
+ *
+ * ```kotlin
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = rememberGitHubTheme(),
+ *     darkHighlightTheme  = rememberGitHubDarkTheme(),
+ * ) { ... }
+ * ```
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ */
+@Composable
+fun rememberGitHubDarkTheme(): HighlightTheme = remember { HighlightTheme.githubDark() }
+
+/**
+ * Creates and remembers the built-in Dracula Classic dark [HighlightTheme].
+ *
+ * Backed by a precompiled color map generated at build time, so no CSS parsing happens at
+ * runtime and no [android.content.Context] is needed.
+ *
+ * ```kotlin
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = rememberAlucardTheme(),
+ *     darkHighlightTheme  = rememberDraculaTheme(),
+ * ) { ... }
+ * ```
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ */
+@Composable
+fun rememberDraculaTheme(): HighlightTheme = remember { HighlightTheme.dracula() }
+
+/**
+ * Creates and remembers the built-in Alucard Classic light [HighlightTheme].
+ *
+ * Backed by a precompiled color map generated at build time, so no CSS parsing happens at
+ * runtime and no [android.content.Context] is needed.
+ *
+ * ```kotlin
+ * HighlightThemeProvider(
+ *     lightHighlightTheme = rememberAlucardTheme(),
+ *     darkHighlightTheme  = rememberDraculaTheme(),
+ * ) { ... }
+ * ```
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ */
+@Composable
+fun rememberAlucardTheme(): HighlightTheme = remember { HighlightTheme.alucard() }
+
 @Preview(showBackground = true)
 @Composable
 private fun HighlightThemeProviderPreview() {

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/GeneratedThemesParityTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/GeneratedThemesParityTest.kt
@@ -11,7 +11,7 @@ import org.robolectric.annotation.Config
 /**
  * Parity safety net for build-time theme precompilation.
  *
- * The build emits `GeneratedThemes.kt` from the four bundled CSS files using a parser in
+ * The build emits `GeneratedThemes.kt` from the bundled CSS files using a parser in
  * `buildSrc/` that mirrors the runtime [ThemeParser]. This test verifies the two stay in
  * sync by:
  * - Loading each bundled CSS file with the runtime parser at test time.
@@ -51,6 +51,26 @@ class GeneratedThemesParityTest {
         assertParity("compose-highlight/themes/atom-one-light.css", GeneratedThemes.ATOM_ONE_LIGHT)
     }
 
+    @Test
+    fun `github precompiled map equals runtime parse`() {
+        assertParity("compose-highlight/themes/github.css", GeneratedThemes.GITHUB)
+    }
+
+    @Test
+    fun `githubDark precompiled map equals runtime parse`() {
+        assertParity("compose-highlight/themes/github-dark.css", GeneratedThemes.GITHUB_DARK)
+    }
+
+    @Test
+    fun `dracula precompiled map equals runtime parse`() {
+        assertParity("compose-highlight/themes/dracula.css", GeneratedThemes.DRACULA)
+    }
+
+    @Test
+    fun `alucard precompiled map equals runtime parse`() {
+        assertParity("compose-highlight/themes/alucard.css", GeneratedThemes.ALUCARD)
+    }
+
     // ----- Identity parity -----
     // HighlightTheme.equals compares (name, contentIdentity). The runtime fromAsset factory
     // computes contentIdentity via contentDigest256("asset", path); the buildSrc generator
@@ -83,12 +103,38 @@ class GeneratedThemesParityTest {
     }
 
     @Test
+    fun `github identity matches runtime fromAsset hash`() {
+        assertThat(HighlightTheme.github())
+            .isEqualTo(HighlightTheme.fromAsset(context, "compose-highlight/themes/github.css", "github"))
+    }
+
+    @Test
+    fun `githubDark identity matches runtime fromAsset hash`() {
+        assertThat(HighlightTheme.githubDark())
+            .isEqualTo(HighlightTheme.fromAsset(context, "compose-highlight/themes/github-dark.css", "github-dark"))
+    }
+
+    @Test
+    fun `dracula identity matches runtime fromAsset hash`() {
+        assertThat(HighlightTheme.dracula())
+            .isEqualTo(HighlightTheme.fromAsset(context, "compose-highlight/themes/dracula.css", "dracula"))
+    }
+
+    @Test
+    fun `alucard identity matches runtime fromAsset hash`() {
+        assertThat(HighlightTheme.alucard())
+            .isEqualTo(HighlightTheme.fromAsset(context, "compose-highlight/themes/alucard.css", "alucard"))
+    }
+
+    @Test
     fun `different built-in themes are not equal`() {
         // Sanity: every built-in carries a distinct identity digest, so the equality check above
         // is meaningful - it fails if the buildSrc digest collides with anything other than the
         // matching runtime-computed value.
         assertThat(HighlightTheme.tomorrow()).isNotEqualTo(HighlightTheme.tomorrowNight())
         assertThat(HighlightTheme.atomOneLight()).isNotEqualTo(HighlightTheme.atomOneDark())
+        assertThat(HighlightTheme.github()).isNotEqualTo(HighlightTheme.githubDark())
+        assertThat(HighlightTheme.alucard()).isNotEqualTo(HighlightTheme.dracula())
     }
 
     private fun assertParity(

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/ThemeParserAssetTest.kt
@@ -46,6 +46,34 @@ class ThemeParserAssetTest {
     }
 
     @Test
+    fun `parseAsset loads github theme from bundled assets`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/github.css")
+        assertThat(result).isNotEmpty()
+        assertThat(result).containsKey(HljsSelectors.BASE)
+    }
+
+    @Test
+    fun `parseAsset loads github-dark theme from bundled assets`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/github-dark.css")
+        assertThat(result).isNotEmpty()
+        assertThat(result).containsKey(HljsSelectors.BASE)
+    }
+
+    @Test
+    fun `parseAsset loads dracula theme from bundled assets`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/dracula.css")
+        assertThat(result).isNotEmpty()
+        assertThat(result).containsKey(HljsSelectors.BASE)
+    }
+
+    @Test
+    fun `parseAsset loads alucard theme from bundled assets`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/alucard.css")
+        assertThat(result).isNotEmpty()
+        assertThat(result).containsKey(HljsSelectors.BASE)
+    }
+
+    @Test
     fun `parseAsset throws IOException for missing file`() {
         try {
             ThemeParser.parseAsset(context, "nonexistent.css")
@@ -133,6 +161,38 @@ class ThemeParserAssetTest {
         val hljsStyle = result[HljsSelectors.BASE]
         assertThat(hljsStyle).isNotNull()
         assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFfafafa))
+    }
+
+    @Test
+    fun `parseAsset github theme background is correct light color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/github.css")
+        val hljsStyle = result[HljsSelectors.BASE]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFffffff))
+    }
+
+    @Test
+    fun `parseAsset github-dark theme background is correct dark color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/github-dark.css")
+        val hljsStyle = result[HljsSelectors.BASE]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF0d1117))
+    }
+
+    @Test
+    fun `parseAsset dracula theme background is correct dark color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/dracula.css")
+        val hljsStyle = result[HljsSelectors.BASE]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFF282a36))
+    }
+
+    @Test
+    fun `parseAsset alucard theme background is correct light color`() {
+        val result = ThemeParser.parseAsset(context, "compose-highlight/themes/alucard.css")
+        val hljsStyle = result[HljsSelectors.BASE]
+        assertThat(hljsStyle).isNotNull()
+        assertThat(hljsStyle!!.background).isEqualTo(Color(0xFFfffbeb))
     }
 
     // ----- 1c-light theme regression - named colors and 4-digit hex -----

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/screenshot/BuiltInThemesScreenshotTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/screenshot/BuiltInThemesScreenshotTest.kt
@@ -20,7 +20,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 /**
- * Screenshot regression coverage for the four bundled built-in themes. Each test renders the
+ * Screenshot regression coverage for the bundled built-in themes. Each test renders the
  * same Kotlin code snippet so visual diffs across themes only reflect color-map differences.
  *
  * Goldens live under `src/test/snapshots/images/theme_*.png`.
@@ -53,6 +53,26 @@ class BuiltInThemesScreenshotTest {
     @Test
     fun theme_atom_one_light() {
         captureWithTheme(name = "theme_atom_one_light", theme = HighlightTheme.atomOneLight())
+    }
+
+    @Test
+    fun theme_github() {
+        captureWithTheme(name = "theme_github", theme = HighlightTheme.github())
+    }
+
+    @Test
+    fun theme_github_dark() {
+        captureWithTheme(name = "theme_github_dark", theme = HighlightTheme.githubDark())
+    }
+
+    @Test
+    fun theme_dracula() {
+        captureWithTheme(name = "theme_dracula", theme = HighlightTheme.dracula())
+    }
+
+    @Test
+    fun theme_alucard() {
+        captureWithTheme(name = "theme_alucard", theme = HighlightTheme.alucard())
     }
 
     private fun captureWithTheme(

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,8 @@ That's it. `HighlightThemeProvider` automatically picks Tomorrow (light) or Tomo
 
 - **Wide language coverage** - use any language supported by the bundled Highlight.js build
 - **Light + dark themes** - automatic system-mode switching, or manual override
-- **Built-in themes** - Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light
+- **Built-in themes** - Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light, GitHub,
+  GitHub Dark, Dracula, Alucard
 - **Custom themes** - load any Highlight.js CSS from `assets/`, raw CSS string, or a `Map<String, SpanStyle>`
 - **Slots** - replace the language badge and copy button with any composable
 - **Line numbers** - optional gutter with configurable width and color

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -10,11 +10,15 @@ Full API in Dokka:
 - [`rememberTomorrowNightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-night-theme.html)
 - [`rememberAtomOneDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-dark-theme.html)
 - [`rememberAtomOneLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-light-theme.html)
+- [`rememberGitHubTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-git-hub-theme.html)
+- [`rememberGitHubDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-git-hub-dark-theme.html)
+- [`rememberDraculaTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-dracula-theme.html)
+- [`rememberAlucardTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-alucard-theme.html)
 
 ## When to use each theme source
 
-- Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`): fastest setup,
-  precompiled maps, no CSS parsing at runtime.
+- Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `github`,
+  `githubDark`, `dracula`, `alucard`): fastest setup, precompiled maps, no CSS parsing at runtime.
 - `fromAsset(...)`: best for shipping a highlight.js CSS file with your app.
 - `fromCss(...)`: useful when CSS comes from network, config, or generated text.
 - `fromColorMap(...)`: best when you want full programmatic control, for example Material 3
@@ -35,6 +39,11 @@ HighlightThemeProvider(
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) { ... }
 ```
+
+Other bundled pairs now available:
+
+- `rememberGitHubTheme()` + `rememberGitHubDarkTheme()`
+- `rememberAlucardTheme()` + `rememberDraculaTheme()`
 
 ## Custom theme from asset CSS
 


### PR DESCRIPTION
## Summary
- add four new bundled built-in themes: github, github-dark, dracula, and alucard
- expose new HighlightTheme factories and remember*Theme helpers
- extend parser parity tests, asset tests, screenshot coverage, and docs for the expanded built-in set

## Verification
- ./gradlew :compose-highlight:generateThemes
- ./gradlew formatKotlin
- ./gradlew :compose-highlight:test
- ./gradlew :compose-highlight:assembleDebug :sample:assembleDebug
