### PR TITLE
test: migrate instrumented Compose tests to v2 createComposeRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
   `HighlightTheme.alucardDark()`, `rememberDraculaLightTheme()`, and `rememberAlucardDarkTheme()` to
   improve the discoverability of these paired themes under both naming schemes.
 
+### Fixed
+
+- **Migrated instrumented Compose tests to the v2 `createComposeRule` API** - Updated the remaining
+  Android UI tests to use `androidx.compose.ui.test.junit4.v2.createComposeRule` to remove the
+  deprecation warnings tracked in #390.
+
 ## [0.32.0] - 2026-07-04
 
 ### Changed

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/RememberSyntaxHighlightedEditorValueTest.kt
@@ -3,7 +3,7 @@ package dev.hossain.highlight.ui
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput


### PR DESCRIPTION
Fixes #390.

Migrates the remaining instrumented Compose UI tests to `androidx.compose.ui.test.junit4.v2.createComposeRule` and adds a changelog entry for the deprecation cleanup.

Verification:
- `./gradlew :compose-highlight:compileDebugAndroidTestKotlin`
- `npx markdownlint-cli CHANGELOG.md`
