### PR TITLE
refactor: rename rememberTomorrowTheme to rememberTomorrowLightTheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
   (`rememberGithubLightTheme`, `rememberGithubDarkTheme`, `rememberDraculaDarkTheme`, and `rememberAlucardLightTheme`).
   Fixes #381.
 
+### Changed (Breaking)
+
+- **Renamed `rememberTomorrowTheme()` to `rememberTomorrowLightTheme()`** - Renamed the helper function
+  to ensure naming consistency across all light/dark built-in theme helper composables. Fixes #384.
+
 ### Removed
 
 - **Removed dead legacy `parseHtml` + `CustomNode` tree types from `HtmlParser.kt`** -

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies {
 
 ```kotlin
 HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme = rememberTomorrowNightTheme(),
 ) {
     SyntaxHighlightedCode(

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt
@@ -88,7 +88,7 @@ import kotlin.time.measureTimedValue
  * @Composable
  * fun MyCodeBlock(code: String) {
  *     val engine = rememberHighlightEngine()
- *     val theme = rememberTomorrowTheme()
+ *     val theme = rememberTomorrowLightTheme()
  *     var highlighted by remember(code) { mutableStateOf<AnnotatedString?>(null) }
  *     LaunchedEffect(code) {
  *         engine.highlight(code, "kotlin", theme).onSuccess { highlighted = it.annotated }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightLanguage.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightLanguage.kt
@@ -17,7 +17,7 @@ import java.util.Locale
  * SyntaxHighlightedCode(
  *     code = snippet,
  *     language = language,
- *     theme = rememberTomorrowTheme(),
+ *     theme = rememberTomorrowLightTheme(),
  * )
  * ```
  */

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemedHighlightResult.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/ThemedHighlightResult.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.text.AnnotatedString
  * val result by rememberHighlightedCodeBothThemes(
  *     code       = code,
  *     language   = "kotlin",
- *     lightTheme = rememberTomorrowTheme(),
+ *     lightTheme = rememberTomorrowLightTheme(),
  *     darkTheme  = rememberTomorrowNightTheme(),
  * )
  * val text = if (isDark) result?.dark else result?.light

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
@@ -78,13 +78,13 @@ val LocalDarkHighlightTheme =
  *
  * ## Typical setup
  *
- * Prefer [rememberTomorrowTheme] and [rememberTomorrowNightTheme] as the default pattern so theme
+ * Prefer [rememberTomorrowLightTheme] and [rememberTomorrowNightTheme] as the default pattern so theme
  * instances stay stable across recompositions:
  *
  * ```kotlin
  * // At the top of your screen composable:
  * HighlightThemeProvider(
- *     lightHighlightTheme = rememberTomorrowTheme(),
+ *     lightHighlightTheme = rememberTomorrowLightTheme(),
  *     darkHighlightTheme  = rememberTomorrowNightTheme(),
  * ) {
  *     // All SyntaxHighlightedCode composables inside here share 1 WebView
@@ -122,7 +122,7 @@ val LocalDarkHighlightTheme =
  * ```kotlin
  * HighlightThemeProvider(
  *     darkTheme           = userPrefersDark,
- *     lightHighlightTheme = rememberTomorrowTheme(),
+ *     lightHighlightTheme = rememberTomorrowLightTheme(),
  *     darkHighlightTheme  = rememberTomorrowNightTheme(),
  * ) { ... }
  * ```
@@ -161,7 +161,7 @@ val LocalDarkHighlightTheme =
 @Composable
 fun HighlightThemeProvider(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    lightHighlightTheme: HighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme: HighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme: HighlightTheme = rememberTomorrowNightTheme(),
     content: @Composable () -> Unit,
 ) {
@@ -200,7 +200,7 @@ fun HighlightThemeProvider(
  *
  * ```kotlin
  * HighlightThemeProvider(
- *     lightHighlightTheme = rememberTomorrowTheme(),
+ *     lightHighlightTheme = rememberTomorrowLightTheme(),
  *     darkHighlightTheme  = rememberAtomOneDarkTheme(),
  * ) { ... }
  * ```
@@ -208,7 +208,7 @@ fun HighlightThemeProvider(
  * @return A stable [HighlightTheme] instance remembered across recompositions.
  */
 @Composable
-fun rememberTomorrowTheme(): HighlightTheme = remember { HighlightTheme.tomorrow() }
+fun rememberTomorrowLightTheme(): HighlightTheme = remember { HighlightTheme.tomorrow() }
 
 /**
  * Creates and remembers the built-in Base16 Tomorrow Night (dark) [HighlightTheme].
@@ -220,7 +220,7 @@ fun rememberTomorrowTheme(): HighlightTheme = remember { HighlightTheme.tomorrow
  * val result by rememberHighlightedCodeBothThemes(
  *     code       = code,
  *     language   = "kotlin",
- *     lightTheme = rememberTomorrowTheme(),
+ *     lightTheme = rememberTomorrowLightTheme(),
  *     darkTheme  = rememberTomorrowNightTheme(),
  * )
  * ```
@@ -336,7 +336,7 @@ fun rememberAlucardLightTheme(): HighlightTheme = remember { HighlightTheme.aluc
 @Composable
 private fun HighlightThemeProviderPreview() {
     HighlightThemeProvider(
-        lightHighlightTheme = rememberTomorrowTheme(),
+        lightHighlightTheme = rememberTomorrowLightTheme(),
         darkHighlightTheme = rememberTomorrowNightTheme(),
     ) {
         SyntaxHighlightedCode(

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberHighlightedCode.kt
@@ -52,7 +52,7 @@ import dev.hossain.highlight.engine.ThemedHighlightResult
  * every recomposition. Or use the built-in convenience functions which handle this internally:
  *
  * ```kotlin
- * val highlighted by rememberHighlightedCode(code, "kotlin", rememberTomorrowTheme())
+ * val highlighted by rememberHighlightedCode(code, "kotlin", rememberTomorrowLightTheme())
  * ```
  *
  * For light/dark toggling without re-highlighting, prefer [rememberHighlightedCodeBothThemes].
@@ -149,7 +149,7 @@ fun rememberHighlightedCode(
  *     val result by rememberHighlightedCodeBothThemes(
  *         code       = code,
  *         language   = "kotlin",
- *         lightTheme = rememberTomorrowTheme(),
+ *         lightTheme = rememberTomorrowLightTheme(),
  *         darkTheme  = rememberTomorrowNightTheme(),
  *     )
  *     val text = if (isDark) result?.dark else result?.light

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCode.kt
@@ -72,7 +72,7 @@ private val LineNumberGutterSpacing = 8.dp
  *
  * ```kotlin
  * HighlightThemeProvider(
- *     lightHighlightTheme = rememberTomorrowTheme(),
+ *     lightHighlightTheme = rememberTomorrowLightTheme(),
  *     darkHighlightTheme  = rememberAtomOneDarkTheme(),
  * ) {
  *     SyntaxHighlightedCode(
@@ -89,7 +89,7 @@ private val LineNumberGutterSpacing = 8.dp
  * SyntaxHighlightedCode(
  *     code     = "SELECT * FROM users WHERE active = 1",
  *     language = "sql",
- *     theme    = rememberTomorrowTheme(),
+ *     theme    = rememberTomorrowLightTheme(),
  * )
  * ```
  *
@@ -467,7 +467,7 @@ private fun SyntaxHighlightedCodeDefaultPreview() {
     SyntaxHighlightedCode(
         code = "fun hello() = println(\"Hello!\")",
         language = "kotlin",
-        theme = rememberTomorrowTheme(),
+        theme = rememberTomorrowLightTheme(),
     )
 }
 
@@ -478,7 +478,7 @@ private fun SyntaxHighlightedCodeLineNumbersPreview() {
         code = "fun hello() = println(\"Hello!\")\nval x = 42\nprintln(x)",
         language = "kotlin",
         showLineNumbers = true,
-        theme = rememberTomorrowTheme(),
+        theme = rememberTomorrowLightTheme(),
     )
 }
 
@@ -488,6 +488,6 @@ private fun SyntaxHighlightedCodeHeaderPreview() {
     SyntaxHighlightedCode(
         code = "fun hello() = println(\"Hello!\")",
         language = "kotlin",
-        theme = rememberTomorrowTheme(),
+        theme = rememberTomorrowLightTheme(),
     )
 }

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditor.kt
@@ -91,7 +91,7 @@ import dev.hossain.highlight.engine.HighlightTheme
  *
  * ```kotlin
  * HighlightThemeProvider(
- *     lightHighlightTheme = rememberTomorrowTheme(),
+ *     lightHighlightTheme = rememberTomorrowLightTheme(),
  *     darkHighlightTheme  = rememberTomorrowNightTheme(),
  * ) {
  *     var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
@@ -114,7 +114,7 @@ import dev.hossain.highlight.engine.HighlightTheme
  *     value         = editorValue,
  *     onValueChange = { editorValue = it },
  *     language      = "sql",
- *     theme         = rememberTomorrowTheme(),
+ *     theme         = rememberTomorrowLightTheme(),
  * )
  * ```
  *
@@ -403,6 +403,6 @@ private fun SyntaxHighlightedTextEditorPreview() {
         value = TextFieldValue("fun main() {\n    println(\"Hello world!\")\n}"),
         onValueChange = {},
         language = "kotlin",
-        theme = rememberTomorrowTheme(),
+        theme = rememberTomorrowLightTheme(),
     )
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,13 +20,13 @@ Place `HighlightThemeProvider` once near the root of your composition - inside `
 
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
 
 setContent {
     MyAppTheme {
         HighlightThemeProvider(
-            lightHighlightTheme = rememberTomorrowTheme(),
+            lightHighlightTheme = rememberTomorrowLightTheme(),
             darkHighlightTheme  = rememberTomorrowNightTheme(),
         ) {
             MyAppContent()

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -17,11 +17,11 @@ Each extra standalone engine adds roughly **~37 ms** to average highlight time a
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 // Wrap once, high up in your composition tree
 HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) {
     LazyColumn {
@@ -102,7 +102,7 @@ viewModelScope.launch {
 ```
 
 Inside Compose, use `rememberHighlightedCodeBothThemes(code, language)` - or pass
-`rememberTomorrowTheme()` / `rememberTomorrowNightTheme()` to `highlightBothThemes`
+`rememberTomorrowLightTheme()` / `rememberTomorrowNightTheme()` to `highlightBothThemes`
 when you already have an `engine` from `rememberHighlightEngine()`.
 
 ## Timing callbacks

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -6,7 +6,7 @@
 
 | Theme | Style | Helper |
 | --- | --- | --- |
-| Tomorrow | Light | `rememberTomorrowTheme()` |
+| Tomorrow | Light | `rememberTomorrowLightTheme()` |
 | Tomorrow Night | Dark | `rememberTomorrowNightTheme()` |
 | Atom One Dark | Dark | `rememberAtomOneDarkTheme()` |
 | Atom One Light | Light | `rememberAtomOneLightTheme()` |
@@ -29,10 +29,10 @@ Pass a light and dark theme to `HighlightThemeProvider`. It picks the right one 
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) {
     SyntaxHighlightedCode(code = snippet, language = "kotlin")
@@ -116,9 +116,9 @@ For one-off use - pass the theme directly:
 
 ```kotlin
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
-val theme = rememberTomorrowTheme()
+val theme = rememberTomorrowLightTheme()
 SyntaxHighlightedCode(
     code     = snippet,
     language = "python",
@@ -135,10 +135,10 @@ For zero-latency theme switching, tokenize once and apply both color maps. Use `
 ```kotlin
 import dev.hossain.highlight.ui.rememberHighlightEngine
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 val engine     = rememberHighlightEngine()
-val lightTheme = rememberTomorrowTheme()
+val lightTheme = rememberTomorrowLightTheme()
 val darkTheme  = rememberTomorrowNightTheme()
 val fallback   = remember(code) { AnnotatedString(code) }
 val themedPair by produceState(fallback to fallback, code, lightTheme, darkTheme) {

--- a/docs/reference/highlight-engine.md
+++ b/docs/reference/highlight-engine.md
@@ -80,12 +80,12 @@ class CodeViewModel(application: Application) : AndroidViewModel(application) {
 
 ```kotlin
 import dev.hossain.highlight.ui.rememberHighlightEngine
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 @Composable
 fun MyCodeBlock(code: String) {
     val engine = rememberHighlightEngine()
-    val theme  = rememberTomorrowTheme()
+    val theme  = rememberTomorrowLightTheme()
     var highlighted by remember(code) { mutableStateOf<AnnotatedString?>(null) }
 
     LaunchedEffect(code) {
@@ -118,7 +118,7 @@ viewModelScope.launch {
 ```
 
 !!! note
-    Inside `@Composable` functions, prefer `rememberTomorrowTheme()` /
+    Inside `@Composable` functions, prefer `rememberTomorrowLightTheme()` /
     `rememberTomorrowNightTheme()` so the theme is remembered across recompositions.
     The `HighlightTheme.tomorrow()` and `HighlightTheme.tomorrowNight()` factories above
     are the non-composable equivalents - safe to call from a ViewModel or repository.

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -6,7 +6,7 @@ pipeline.
 Full API in Dokka:
 
 - [`HighlightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.engine/-highlight-theme/index.html)
-- [`rememberTomorrowTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-theme.html)
+- [`rememberTomorrowLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-light-theme.html)
 - [`rememberTomorrowNightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-tomorrow-night-theme.html)
 - [`rememberAtomOneDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-dark-theme.html)
 - [`rememberAtomOneLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-atom-one-light-theme.html)
@@ -32,10 +32,10 @@ recompositions.
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) { ... }
 ```

--- a/docs/reference/syntax-highlighted-code.md
+++ b/docs/reference/syntax-highlighted-code.md
@@ -38,10 +38,10 @@ Full API in Dokka:
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 HighlightThemeProvider(
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) {
     SyntaxHighlightedCode(
@@ -56,12 +56,12 @@ HighlightThemeProvider(
 
 ```kotlin
 import dev.hossain.highlight.ui.SyntaxHighlightedCode
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 SyntaxHighlightedCode(
     code     = "SELECT * FROM users WHERE active = 1",
     language = "sql",
-    theme    = rememberTomorrowTheme(),
+    theme    = rememberTomorrowLightTheme(),
 )
 ```
 
@@ -155,11 +155,11 @@ reduces warm-up cost and memory overhead.
 ```kotlin
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 HighlightThemeProvider(
     darkTheme           = userPrefersDark,
-    lightHighlightTheme = rememberTomorrowTheme(),
+    lightHighlightTheme = rememberTomorrowLightTheme(),
     darkHighlightTheme  = rememberTomorrowNightTheme(),
 ) { ... }
 ```

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -86,7 +86,7 @@ import dev.hossain.highlight.ui.ExperimentalHighlightApi
 import dev.hossain.highlight.ui.HighlightThemeProvider
 import dev.hossain.highlight.ui.SyntaxHighlightedTextEditor
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
-import dev.hossain.highlight.ui.rememberTomorrowTheme
+import dev.hossain.highlight.ui.rememberTomorrowLightTheme
 
 @OptIn(ExperimentalHighlightApi::class)
 @Composable
@@ -94,7 +94,7 @@ fun EditorScreen() {
     var editorValue by remember { mutableStateOf(TextFieldValue("fun hello() = println(\"Hello!\")")) }
 
     HighlightThemeProvider(
-        lightHighlightTheme = rememberTomorrowTheme(),
+        lightHighlightTheme = rememberTomorrowLightTheme(),
         darkHighlightTheme  = rememberTomorrowNightTheme(),
     ) {
         SyntaxHighlightedTextEditor(
@@ -123,7 +123,7 @@ fun SqlEditor() {
         value         = editorValue,
         onValueChange = { editorValue = it },
         language      = "sql",
-        theme         = rememberTomorrowTheme(),
+        theme         = rememberTomorrowLightTheme(),
     )
 }
 ```


### PR DESCRIPTION
This PR renames the built-in composable remember helper `rememberTomorrowTheme()` to `rememberTomorrowLightTheme()` to ensure naming consistency across all light/dark suffix theme helpers.

### Changes
1. **API Update**:
   - Renamed `rememberTomorrowTheme()` to `rememberTomorrowLightTheme()` in `HighlightThemeProvider.kt`.
2. **KDoc, Code Comments, & Previews**:
   - Updated all class/function-level KDocs, preview methods, and code blocks references across the library source files.
3. **User Documentation**:
   - Updated references in `README.md`, `docs/getting-started.md`, `docs/guides/performance.md`, `docs/guides/theming.md`, and various reference pages under `docs/reference/`.
4. **Changelog**:
   - Logged the breaking change entry in `CHANGELOG.md` under `[Unreleased]` / `### Changed (Breaking)`.

Fixes #384