### PR TITLE
chore: prepare release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-18
+
 ### Added
 
 - **Added Dracula and Alucard light/dark theme aliases** - Added `HighlightTheme.draculaLight()`,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.32.0")
+    implementation("dev.hossain:compose-highlight:0.33.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.33.0 - Dracula/Alucard theme aliases, docs asset fingerprinting, and dependency updates
+
+- Added Dracula and Alucard light/dark theme convenience aliases (`rememberDraculaLightTheme()`, `rememberAlucardDarkTheme()`, etc.)
+- Migrated instrumented Compose UI tests to the v2 `createComposeRule` API
+- Fixed trailing newline bug in documentation code blocks
+- Added post-build asset fingerprinting for custom docsite assets to ensure reliable browser cache-busting
+- Updated Compose BOM (`2026.08.00`), AndroidX WebKit (`1.17.0`), Kotlinter (`5.7.0`), Roborazzi (`1.71.0`), and Gradle wrapper (`9.7.0`)
+
 ### 0.32.0 - New precompiled themes, spec compliance, and API cleanups
 
 - Added four new built-in themes (GitHub, GitHub Dark, Dracula, and Alucard) with precompiled color maps for fast loading without Context
@@ -43,19 +51,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
   across all fixtures
 - Saved Jsoup baseline and SAX optimized JSON reports under
   `resources/html-parser-benchmarks/` for regression tracking
-
-### 0.30.0 - Custom HTML parser replaces Jsoup
-
-- Replaced the JVM-only Jsoup dependency with a single-pass pure-Kotlin HTML
-  tokenizer scoped to the hljs HTML subset
-- Sample APK measured 128.7 KB smaller post-R8 (-5.49%); dex drops 271 classes and
-  2,298 methods. Four R8/ProGuard `-keep` rules were removed from downstream consumers
-- Dual-theme highlight path is 1.27×-1.97× faster on real-world
-  Kotlin/C/Rust/Go/C#/SQL fixtures
-- Added real-world language test coverage with extensive token-count assertions and an
-  opt-in JVM microbenchmark (`HtmlParserBenchmark`)
-- Prepared the codebase for Kotlin Multiplatform (KMP)
-
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.32.0")
+    implementation("dev.hossain:compose-highlight:0.33.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.32.0")
+    implementation("dev.hossain:compose-highlight:0.33.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.32.0
+VERSION_NAME=0.33.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 39
-        versionName = "0.32.0"
+        versionCode = 40
+        versionName = "0.33.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Prepares release `0.33.0`:

- Bumps version to `0.33.0` in `gradle.properties`, `README.md`, docs, and `pyproject.toml`
- Increments sample app `versionCode` to 40 and `versionName` to `0.33.0`
- Finalizes `[0.33.0] - 2026-08-18` section in `CHANGELOG.md`

## Verification
- Verified `./gradlew formatKotlin :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test` passes.