### PR TITLE
chore: prepare release 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-28
+
 ### Added
 
 - **Added `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode` (`@ExperimentalHighlightApi`)** -

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.33.0")
+    implementation("dev.hossain:compose-highlight:0.34.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.34.0 - Streaming Syntax Highlighting for AI & LLMs
+
+- Added `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode` (`@ExperimentalHighlightApi`) for real-time and LLM token streaming
+- Implemented span-transfer snapshot pipeline (`applySnapshotSpans`) for zero-flicker, 0 ms UI render latency during streaming
+- Added streaming-aware scroll handling to preserve user scroll offsets during token appends
+- Added "LLM/Streaming" interactive demo tab in the sample app simulating token streams across Kotlin, Python, and TypeScript
+- Upgraded documentation site generator Zensical to 0.0.56 with refreshed Dokka chrome assets
+
 ### 0.33.0 - Dracula/Alucard theme aliases, docs asset fingerprinting, and dependency updates
 
 - Added Dracula and Alucard light/dark theme convenience aliases (`rememberDraculaLightTheme()`, `rememberAlucardDarkTheme()`, etc.)
@@ -23,34 +31,18 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ### 0.31.0 - Scroll hoisting, preview fixes, and CI hardening
 
-- Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor`
-  for programmatic scroll control
-- Fixed Compose Preview crashes by blocking WebView initialization in `@Preview`
-  composables across the editor, read-only blocks, and theme provider
+- Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor` for programmatic scroll control
+- Fixed Compose Preview crashes by blocking WebView initialization in `@Preview` composables across the editor, read-only blocks, and theme provider
 - Fixed `HighlightResult.spanCount` semantics and CSS `#RRGGBBAA` color parsing order
-- Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers,
-  and added `modifier` parameters to the default copy button and language badge slot helpers
-- Hardened CI with release builds, Maven publication smoke test, and Compose compiler
-  report verification
+- Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers, and added `modifier` parameters to the default copy button and language badge slot helpers
+- Hardened CI with release builds, Maven publication smoke test, and Compose compiler report verification
 
 ### 0.30.2 - Remove deprecated treeWalk timing
 
 - Removed the deprecated `treeWalk` timing property entirely from `HighlightTimings`
 - Cleaned up the timings usage in `HighlightEngine` and internally in `HtmlToAnnotatedString`
-- Updated the sample app performance breakdown screen and timing unit tests to
-  remove the property
+- Updated the sample app performance breakdown screen and timing unit tests to remove the property
 - Synced documentation across the guides to reflect the updated timing model
-
-### 0.30.1 - Parser performance optimizations
-
-- Optimized HTML-to-AnnotatedString pipeline with SAX-style single-pass parsing,
-  eliminating intermediate tree allocations
-- Added substring avoidance, in-place attribute extraction, lazy entity decoding, and
-  allocation-free numeric parsing
-- Benchmarks show 29-57% faster single-theme and 5-39% faster dual-theme conversions
-  across all fixtures
-- Saved Jsoup baseline and SAX optimized JSON reports under
-  `resources/html-parser-benchmarks/` for regression tracking
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.33.0")
+    implementation("dev.hossain:compose-highlight:0.34.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.33.0")
+    implementation("dev.hossain:compose-highlight:0.34.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.33.0
+VERSION_NAME=0.34.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 40
-        versionName = "0.33.0"
+        versionCode = 41
+        versionName = "0.34.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Prepares release **0.34.0**:

- Bumped library version to `0.34.0` across `gradle.properties`, `README.md`, `docs/index.md`, `docs/getting-started.md`, `pyproject.toml`, and `sample/build.gradle.kts` (versionCode `41`).
- Renamed `[Unreleased]` to `[0.34.0] - 2026-08-28` in `CHANGELOG.md`.
- Updated `docs/changelog.md` with `0.34.0` release highlights.

## Release Highlights (0.34.0)

- **`StreamingSyntaxHighlightedCode` & `rememberStreamingHighlightedCode` (`@ExperimentalHighlightApi`)**: Added dedicated composables tailored for AI/LLM streaming with instant 0 ms token rendering and zero flicker.
- **Span-Transfer Snapshot Pipeline (`applySnapshotSpans`)**: Preserves syntax highlighting on previous lines while streaming new tokens.
- **Sample App Demo**: Added new "LLM/Streaming" demo tab with simulated token generation.
- **Dependency & Infrastructure Updates**: Upgraded Zensical docs generator to 0.0.56.