### PR TITLE
chore: prepare release 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-30
+
 ### Added
 
 - **Added newline-aware debouncing and progressive line backfilling for streaming code** - Added `triggerOnNewline`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.34.0")
+    implementation("dev.hossain:compose-highlight:0.35.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - Added newline-aware debouncing and progressive line backfilling for `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode`
 - Completed lines now snap into full syntax highlighting in the background as newlines (`\n`) arrive without waiting for idle pauses
 - Added `triggerOnNewline` and `minThrottleMs` (150 ms) to throttle background highlight jobs and protect the JS engine
+- Fixed mid-stream highlight failures flashing the code block to plain text by preserving previously highlighted spans
 - Updated sample app with an interactive progressive backfill toggle and comprehensive TypeScript streaming demo
 
 ### 0.34.0 - Streaming Syntax Highlighting for AI & LLMs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.35.0 - Newline-aware streaming & progressive backfill
+
+- Added newline-aware debouncing and progressive line backfilling for `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode`
+- Completed lines now snap into full syntax highlighting in the background as newlines (`\n`) arrive without waiting for idle pauses
+- Added `triggerOnNewline` and `minThrottleMs` (150 ms) to throttle background highlight jobs and protect the JS engine
+- Updated sample app with an interactive progressive backfill toggle and comprehensive TypeScript streaming demo
+
 ### 0.34.0 - Streaming Syntax Highlighting for AI & LLMs
 
 - Added `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode` (`@ExperimentalHighlightApi`) for real-time and LLM token streaming
@@ -36,13 +43,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - Fixed `HighlightResult.spanCount` semantics and CSS `#RRGGBBAA` color parsing order
 - Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers, and added `modifier` parameters to the default copy button and language badge slot helpers
 - Hardened CI with release builds, Maven publication smoke test, and Compose compiler report verification
-
-### 0.30.2 - Remove deprecated treeWalk timing
-
-- Removed the deprecated `treeWalk` timing property entirely from `HighlightTimings`
-- Cleaned up the timings usage in `HighlightEngine` and internally in `HtmlToAnnotatedString`
-- Updated the sample app performance breakdown screen and timing unit tests to remove the property
-- Synced documentation across the guides to reflect the updated timing model
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.34.0")
+    implementation("dev.hossain:compose-highlight:0.35.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.34.0")
+    implementation("dev.hossain:compose-highlight:0.35.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.34.0
+VERSION_NAME=0.35.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 41
-        versionName = "0.34.0"
+        versionCode = 42
+        versionName = "0.35.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Prepares release **0.35.0**:
- Updated `VERSION_NAME` to `0.35.0` in `gradle.properties`
- Updated dependency coordinate snippets across `README.md`, `docs/index.md`, and `docs/getting-started.md`
- Updated sample app `versionName` to `0.35.0` and incremented `versionCode` (`41` -> `42`) in `sample/build.gradle.kts`
- Updated `pyproject.toml` version to `0.35.0`
- Updated `CHANGELOG.md` and synced `docs/changelog.md` with 0.35.0 release highlights