### PR TITLE
feat: add newline-aware debouncing and progressive line backfilling for streaming code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Added newline-aware debouncing and progressive line backfilling for streaming code** - Added `triggerOnNewline`
+  and `minThrottleMs` to `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode`. When newlines
+  are emitted during streaming, completed lines are progressively styled in the background without waiting for the
+  idle debounce timer, while throttling engine executions to avoid JS overload (#440).
+
 ## [0.34.0] - 2026-08-28
 
 ### Added

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.AnnotatedString
 import dev.hossain.highlight.engine.HighlightException
@@ -14,7 +15,9 @@ import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.ui.internal.HighlightSnapshot
 import dev.hossain.highlight.ui.internal.applySnapshotSpans
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Runs the debounce + syntax-highlight pipeline for streaming / real-time code (such as LLM responses
@@ -29,7 +32,10 @@ import kotlinx.coroutines.delay
  * 1. **Immediate render (0 ms latency):** As new tokens arrive, the full string is returned immediately.
  * 2. **Continuous styling:** Spans from the last completed highlight run are carried forward onto
  *    the unchanged prefix of the new text, keeping existing lines colored.
- * 3. **Debounced engine calls:** Highlighting is delayed by [debounceMs], coalescing rapid token emissions
+ * 3. **Newline-aware progressive backfilling:** When [triggerOnNewline] is enabled, completed lines
+ *    are progressively highlighted in the background as newlines (`\n`) arrive (throttled by [minThrottleMs]),
+ *    snapping finished lines to full syntax colors while subsequent tokens continue streaming.
+ * 4. **Debounced engine calls:** Idle pauses are debounced by [debounceMs], coalescing rapid token emissions
  *    into a single highlight engine run when generation pauses or finishes.
  *
  * ## Usage
@@ -50,8 +56,13 @@ import kotlinx.coroutines.delay
  * @param code The current source code string (actively growing or static).
  * @param language Highlight.js language identifier (e.g. `"kotlin"`, `"python"`, `"json"`).
  * @param theme The highlight theme to apply. Defaults to [LocalHighlightTheme].
- * @param debounceMs Milliseconds to wait after the last text change before triggering a new
+ * @param debounceMs Milliseconds to wait after the last text change before triggering an idle
  *   highlight call. Defaults to [StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS] (200 ms).
+ * @param triggerOnNewline Whether to trigger a background highlight run when a new newline (`\n`)
+ *   is detected in the stream, progressively styling completed lines. Defaults to `true`.
+ * @param minThrottleMs Minimum interval in milliseconds between consecutive newline-triggered
+ *   highlight runs to avoid engine overload. Defaults to
+ *   [StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS] (150 ms).
  * @param onHighlightComplete Optional callback invoked with a [HighlightResult] when a highlight
  *   cycle completes successfully. Fires after the snapshot is updated.
  * @param onError Optional callback invoked with the [HighlightException] when highlighting fails.
@@ -66,6 +77,8 @@ fun rememberStreamingHighlightedCode(
     language: String,
     theme: HighlightTheme = LocalHighlightTheme.current,
     debounceMs: Long = StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS,
+    triggerOnNewline: Boolean = true,
+    minThrottleMs: Long = StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS,
     onHighlightComplete: ((HighlightResult) -> Unit)? = null,
     onError: ((HighlightException) -> Unit)? = null,
 ): AnnotatedString {
@@ -75,23 +88,76 @@ fun rememberStreamingHighlightedCode(
 
     val engine = rememberHighlightEngine()
     var highlighted by remember { mutableStateOf<HighlightSnapshot?>(null) }
+    val currentCode by rememberUpdatedState(code)
     val currentDebounceMs by rememberUpdatedState(debounceMs)
+    val currentTriggerOnNewline by rememberUpdatedState(triggerOnNewline)
+    val currentMinThrottleMs by rememberUpdatedState(minThrottleMs)
     val currentOnHighlightComplete by rememberUpdatedState(onHighlightComplete)
     val currentOnError by rememberUpdatedState(onError)
 
-    LaunchedEffect(code, language, theme) {
-        if (currentDebounceMs > 0L) {
-            delay(currentDebounceMs)
-        }
-        engine
-            .highlight(code, language, theme)
-            .onSuccess { result ->
-                highlighted = HighlightSnapshot(result.annotated, language, theme)
-                currentOnHighlightComplete?.invoke(result)
-            }.onFailure { error ->
+    LaunchedEffect(language, theme, engine) {
+        var lastHighlightedText = ""
+        var lastHighlightStartTime = 0L
+        var pendingDebounceJob: Job? = null
+
+        suspend fun executeHighlight(textToHighlight: String) {
+            if (textToHighlight.isEmpty()) {
                 highlighted = null
-                (error as? HighlightException)?.let { currentOnError?.invoke(it) }
+                lastHighlightedText = ""
+                return
             }
+            if (textToHighlight == lastHighlightedText) return
+
+            lastHighlightStartTime = System.currentTimeMillis()
+            engine
+                .highlight(textToHighlight, language, theme)
+                .onSuccess { result ->
+                    highlighted = HighlightSnapshot(result.annotated, language, theme)
+                    lastHighlightedText = textToHighlight
+                    currentOnHighlightComplete?.invoke(result)
+                }.onFailure { error ->
+                    highlighted = null
+                    (error as? HighlightException)?.let { currentOnError?.invoke(it) }
+                }
+        }
+
+        snapshotFlow { currentCode }.collect { latestCode ->
+            if (latestCode.isEmpty()) {
+                pendingDebounceJob?.cancel()
+                highlighted = null
+                lastHighlightedText = ""
+                return@collect
+            }
+
+            val newlinesInCurrent = latestCode.count { it == '\n' }
+            val newlinesInLast = lastHighlightedText.count { it == '\n' }
+            val hasNewNewline = newlinesInCurrent > newlinesInLast
+            val now = System.currentTimeMillis()
+            val timeSinceLast = now - lastHighlightStartTime
+
+            if (currentTriggerOnNewline && hasNewNewline) {
+                pendingDebounceJob?.cancel()
+                if (timeSinceLast >= currentMinThrottleMs) {
+                    launch { executeHighlight(latestCode) }
+                } else {
+                    val remainingThrottle = (currentMinThrottleMs - timeSinceLast).coerceAtLeast(0L)
+                    pendingDebounceJob =
+                        launch {
+                            delay(remainingThrottle)
+                            executeHighlight(latestCode)
+                        }
+                }
+            } else {
+                pendingDebounceJob?.cancel()
+                pendingDebounceJob =
+                    launch {
+                        if (currentDebounceMs > 0L) {
+                            delay(currentDebounceMs)
+                        }
+                        executeHighlight(latestCode)
+                    }
+            }
+        }
     }
 
     val snapshot = highlighted

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
@@ -95,11 +95,27 @@ fun rememberStreamingHighlightedCode(
     val currentOnHighlightComplete by rememberUpdatedState(onHighlightComplete)
     val currentOnError by rememberUpdatedState(onError)
 
+    // Keying LaunchedEffect on (language, theme, engine) rather than `code` gives us a
+    // persistent coroutine scope across streaming updates. If we keyed on `code`, every incoming
+    // token (15-40 Hz) would cancel and restart the effect, aborting in-flight highlight runs
+    // and resetting debounce timers before they could ever complete.
     LaunchedEffect(language, theme, engine) {
+        // Tracks the most recent text string that successfully finished highlighting.
+        // Used to detect when new lines ('\n') have been completed and to prevent redundant highlights.
         var lastHighlightedText = ""
+
+        // Timestamp (epoch ms) when the last highlight run was started. Used to enforce `minThrottleMs`.
         var lastHighlightStartTime = 0L
+
+        // Reference to the currently scheduled debounce or throttle delay job.
         var pendingDebounceJob: Job? = null
 
+        /**
+         * Dispatches a syntax highlight request to the underlying [HighlightEngine].
+         *
+         * Updates [highlighted] on success, unblocks [applySnapshotSpans] for downstream text,
+         * and routes callbacks ([currentOnHighlightComplete] / [currentOnError]).
+         */
         suspend fun executeHighlight(textToHighlight: String) {
             if (textToHighlight.isEmpty()) {
                 highlighted = null
@@ -121,6 +137,7 @@ fun rememberStreamingHighlightedCode(
                 }
         }
 
+        // Continuously observe incoming text updates from the stream without restarting the parent coroutine.
         snapshotFlow { currentCode }.collect { latestCode ->
             if (latestCode.isEmpty()) {
                 pendingDebounceJob?.cancel()
@@ -129,6 +146,7 @@ fun rememberStreamingHighlightedCode(
                 return@collect
             }
 
+            // 1. Check if the latest stream chunk completed one or more new lines ('\n').
             val newlinesInCurrent = latestCode.count { it == '\n' }
             val newlinesInLast = lastHighlightedText.count { it == '\n' }
             val hasNewNewline = newlinesInCurrent > newlinesInLast
@@ -136,10 +154,18 @@ fun rememberStreamingHighlightedCode(
             val timeSinceLast = now - lastHighlightStartTime
 
             if (currentTriggerOnNewline && hasNewNewline) {
+                // Cancel any pending idle debounce since a structural token boundary (newline) was completed.
                 pendingDebounceJob?.cancel()
+
+                // 2. Throttle newline-triggered executions to prevent overloading the WebView JS engine
+                // during rapid multi-line bursts (e.g. consecutive empty lines or multi-line chunks).
                 if (timeSinceLast >= currentMinThrottleMs) {
+                    // Min throttle interval has elapsed: launch highlight immediately in background.
+                    // Note: Launching a child coroutine ensures in-flight executions aren't cancelled
+                    // when subsequent intra-line tokens arrive.
                     launch { executeHighlight(latestCode) }
                 } else {
+                    // Newline arrived too soon: schedule execution after the remaining throttle window.
                     val remainingThrottle = (currentMinThrottleMs - timeSinceLast).coerceAtLeast(0L)
                     pendingDebounceJob =
                         launch {
@@ -148,6 +174,7 @@ fun rememberStreamingHighlightedCode(
                         }
                 }
             } else {
+                // 3. Intra-line token or triggerOnNewline disabled: debounce until the stream pauses or ends.
                 pendingDebounceJob?.cancel()
                 pendingDebounceJob =
                     launch {

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCode.kt
@@ -82,6 +82,11 @@ private val LineNumberGutterSpacing = 8.dp
  * @param showLineNumbers Whether to show a line-number gutter on the left.
  * @param debounceMs Delay in milliseconds to debounce highlight engine calls after token arrival.
  *   Defaults to [StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS] (200 ms).
+ * @param triggerOnNewline Whether to trigger a background highlight run when a new newline (`\n`)
+ *   is detected in the stream, progressively styling completed lines. Defaults to `true`.
+ * @param minThrottleMs Minimum interval in milliseconds between consecutive newline-triggered
+ *   highlight runs to avoid engine overload. Defaults to
+ *   [StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS] (150 ms).
  * @param scrollState Hoisted scroll state for horizontal scrolling.
  * @param languageLabel Optional composable for the language badge in the header. `null` hides it.
  * @param copyButton Optional composable for the copy button in the header. `null` hides it.
@@ -99,6 +104,8 @@ fun StreamingSyntaxHighlightedCode(
     style: CodeBlockStyle = CodeBlockStyle.Default,
     showLineNumbers: Boolean = false,
     debounceMs: Long = StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS,
+    triggerOnNewline: Boolean = true,
+    minThrottleMs: Long = StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS,
     scrollState: ScrollState = rememberScrollState(),
     languageLabel: (@Composable () -> Unit)? =
         if (language.isNotBlank()) DefaultLanguageLabelSentinel else null,
@@ -174,6 +181,8 @@ fun StreamingSyntaxHighlightedCode(
             language = language,
             theme = theme,
             debounceMs = debounceMs,
+            triggerOnNewline = triggerOnNewline,
+            minThrottleMs = minThrottleMs,
             onHighlightComplete = onHighlightComplete,
             onError = onError,
         )

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeDefaults.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeDefaults.kt
@@ -24,4 +24,12 @@ object StreamingSyntaxHighlightedCodeDefaults {
      * excessive WebView calls during active token generation.
      */
     const val DEBOUNCE_MS: Long = 200L
+
+    /**
+     * Default minimum throttle interval in milliseconds between consecutive newline-triggered highlight runs.
+     *
+     * 150 ms prevents overloading the JavaScript engine when rapid or consecutive newlines (`\n\n`) arrive,
+     * while allowing completed lines to be progressively styled in the background as streaming continues.
+     */
+    const val MIN_THROTTLE_MS: Long = 150L
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCodeRobolectricTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCodeRobolectricTest.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dev.hossain.highlight.engine.HighlightEngine
 import dev.hossain.highlight.engine.HighlightException
+import dev.hossain.highlight.engine.HighlightResult
 import dev.hossain.highlight.engine.HighlightTheme
 import dev.hossain.highlight.ui.internal.LocalHighlightEngine
 import org.junit.Rule
@@ -119,5 +120,144 @@ class RememberStreamingHighlightedCodeRobolectricTest {
         code = "val a = 1\nval b = 2"
         composeTestRule.waitForIdle()
         assertThat(capturedResult?.text).isEqualTo("val a = 1\nval b = 2")
+    }
+
+    @Test
+    fun clearingCodeResetsStateToEmptyAnnotatedString() {
+        var code by mutableStateOf("val initial = true")
+        var capturedResult: AnnotatedString? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                HighlightThemeProvider {
+                    capturedResult =
+                        rememberStreamingHighlightedCode(
+                            code = code,
+                            language = "kotlin",
+                        )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertThat(capturedResult?.text).isEqualTo("val initial = true")
+
+        code = ""
+        composeTestRule.waitForIdle()
+        assertThat(capturedResult?.text).isEmpty()
+    }
+
+    @Test
+    fun newlineTriggersHighlightCallback() {
+        val completedResults = mutableListOf<HighlightResult>()
+        var code by mutableStateOf("val a = 1")
+        val theme = HighlightTheme.fromCss(".hljs-keyword { color: #ff0000; }", "test-theme")
+        var capturedEngine: HighlightEngine? = null
+
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val engine =
+                remember {
+                    HighlightEngine(context.applicationContext).also { capturedEngine = it }
+                }
+            CompositionLocalProvider(LocalHighlightEngine provides engine) {
+                rememberStreamingHighlightedCode(
+                    code = code,
+                    language = "kotlin",
+                    theme = theme,
+                    debounceMs = 5000L, // long debounce so idle timeout won't fire during test
+                    triggerOnNewline = true,
+                    minThrottleMs = 0L,
+                    onHighlightComplete = { completedResults.add(it) },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val engine = capturedEngine ?: error("Engine was not captured")
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        // Emitting a newline should trigger highlight despite 5000ms debounceMs
+        code = "val a = 1\nval b = 2"
+        composeTestRule.waitForIdle()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            engine.webViewForTest() != null
+        }
+
+        val webView = engine.webViewForTest()
+        assertThat(webView).isNotNull()
+        val nonNullWebView = requireNotNull(webView)
+
+        val webViewClient = Shadows.shadowOf(nonNullWebView).getWebViewClient()
+        val lastUrl = Shadows.shadowOf(nonNullWebView).getLastLoadedUrl() ?: ""
+        webViewClient?.onPageFinished(nonNullWebView, lastUrl)
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback() != null
+        }
+
+        val jsCallback = Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback()
+        assertThat(jsCallback).isNotNull()
+        val resultPayload =
+            org.json
+                .JSONObject()
+                .apply {
+                    put("error", false)
+                    put("html", "<span class=\"hljs-keyword\">val</span> a = 1\n<span class=\"hljs-keyword\">val</span> b = 2")
+                    put("language", "kotlin")
+                }.toString()
+        requireNotNull(jsCallback).onReceiveValue(org.json.JSONObject.quote(resultPayload))
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            completedResults.isNotEmpty()
+        }
+
+        assertThat(completedResults).hasSize(1)
+        assertThat(completedResults.first().annotated.text).isEqualTo("val a = 1\nval b = 2")
+    }
+
+    @Test
+    fun triggerOnNewlineFalseDoesNotTriggerOnNewlineBeforeDebounceMs() {
+        val completedResults = mutableListOf<HighlightResult>()
+        var code by mutableStateOf("val a = 1")
+        val theme = HighlightTheme.fromCss(".hljs-keyword { color: #ff0000; }", "test-theme")
+        var capturedEngine: HighlightEngine? = null
+
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val engine =
+                remember {
+                    HighlightEngine(context.applicationContext).also { capturedEngine = it }
+                }
+            CompositionLocalProvider(LocalHighlightEngine provides engine) {
+                rememberStreamingHighlightedCode(
+                    code = code,
+                    language = "kotlin",
+                    theme = theme,
+                    debounceMs = 5000L, // long debounce so idle timeout won't fire during test
+                    triggerOnNewline = false,
+                    onHighlightComplete = { completedResults.add(it) },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val engine = capturedEngine ?: error("Engine was not captured")
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        // Emitting a newline when triggerOnNewline is false should not trigger highlight before debounceMs
+        code = "val a = 1\nval b = 2"
+        composeTestRule.waitForIdle()
+        ShadowLooper.idleMainLooper()
+
+        assertThat(engine.webViewForTest()).isNull()
+        assertThat(completedResults).isEmpty()
     }
 }

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRobolectricTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRobolectricTest.kt
@@ -127,4 +127,24 @@ class StreamingSyntaxHighlightedCodeRobolectricTest {
             .onNodeWithText("sql")
             .assertIsDisplayed()
     }
+
+    @Test
+    fun `renders with custom triggerOnNewline and minThrottleMs`() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                HighlightThemeProvider {
+                    StreamingSyntaxHighlightedCode(
+                        code = "fun stream() = true",
+                        language = "kotlin",
+                        triggerOnNewline = false,
+                        minThrottleMs = 250L,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("fun stream() = true")
+            .assertIsDisplayed()
+    }
 }

--- a/docs/reference/streaming-syntax-highlighted-code.md
+++ b/docs/reference/streaming-syntax-highlighted-code.md
@@ -50,8 +50,9 @@ Unlike `SyntaxHighlightedCode` (which uses fade-in animations and resets in-flig
 
 1. **Zero UI Latency:** The composable renders the current text immediately on every frame.
 2. **Span Preservation:** Syntax styling on unchanged prefixes (all previous lines) is carried forward seamlessly.
-3. **Engine Debouncing:** Background highlight calls are debounced (`debounceMs = 200L`), ensuring fast token streams do not overload the underlying JavaScript engine.
-4. **Streaming-Aware Scroll:** Horizontal scroll position is preserved when text is appended, preventing jarring scroll resets while the user is reading streaming output.
+3. **Newline-Aware Progressive Backfilling:** When `triggerOnNewline` is enabled (default `true`), completing a line (`\n`) triggers a background highlight run (throttled by `minThrottleMs = 150L`), progressively snapping finished lines to full syntax colors while subsequent tokens continue streaming.
+4. **Engine Debouncing:** Idle pauses are debounced (`debounceMs = 200L`), ensuring fast token streams do not overload the underlying JavaScript engine.
+5. **Streaming-Aware Scroll:** Horizontal scroll position is preserved when text is appended, preventing jarring scroll resets while the user is reading streaming output.
 
 ## Key parameters
 
@@ -60,7 +61,9 @@ Unlike `SyntaxHighlightedCode` (which uses fade-in animations and resets in-flig
 - `theme` - Active theme, defaults to `LocalHighlightTheme.current`.
 - `style` - Visual style configuration (`CodeBlockStyle`).
 - `showLineNumbers` - Whether to show the line number gutter on the left.
-- `debounceMs` - Delay in milliseconds to wait after the last token before triggering a highlight call. Defaults to `StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS` (200 ms).
+- `debounceMs` - Delay in milliseconds to wait after the last token before triggering an idle highlight call. Defaults to `StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS` (200 ms).
+- `triggerOnNewline` - Whether to trigger a background highlight run when a new newline (`\n`) is detected in the stream, progressively styling completed lines. Defaults to `true`.
+- `minThrottleMs` - Minimum interval in milliseconds between consecutive newline-triggered highlight runs. Defaults to `StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS` (150 ms).
 - `scrollState` - Hoisted horizontal `ScrollState`.
 - `languageLabel` - Optional composable slot for the language badge in the header (`null` to hide).
 - `copyButton` - Optional composable slot for the copy button in the header (`null` to hide).

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
@@ -154,6 +154,7 @@ internal fun StreamingSection() {
     var streamedCode by remember { mutableStateOf("") }
     var isStreaming by remember { mutableStateOf(false) }
     var isPaused by remember { mutableStateOf(false) }
+    var triggerOnNewline by remember { mutableStateOf(true) }
     var highlightCount by remember { mutableIntStateOf(0) }
     var lastHighlightDurationMs by remember { mutableStateOf<Long?>(null) }
 
@@ -216,17 +217,19 @@ internal fun StreamingSection() {
                 Text(
                     text =
                         "StreamingSyntaxHighlightedCode renders incoming tokens immediately with 0 ms UI latency " +
-                            "while preserving existing syntax colors via span-transfer (applySnapshotSpans). " +
-                            "Engine highlight jobs are debounced (200 ms) so rapid token streams do not overload the JS engine.",
+                            "while preserving existing syntax colors via span-transfer. With progressive line backfilling enabled, " +
+                            "completed lines snap into full syntax highlighting in the background as newlines (\\n) arrive, " +
+                            "while engine highlight jobs are throttled (150 ms) and idle pauses are debounced (200 ms).",
                     style = MaterialTheme.typography.bodySmall,
                 )
             }
         }
 
-        // Snippet picker chips
+        // Snippet picker and options chips
         Row(
             modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             STREAMING_SNIPPETS.forEachIndexed { index, snippet ->
                 FilterChip(
@@ -240,6 +243,20 @@ internal fun StreamingSection() {
                     label = { Text(snippet.title) },
                 )
             }
+
+            FilterChip(
+                selected = triggerOnNewline,
+                onClick = { triggerOnNewline = !triggerOnNewline },
+                label = { Text("Progressive Backfill (\\n)") },
+                leadingIcon = {
+                    if (triggerOnNewline) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.check_24dp),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
         }
 
         // Controls & Progress bar
@@ -328,6 +345,7 @@ internal fun StreamingSection() {
             language = currentSnippet.language,
             showLineNumbers = true,
             debounceMs = StreamingSyntaxHighlightedCodeDefaults.DEBOUNCE_MS,
+            triggerOnNewline = triggerOnNewline,
             onHighlightComplete = { result: HighlightResult ->
                 highlightCount++
                 lastHighlightDurationMs = result.durationMs

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
@@ -207,22 +207,14 @@ internal fun StreamingSection() {
                     containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                 ),
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(
-                    text = "Zero-Flicker Streaming Highlighting",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text =
-                        "StreamingSyntaxHighlightedCode renders incoming tokens immediately with 0 ms UI latency " +
-                            "while preserving existing syntax colors via span-transfer. With progressive line backfilling enabled, " +
-                            "completed lines snap into full syntax highlighting in the background as newlines (\\n) arrive, " +
-                            "while engine highlight jobs are throttled (150 ms) and idle pauses are debounced (200 ms).",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
+            Text(
+                text =
+                    "Renders streaming tokens with 0 ms UI latency via span-transfer. " +
+                        "Progressive backfill highlights completed lines on newlines (\\n, 150 ms throttle) " +
+                        "and debounces stream pauses (200 ms).",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(12.dp),
+            )
         }
 
         // Snippet picker and options chips


### PR DESCRIPTION
## Summary

Closes #440

Introduces **newline-aware debouncing and progressive line backfilling** for `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode` (`@ExperimentalHighlightApi`):

- **Newline-Aware Triggering**: Detects new line breaks (`\n`) in streaming code to immediately trigger background highlight cycles on completed lines without waiting for the idle `debounceMs` timer.
- **Throttling & Coalescing (`minThrottleMs = 150L`)**: Throttles engine calls to prevent overloading the WebView JS engine during rapid newline bursts, coalescing intermediate requests.
- **Idle Debounce Fallback (`debounceMs = 200L`)**: Preserves the idle debounce delay when typing pauses mid-line or when streaming without newlines.
- **`StreamingSyntaxHighlightedCodeDefaults.MIN_THROTTLE_MS`**: Declares the `150L` default throttle interval.

## Verification

- Added Robolectric tests in `RememberStreamingHighlightedCodeRobolectricTest` & `StreamingSyntaxHighlightedCodeRobolectricTest`.
- Ran `./gradlew formatKotlin`, `./gradlew lintKotlin`, and `npx markdownlint-cli CHANGELOG.md`.
- Ran `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test`.
- Ran `./gradlew :compose-highlight:dokkaGeneratePublicationHtml` and `zensical build`.