### PR TITLE
chore: add post-build asset fingerprinting for custom docs assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build docs site
         run: zensical build --clean
 
+      - name: Fingerprint custom docs assets with git hash
+        run: python3 scripts/fingerprint-docs.py
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ resources/api/
 # Zensical docs build output
 site/
 .cache/
+.venv/
+*.egg-info/
 gradle/gradle-daemon-jvm.properties
 *.salive
 build_log.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to this project will be documented in this file.
   Android UI tests to use `androidx.compose.ui.test.junit4.v2.createComposeRule` to remove the
   deprecation warnings tracked in #390.
 
+### Infrastructure
+
+- **Added post-build asset fingerprinting for custom docs assets** - Created `scripts/fingerprint-docs.py` and
+  integrated it into `.github/workflows/docs.yml`. The script appends the current short Git commit hash to
+  `site/javascripts/shiki-kotlin.js` and `site/stylesheets/shiki-kotlin.css` right after Zensical builds the site,
+  rewriting all HTML references to enforce reliable browser cache busting on every documentation update.
+
 ## [0.32.0] - 2026-07-04
 
 ### Changed

--- a/scripts/fingerprint-docs.py
+++ b/scripts/fingerprint-docs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Post-build script for Zensical documentation site.
+Fingerprints shiki-kotlin.js and shiki-kotlin.css in the site/ directory with the current
+git commit hash and updates all HTML file references to enforce browser cache busting.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+SITE_DIR = Path("site")
+ASSETS_TO_FINGERPRINT = [
+    ("javascripts/shiki-kotlin.js", "javascripts/shiki-kotlin.{hash_str}.js"),
+    ("stylesheets/shiki-kotlin.css", "stylesheets/shiki-kotlin.{hash_str}.css"),
+]
+
+
+def get_git_hash() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+    except Exception as e:
+        print(f"Warning: Could not get git hash ({e}), falling back to 'latest'")
+        return "latest"
+
+
+def main():
+    if not SITE_DIR.exists() or not SITE_DIR.is_dir():
+        print("Error: site/ directory not found. Run 'zensical build' first.")
+        sys.exit(1)
+
+    hash_str = get_git_hash()
+    print(f"Fingerprinting docs assets with hash: {hash_str}")
+
+    replacements = {}
+    for old_rel, new_rel_template in ASSETS_TO_FINGERPRINT:
+        old_path = SITE_DIR / old_rel
+        if not old_path.exists():
+            print(f"Warning: Asset not found, skipping: {old_path}")
+            continue
+
+        new_rel = new_rel_template.format(hash_str=hash_str)
+        new_path = SITE_DIR / new_rel
+
+        # Rename file on disk
+        old_path.rename(new_path)
+        replacements[old_rel] = new_rel
+        print(f"  Renamed: {old_rel} -> {new_rel}")
+
+    if not replacements:
+        print("No assets were fingerprinted.")
+        return
+
+    # Rewrite references across all HTML files in site/
+    html_files = list(SITE_DIR.rglob("*.html"))
+    updated_count = 0
+    for html_file in html_files:
+        content = html_file.read_text(encoding="utf-8")
+        original_content = content
+
+        for old_rel, new_rel in replacements.items():
+            content = content.replace(old_rel, new_rel)
+
+        if content != original_content:
+            html_file.write_text(content, encoding="utf-8")
+            updated_count += 1
+
+    print(f"Successfully updated asset references in {updated_count} HTML files.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds automated post-build asset fingerprinting (filename hashing) for custom documentation assets (`shiki-kotlin.js` and `shiki-kotlin.css`) to guarantee browser cache busting across GitHub Pages deployments.

### Implementation
  - **`scripts/fingerprint-docs.py`**: A post-build script that runs after `zensical build`. It renames `site/javascripts/shiki-kotlin.js` and `site/stylesheets/shiki-kotlin.css` to include the short Git commit hash (`shiki-kotlin.<hash>.js`), then automatically rewrites all `<link>` and `<script>`  references across `site/**/*.html`.
- **`.github/workflows/docs.yml`**: Integrated the script right after the Zensical build step (`zensical build --clean`).
- **`.gitignore` & `CHANGELOG.md`**: Ignored local `.venv` / `.egg-info` directories and documented the infrastructure enhancement in `CHANGELOG.md`.

    ---

## Verification

- [x] Tested locally (`.venv/bin/zensical build --clean && python3 scripts/fingerprint-docs.py`) — successfully fingerprinted assets and updated references  across HTML files
- [x] Ran `./gradlew formatKotlin` (passed cleanly)
- [x] Built library & sample (`./gradlew :compose-highlight:assembleDebug :sample:assembleDebug`)
- [x] Ran all JVM unit tests (`./gradlew :compose-highlight:test` — 81 tests passed)
- [x] Verified markdown formatting (`npx markdownlint-cli CHANGELOG.md` — passed cleanly)