### PR TITLE
fix: use bundled GitHub and Dracula themes in sample picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Updated the sample app's custom theme demo to Tokyo Night** - Since GitHub and GitHub Dark are
+  now bundled built-in themes, the sample app no longer loads GitHub CSS assets as its custom
+  `fromAsset()` example. The sample theme picker and theme-creation section now use
+  `tokyo-night-light` and `tokyo-night-dark` instead.
+
 ### Added
 
 - **Added four new built-in themes: GitHub, GitHub Dark, Dracula, and Alucard** - Emitted precompiled

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleData.kt
@@ -110,12 +110,12 @@ httpApiClient.get("/users")
 internal val FROM_ASSET_SNIPPET =
     """
 // Save any highlight.js CSS theme file in your app's assets:
-//   app/src/main/assets/themes/dracula.min.css
+//   app/src/main/assets/themes/tokyo-night-dark.min.css
 
 val theme = HighlightTheme.fromAsset(
     context   = context.applicationContext,
-    assetPath = "themes/dracula.min.css",
-    name      = "dracula",
+    assetPath = "themes/tokyo-night-dark.min.css",
+    name      = "tokyo-night-dark",
 )
 
 // Pass the theme directly to the composable

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -68,13 +68,13 @@ import kotlinx.coroutines.withContext
  *
  * Uses [HighlightThemeProvider] to supply the active theme to all [SyntaxHighlightedCode]
  * composables in the tree. The top bar provides two controls:
- * - **Theme picker** (🎨): cycles between GitHub (custom asset-based), Tomorrow, and Atom One
- *   theme families, demonstrating both built-in and user-provided themes.
+ * - **Theme picker** (🎨): cycles between Tokyo Night (custom asset-based), GitHub, Dracula,
+ *   Tomorrow, and Atom One theme families, demonstrating both built-in and user-provided themes.
  * - **Light/Dark toggle**: switches between the light and dark variant of the selected theme.
  *
- * The GitHub themes are loaded from the sample app's own assets via [HighlightTheme.fromAsset],
- * showcasing that library users can bundle any Highlight.js CSS and use it as a theme - they are
- * not limited to the built-in options.
+ * The Tokyo Night themes are loaded from the sample app's own assets via
+ * [HighlightTheme.fromAsset], showcasing that library users can bundle any Highlight.js CSS and
+ * use it as a theme - they are not limited to the built-in options.
  *
  * Sections are organized into tabs:
  * - **Languages**: highlights SAMPLES across different languages (original demo).
@@ -112,7 +112,7 @@ internal fun SampleScreen(viewModel: SampleViewModel = viewModel()) {
             }
         }
 
-    var selectedThemeIndex by rememberSaveable { mutableIntStateOf(2) } // Atom One
+    var selectedThemeIndex by rememberSaveable { mutableIntStateOf(4) } // Atom One
     val activePair = themePairs[selectedThemeIndex.coerceIn(themePairs.indices)]
     val tabs = DemoTab.all
 

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleViewModel.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleViewModel.kt
@@ -23,13 +23,23 @@ internal class SampleViewModel(
         loadCodeSamples(application)
     }
 
-    /** All available theme pairs - GitHub uses fromAsset() to demonstrate custom themes. */
+    /** All available theme pairs - Tokyo Night uses fromAsset() to demonstrate custom themes. */
     val themePairs: List<ThemePair> by lazy {
         listOf(
             ThemePair(
+                name = "Tokyo Night",
+                light = HighlightTheme.fromAsset(application, "themes/tokyo-night-light.min.css", "tokyo-night-light"),
+                dark = HighlightTheme.fromAsset(application, "themes/tokyo-night-dark.min.css", "tokyo-night-dark"),
+            ),
+            ThemePair(
                 name = "GitHub",
-                light = HighlightTheme.fromAsset(application, "themes/github.css", "github"),
-                dark = HighlightTheme.fromAsset(application, "themes/github-dark.css", "github-dark"),
+                light = HighlightTheme.githubLight(),
+                dark = HighlightTheme.githubDark(),
+            ),
+            ThemePair(
+                name = "Dracula",
+                light = HighlightTheme.alucardLight(),
+                dark = HighlightTheme.draculaDark(),
             ),
             ThemePair(
                 name = "Tomorrow",

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/ThemeCreationSection.kt
@@ -141,7 +141,7 @@ internal fun ThemeCreationSection() {
             text =
                 "Save any highlight.js-compatible CSS file anywhere under your app's assets/ " +
                     "directory and load it at runtime with HighlightTheme.fromAsset(). " +
-                    "The code block below shows you exactly how to do it:",
+                    "This sample now uses Tokyo Night as that custom asset-loaded example:",
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(horizontal = 4.dp),
         )


### PR DESCRIPTION
## Summary
- switch the sample app custom asset-loaded demo pair from GitHub to Tokyo Night
- add bundled GitHub and Dracula theme families to the top-level sample theme picker
- update sample copy and changelog to reflect the new built-in vs custom-theme split

## Verification
- ./gradlew formatKotlin
- ./gradlew :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test

Fixes #385
