### PR TITLE
docs: fill documentation gaps found in post-0.32.0 audit

### DIFF
--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -201,3 +201,28 @@ SyntaxHighlightedCode(
     },
 )
 ```
+
+## Fallback background and text colors
+
+When you use a custom `HighlightTheme` (via `fromAsset()` or `fromCss()`) whose CSS omits the
+base `.hljs { background: ...; color: ... }` rule, the block would otherwise render with a
+transparent background and invisible text. Override the two fallback parameters on `CodeBlockStyle`
+to control what is shown in that case:
+
+```kotlin
+import dev.hossain.highlight.ui.CodeBlockStyle
+import dev.hossain.highlight.ui.SyntaxHighlightedCode
+
+SyntaxHighlightedCode(
+    code     = snippet,
+    language = "kotlin",
+    style    = CodeBlockStyle(
+        fallbackBackgroundColor = Color(0xFF0D1117),
+        fallbackTextColor       = Color(0xFFC9D1D9),
+    ),
+)
+```
+
+!!! note
+    Built-in themes (Tomorrow, Atom One, GitHub, Dracula, Alucard) always include a full
+    `.hljs` rule, so these fallback colors have no visible effect when using them.

--- a/docs/reference/code-block-style.md
+++ b/docs/reference/code-block-style.md
@@ -64,8 +64,36 @@ Wrap inline style creation in `remember` to avoid creating new style objects eve
 val myStyle = remember { CodeBlockStyle(padding = PaddingValues(8.dp)) }
 ```
 
+## Fallback colors for custom themes
+
+When a custom `HighlightTheme` CSS omits the base `.hljs { background: ...; color: ... }` rule,
+`CodeBlockStyle` uses fallback colors so the block still renders correctly:
+
+| Parameter | Default | When it applies |
+|---|---|---|
+| `fallbackBackgroundColor` | `Color(0xFF1E1E1E)` (dark grey) | `HighlightTheme.backgroundColor` is `Color.Unspecified` |
+| `fallbackTextColor` | `Color(0xFFD4D4D4)` (light grey) | `HighlightTheme.defaultTextColor` is `Color.Unspecified` |
+
+Override them to match your app's branding when using a stripped-down custom theme:
+
+```kotlin
+val myStyle = CodeBlockStyle(
+    fallbackBackgroundColor = Color(0xFF0D1117), // GitHub dark background
+    fallbackTextColor       = Color(0xFFC9D1D9), // GitHub dark foreground
+)
+
+SyntaxHighlightedCode(code = snippet, language = "kotlin", style = myStyle)
+```
+
+!!! note
+    Built-in themes (Tomorrow, Atom One, GitHub, Dracula, Alucard) always include a full
+    `.hljs` rule, so `fallbackBackgroundColor` and `fallbackTextColor` have no effect when using them.
+    They only matter for custom `fromAsset()` or `fromCss()` themes that omit that rule.
+
 ## Common pitfalls
 
 - Overriding `textStyle.color` and expecting it to win over theme foreground.
 - Using too-small `copyButtonSize` and reducing touch target usability.
 - Mismatched `shape` and outer container decoration, causing clipped or inconsistent edges.
+- Not providing fallback colors when using a minimal custom theme without a base `.hljs` rule,
+  leading to invisible text or a transparent background.

--- a/docs/reference/syntax-highlighted-text-editor.md
+++ b/docs/reference/syntax-highlighted-text-editor.md
@@ -58,6 +58,11 @@ and render your own field - the editor is intentionally opinionated.
 
 ## Opting in
 
+Both `SyntaxHighlightedTextEditor` and `SyntaxHighlightedTextEditorDefaults` are annotated
+with `@ExperimentalHighlightApi`, so accessing either — including static members like
+`SyntaxHighlightedTextEditorDefaults.DefaultTextStyle` or `CodeKeyboardOptions` — requires the
+same opt-in.
+
 ```kotlin
 // Option 1 - opt in at the call site
 @OptIn(ExperimentalHighlightApi::class)


### PR DESCRIPTION
Post-release documentation audit found two gaps where source code behaviour was not reflected in the docs:

### 1.  and  were not documented

These two constructor parameters are the safety net when a custom  CSS omits the base  rule. Without them documented, users writing stripped-down custom themes would see a transparent background and invisible text and have no way to discover the fix from the docs.

**Files changed:**
-  - new "Fallback colors for custom themes" section with a table and example
-  - new "Fallback background and text colors" section matching the reference

### 2. `SyntaxHighlightedTextEditorDefaults` opt-in requirement was missing

Both `SyntaxHighlightedTextEditor` and `SyntaxHighlightedTextEditorDefaults` are annotated `@ExperimentalHighlightApi`. The editor reference only mentioned the composable, so users accessing `SyntaxHighlightedTextEditorDefaults.DefaultTextStyle` or `CodeKeyboardOptions` would get a compile error with no obvious explanation.

**Files changed:**
- `docs/reference/syntax-highlighted-text-editor.md` - expanded "Opting in" section to explicitly name `SyntaxHighlightedTextEditorDefaults` and its members

All other API names, parameter names, signatures, version numbers, and built-in theme names in all 16 doc files were verified accurate.