### PR TITLE
feat: add Dracula and Alucard light/dark theme aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Added Dracula and Alucard light/dark theme aliases** - Added `HighlightTheme.draculaLight()`,
+  `HighlightTheme.alucardDark()`, `rememberDraculaLightTheme()`, and `rememberAlucardDarkTheme()` to
+  improve the discoverability of these paired themes under both naming schemes.
+
 ## [0.32.0] - 2026-07-04
 
 ### Changed

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightTheme.kt
@@ -333,6 +333,24 @@ class HighlightTheme private constructor(
             )
 
         /**
+         * Alias for [alucardLight]. Makes the Alucard light theme discoverable under
+         * the Dracula family name.
+         *
+         * @return A [HighlightTheme] backed by the bundled `alucard.css`.
+         * @see alucardLight
+         */
+        fun draculaLight(): HighlightTheme = alucardLight()
+
+        /**
+         * Alias for [draculaDark]. Makes the Dracula dark theme discoverable under
+         * the Alucard family name.
+         *
+         * @return A [HighlightTheme] backed by the bundled `dracula.css`.
+         * @see draculaDark
+         */
+        fun alucardDark(): HighlightTheme = draculaDark()
+
+        /**
          * Custom theme loaded from a Highlight.js CSS file in the app's `assets/` folder.
          *
          * This is the recommended way for app developers to ship additional themes. Download any

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/HighlightThemeProvider.kt
@@ -348,6 +348,26 @@ fun rememberDraculaDarkTheme(): HighlightTheme = remember { HighlightTheme.dracu
 @Composable
 fun rememberAlucardLightTheme(): HighlightTheme = remember { HighlightTheme.alucardLight() }
 
+/**
+ * Creates and remembers the built-in Alucard (light) theme as an alias under the Dracula naming scheme.
+ * Makes the light theme discoverable under the Dracula family name.
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ * @see rememberAlucardLightTheme
+ */
+@Composable
+fun rememberDraculaLightTheme(): HighlightTheme = rememberAlucardLightTheme()
+
+/**
+ * Creates and remembers the built-in Dracula (dark) theme as an alias under the Alucard naming scheme.
+ * Makes the dark theme discoverable under the Alucard family name.
+ *
+ * @return A stable [HighlightTheme] instance remembered across recompositions.
+ * @see rememberDraculaDarkTheme
+ */
+@Composable
+fun rememberAlucardDarkTheme(): HighlightTheme = rememberDraculaDarkTheme()
+
 @Preview(showBackground = true)
 @Composable
 private fun HighlightThemeProviderPreview() {

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightThemeTest.kt
@@ -316,4 +316,16 @@ class HighlightThemeTest {
 
         assertThat(duration).isEqualTo(Duration.ZERO)
     }
+
+    // ----- draculaLight and alucardDark aliases -----
+
+    @Test
+    fun `draculaLight returns alucardLight theme`() {
+        assertThat(HighlightTheme.draculaLight()).isEqualTo(HighlightTheme.alucardLight())
+    }
+
+    @Test
+    fun `alucardDark returns draculaDark theme`() {
+        assertThat(HighlightTheme.alucardDark()).isEqualTo(HighlightTheme.draculaDark())
+    }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/HighlightThemeProviderRobolectricTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/HighlightThemeProviderRobolectricTest.kt
@@ -85,4 +85,28 @@ class HighlightThemeProviderRobolectricTest {
             }
         assertThat(thrown.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
     }
+
+    @Test
+    fun `rememberDraculaLightTheme returns same theme as rememberAlucardLightTheme`() {
+        var draculaLightTheme: HighlightTheme? = null
+        var alucardLightTheme: HighlightTheme? = null
+        composeTestRule.setContent {
+            draculaLightTheme = rememberDraculaLightTheme()
+            alucardLightTheme = rememberAlucardLightTheme()
+        }
+        composeTestRule.waitForIdle()
+        assertThat(draculaLightTheme).isEqualTo(alucardLightTheme)
+    }
+
+    @Test
+    fun `rememberAlucardDarkTheme returns same theme as rememberDraculaDarkTheme`() {
+        var alucardDarkTheme: HighlightTheme? = null
+        var draculaDarkTheme: HighlightTheme? = null
+        composeTestRule.setContent {
+            alucardDarkTheme = rememberAlucardDarkTheme()
+            draculaDarkTheme = rememberDraculaDarkTheme()
+        }
+        composeTestRule.waitForIdle()
+        assertThat(alucardDarkTheme).isEqualTo(draculaDarkTheme)
+    }
 }

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -12,8 +12,15 @@
 | Atom One Light | Light | `rememberAtomOneLightTheme()` |
 | GitHub | Light | `rememberGithubLightTheme()` |
 | GitHub Dark | Dark | `rememberGithubDarkTheme()` |
-| Dracula | Dark | `rememberDraculaDarkTheme()` |
-| Alucard | Light | `rememberAlucardLightTheme()` |
+| Dracula | Dark | `rememberDraculaDarkTheme()` (or `rememberAlucardDarkTheme()`) |
+| Alucard | Light | `rememberAlucardLightTheme()` (or `rememberDraculaLightTheme()`) |
+
+!!! tip "Dracula and Alucard Aliases"
+    Dracula (Dark) and Alucard (Light) are designed as a pair (since *Alucard* is *Dracula* spelled backward 😅).
+    To make them easier to find, the library provides convenience aliases under both naming schemes:
+
+    * **Dracula Light**: `rememberDraculaLightTheme()` (alias for `rememberAlucardLightTheme()`) or `HighlightTheme.draculaLight()`
+    * **Alucard Dark**: `rememberAlucardDarkTheme()` (alias for `rememberDraculaDarkTheme()`) or `HighlightTheme.alucardDark()`
 
 Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `githubLight`, `githubDark`, `draculaDark`, `alucardLight`) are fast-path themes:
 

--- a/docs/reference/highlight-theme.md
+++ b/docs/reference/highlight-theme.md
@@ -14,10 +14,12 @@ Full API in Dokka:
 - [`rememberGithubDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-github-dark-theme.html)
 - [`rememberDraculaDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-dracula-dark-theme.html)
 - [`rememberAlucardLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-alucard-light-theme.html)
+- [`rememberDraculaLightTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-dracula-light-theme.html) (alias)
+- [`rememberAlucardDarkTheme`](https://hossain-khan.github.io/android-compose-highlight/api/compose-highlight/dev.hossain.highlight.ui/remember-alucard-dark-theme.html) (alias)
 
 ## When to use each theme source
 
-- Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `githubLight`, `githubDark`, `draculaDark`, `alucardLight`): fastest setup,
+- Built-in themes (`tomorrow`, `tomorrowNight`, `atomOneDark`, `atomOneLight`, `githubLight`, `githubDark`, `draculaDark`, `alucardLight`) and their aliases: fastest setup,
   precompiled maps, no CSS parsing at runtime.
 - `fromAsset(...)`: best for shipping a highlight.js CSS file with your app.
 - `fromCss(...)`: useful when CSS comes from network, config, or generated text.
@@ -43,7 +45,7 @@ HighlightThemeProvider(
 Other bundled pairs now available:
 
 - `rememberGithubLightTheme()` + `rememberGithubDarkTheme()`
-- `rememberAlucardLightTheme()` + `rememberDraculaDarkTheme()`
+- `rememberAlucardLightTheme()` + `rememberDraculaDarkTheme()` (or aliases `rememberDraculaLightTheme()` + `rememberAlucardDarkTheme()`)
 
 ## Custom theme from asset CSS
 


### PR DESCRIPTION
This PR adds alias functions for Dracula and Alucard light/dark themes to improve discoverability.

### Added
- `HighlightTheme.draculaLight()` delegating to `alucardLight()`
- `HighlightTheme.alucardDark()` delegating to `draculaDark()`
- `rememberDraculaLightTheme()` delegating to `rememberAlucardLightTheme()`
- `rememberAlucardDarkTheme()` delegating to `rememberDraculaDarkTheme()`
- Unit tests verifying the alias mapping in `HighlightThemeTest.kt` and `HighlightThemeProviderRobolectricTest.kt`
- Documentation entries in `CHANGELOG.md` under `[Unreleased]`.