### PR TITLE
chore: prepare release 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-04
+
 ### Changed
 
 - **Updated the sample app's custom theme demo to Tokyo Night** - Since GitHub and GitHub Dark are

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.31.0")
+    implementation("dev.hossain:compose-highlight:0.32.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.32.0 - New precompiled themes, spec compliance, and API cleanups
+
+- Added four new built-in themes (GitHub, GitHub Dark, Dracula, and Alucard) with precompiled color maps for fast loading without Context
+- Aligned Dracula and Alucard built-in themes to be fully spec-compliant with correct color and selector mappings
+- Renamed `rememberTomorrowTheme()` to `rememberTomorrowLightTheme()` for naming consistency across light/dark suffix theme helpers
+- Removed dead legacy parser code from `HtmlParser.kt` to shrink AAR size and improve code coverage metrics
+
 ### 0.31.0 - Scroll hoisting, preview fixes, and CI hardening
 
 - Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor`
@@ -49,15 +56,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
   opt-in JVM microbenchmark (`HtmlParserBenchmark`)
 - Prepared the codebase for Kotlin Multiplatform (KMP)
 
-### 0.29.0 - Tab and auto-indent support in text editor
-
-- Added `indentation`, `autoIndentEnabled`, and `tabKeyInterceptionEnabled`
-  parameters to `SyntaxHighlightedTextEditor`
-- Added Tab key hardware interception to insert custom indentation instead of
-  shifting focus
-- Added auto-indentation to copy the previous line's leading whitespace on
-  hardware and virtual keyboards
-- Intercepted arrow keys to prevent focus from escaping the editor boundaries
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.31.0")
+    implementation("dev.hossain:compose-highlight:0.32.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.31.0")
+    implementation("dev.hossain:compose-highlight:0.32.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.31.0
+VERSION_NAME=0.32.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 38
-        versionName = "0.31.0"
+        versionCode = 39
+        versionName = "0.32.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
This PR prepares the library release version `0.32.0`.

### Changes
- Updated version name and code in Gradle configuration and Python project manifest.
- Promoted `[Unreleased]` changes to `[0.32.0] - 2026-07-04` in `CHANGELOG.md`.
- Updated curated highlights block in `docs/changelog.md` to keep the last 5 releases.