### PR TITLE
fix: trim trailing newline from code block text to prevent extra line in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Fixed extra empty line at the bottom of Kotlin code blocks on the docs site** - Trimmed trailing newline
+  from Pygments `textContent` in `docs/javascripts/shiki-kotlin.js` before passing to `codeToHtml()`. Previously,
+  the trailing newline generated an empty line span with `1.45em` minimum height.
 - **Migrated instrumented Compose tests to the v2 `createComposeRule` API** - Updated the remaining
   Android UI tests to use `androidx.compose.ui.test.junit4.v2.createComposeRule` to remove the
   deprecation warnings tracked in #390.

--- a/docs/javascripts/shiki-kotlin.js
+++ b/docs/javascripts/shiki-kotlin.js
@@ -19,7 +19,9 @@ async function highlightKotlinBlocks() {
     const block = pre.querySelector('code')
     if (!block) continue
 
-    const code = block.textContent
+    // Trim trailing newline (\n) from Pygments HTML to prevent Shiki from
+    // generating an extra empty line at the end of the code block.
+    const code = block.textContent.trimEnd()
 
     try {
       const html = await codeToHtml(code, {


### PR DESCRIPTION
## Summary

Fixes an issue where an extra trailing empty line is rendered at the bottom of Kotlin code blocks across the Zensical documentation site (`https://hossain-
  khan.github.io/android-compose-highlight/`).

### Root Cause
When Pygments (`pymdownx.highlight`) renders Markdown code blocks into HTML (`<pre><code>...</code></pre>`), `block.textContent` almost always includes a
  trailing newline (`\n`). When `docs/javascripts/shiki-kotlin.js` passed `block.textContent` directly to Shiki's `codeToHtml()` without trimming, Shiki
  treated that final newline as an extra line break and generated an empty `<span class="line"></span>` at the end of the code block. Combined with `pre[data-
  shiki] code .line { display: block; min-height: 1.45em; }` in `shiki-kotlin.css`, this caused a `1.45em` tall blank line to appear at the bottom of every
  Kotlin code block box.

### Solution
    - **`docs/javascripts/shiki-kotlin.js`**: Call `.trimEnd()` on `block.textContent` before passing the code string to `codeToHtml()`, preventing the
  creation of the trailing empty line span. Added an explanatory inline comment.
    - **`CHANGELOG.md`**: Added entry under `[Unreleased] -> ### Fixed`.
