### PR TITLE
fix: preserve streaming highlight spans on mid-stream engine failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable changes to this project will be documented in this file.
   are emitted during streaming, completed lines are progressively styled in the background without waiting for the
   idle debounce timer, while throttling engine executions to avoid JS overload (#440).
 
+### Fixed
+
+- **Fixed mid-stream highlight failures flashing the whole code block to plain text** - `rememberStreamingHighlightedCode`
+  previously reset its snapshot to `null` when a highlight run failed, discarding all preserved spans and flashing
+  already-colored lines back to unstyled text during active streaming. The last successful snapshot is now kept on
+  failure and the next debounce/throttle cycle retries with newer text. Also added an explicit run-ordering guard so a
+  result or error from a superseded highlight run can never overwrite a newer run's snapshot or re-fire callbacks,
+  making the engine's serialized-execution assumption an enforced invariant.
+
 ## [0.34.0] - 2026-08-28
 
 ### Added

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCode.kt
@@ -66,7 +66,8 @@ import kotlinx.coroutines.launch
  * @param onHighlightComplete Optional callback invoked with a [HighlightResult] when a highlight
  *   cycle completes successfully. Fires after the snapshot is updated.
  * @param onError Optional callback invoked with the [HighlightException] when highlighting fails.
- *   Falls back to plain text on failure - this callback is purely observational.
+ *   Previously highlighted spans are preserved on failure (no flash to plain text mid-stream) -
+ *   this callback is purely observational.
  * @return An [AnnotatedString] with syntax highlighting applied and previous spans preserved
  *   across stream updates.
  */
@@ -110,6 +111,13 @@ fun rememberStreamingHighlightedCode(
         // Reference to the currently scheduled debounce or throttle delay job.
         var pendingDebounceJob: Job? = null
 
+        // Monotonic id assigned to each highlight run. The engine's mutex serializes runs in
+        // launch order today, but this guard makes that ordering invariant explicit: a result
+        // (or failure) from a superseded run can never overwrite a newer run's snapshot or
+        // re-fire callbacks, even if run interleaving ever changes.
+        var lastAppliedRunId = 0L
+        var nextRunId = 0L
+
         /**
          * Dispatches a syntax highlight request to the underlying [HighlightEngine].
          *
@@ -124,16 +132,27 @@ fun rememberStreamingHighlightedCode(
             }
             if (textToHighlight == lastHighlightedText) return
 
+            val runId = ++nextRunId
             lastHighlightStartTime = System.currentTimeMillis()
             engine
                 .highlight(textToHighlight, language, theme)
                 .onSuccess { result ->
-                    highlighted = HighlightSnapshot(result.annotated, language, theme)
-                    lastHighlightedText = textToHighlight
-                    currentOnHighlightComplete?.invoke(result)
+                    if (runId > lastAppliedRunId) {
+                        lastAppliedRunId = runId
+                        highlighted = HighlightSnapshot(result.annotated, language, theme)
+                        lastHighlightedText = textToHighlight
+                        currentOnHighlightComplete?.invoke(result)
+                    }
                 }.onFailure { error ->
-                    highlighted = null
-                    (error as? HighlightException)?.let { currentOnError?.invoke(it) }
+                    if (runId > lastAppliedRunId) {
+                        // Keep the previous snapshot: a mid-stream failure (e.g. a transient
+                        // WebView timeout) must not flash already-highlighted lines back to
+                        // plain text. The next debounce/throttle cycle retries with newer
+                        // text; `lastHighlightedText` is intentionally left unchanged so
+                        // text that already has a valid snapshot is not needlessly re-run.
+                        lastAppliedRunId = runId
+                        (error as? HighlightException)?.let { currentOnError?.invoke(it) }
+                    }
                 }
         }
 

--- a/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCode.kt
+++ b/compose-highlight/src/main/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCode.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCodeRobolectricTest.kt
+++ b/compose-highlight/src/test/kotlin/dev/hossain/highlight/ui/RememberStreamingHighlightedCodeRobolectricTest.kt
@@ -246,6 +246,7 @@ class RememberStreamingHighlightedCodeRobolectricTest {
                 )
             }
         }
+
         composeTestRule.waitForIdle()
 
         val engine = capturedEngine ?: error("Engine was not captured")
@@ -259,5 +260,119 @@ class RememberStreamingHighlightedCodeRobolectricTest {
 
         assertThat(engine.webViewForTest()).isNull()
         assertThat(completedResults).isEmpty()
+    }
+
+    /**
+     * A mid-stream highlight failure (e.g. a transient WebView/JS error) must NOT discard the
+     * last successful snapshot. Previously highlighted spans stay applied to the unchanged
+     * prefix of the streaming text instead of flashing the whole block back to plain text.
+     *
+     * Drives two sequential highlight runs through Robolectric's ShadowWebView:
+     * run 1 succeeds (spans applied), run 2 fails (null JS result). Asserts the returned
+     * AnnotatedString still carries the run-1 spans after the failure.
+     */
+    @Test
+    fun midStreamHighlightFailurePreservesPreviouslyHighlightedSpans() {
+        val completedResults = mutableListOf<HighlightResult>()
+        val errors = mutableListOf<HighlightException>()
+        var code by mutableStateOf("val a = 1")
+        val theme = HighlightTheme.fromCss(".hljs-keyword { color: #ff0000; }", "test-theme")
+        var capturedEngine: HighlightEngine? = null
+        var capturedResult: AnnotatedString? = null
+
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val engine =
+                remember {
+                    HighlightEngine(context.applicationContext).also { capturedEngine = it }
+                }
+            CompositionLocalProvider(LocalHighlightEngine provides engine) {
+                capturedResult =
+                    rememberStreamingHighlightedCode(
+                        code = code,
+                        language = "kotlin",
+                        theme = theme,
+                        debounceMs = 5000L, // long debounce so idle timeout won't fire during test
+                        triggerOnNewline = true,
+                        minThrottleMs = 0L,
+                        onHighlightComplete = { completedResults.add(it) },
+                        onError = { errors.add(it) },
+                    )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val engine = capturedEngine ?: error("Engine was not captured")
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        // First newline completes line 1 and triggers the first (successful) highlight run.
+        code = "val a = 1\nval b = 2"
+        composeTestRule.waitForIdle()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            engine.webViewForTest() != null
+        }
+        val webView = engine.webViewForTest()
+        assertThat(webView).isNotNull()
+        val nonNullWebView = requireNotNull(webView)
+
+        val webViewClient = Shadows.shadowOf(nonNullWebView).getWebViewClient()
+        val lastUrl = Shadows.shadowOf(nonNullWebView).getLastLoadedUrl() ?: ""
+        webViewClient?.onPageFinished(nonNullWebView, lastUrl)
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback() != null
+        }
+        val firstCallback = Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback()
+        assertThat(firstCallback).isNotNull()
+        val successPayload =
+            org.json
+                .JSONObject()
+                .apply {
+                    put("error", false)
+                    put("html", "<span class=\"hljs-keyword\">val</span> a = 1\n<span class=\"hljs-keyword\">val</span> b = 2")
+                    put("language", "kotlin")
+                }.toString()
+        requireNotNull(firstCallback).onReceiveValue(org.json.JSONObject.quote(successPayload))
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            completedResults.isNotEmpty()
+        }
+        assertThat(completedResults).hasSize(1)
+        assertThat(capturedResult?.text).isEqualTo("val a = 1\nval b = 2")
+        assertThat(capturedResult?.spanStyles).isNotEmpty()
+
+        // Second newline triggers a second highlight run; drive it to failure with a null JS result.
+        code = "val a = 1\nval b = 2\nval c = 3"
+        composeTestRule.waitForIdle()
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            val next = Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback()
+            next != null && next !== firstCallback
+        }
+        val secondCallback = Shadows.shadowOf(nonNullWebView).getLastEvaluatedJavascriptCallback()
+        assertThat(secondCallback).isNotNull()
+        requireNotNull(secondCallback).onReceiveValue(null)
+
+        composeTestRule.waitUntil(timeoutMillis = 3000) {
+            ShadowLooper.idleMainLooper()
+            errors.isNotEmpty()
+        }
+        ShadowLooper.idleMainLooper()
+        composeTestRule.waitForIdle()
+
+        assertThat(errors).hasSize(1)
+        assertThat(errors.first()).isInstanceOf(HighlightException.JsExecutionFailed::class.java)
+        // The new token text renders immediately while spans from the successful first run
+        // remain applied to the unchanged prefix - no flash to fully plain text.
+        assertThat(capturedResult?.text).isEqualTo("val a = 1\nval b = 2\nval c = 3")
+        assertThat(capturedResult?.spanStyles).isNotEmpty()
     }
 }


### PR DESCRIPTION
## Problem

Code review of the recently added `StreamingSyntaxHighlightedCode` / `rememberStreamingHighlightedCode` found three issues in the streaming highlight pipeline:

1. **Mid-stream failures flash the whole block to plain text** - `onFailure` reset the snapshot to `null`, discarding all preserved spans. A transient failure (e.g. `HighlightException.Timeout` while the WebView is busy) during active token streaming visually reset every already-colored line back to unstyled text, defeating the span-transfer feature.
2. **No explicit ordering guard between overlapping highlight runs** - the newline-triggered immediate run is untracked and can overlap a throttle/debounce job. Safety depended entirely on the engine fair `Mutex` serializing calls in launch order - an implicit cross-module invariant.
3. **Unused `LocalContentColor` import** in `StreamingSyntaxHighlightedCode.kt`.

## Solution

- `executeHighlight` now keeps the last successful snapshot on failure; the next debounce/throttle cycle retries with newer text. `lastHighlightedText` is intentionally left unchanged on failure so text that already has a valid snapshot is deduped.
- Added a monotonic `runId` guard: a result (or failure) from a superseded run can never overwrite a newer run\s snapshot or re-fire callbacks (`onHighlightComplete` / `onError`). The engine\s serialized-execution assumption is now an enforced invariant rather than an implicit one.
- Removed the unused import.
- Updated the `onError` KDoc on `rememberStreamingHighlightedCode` to describe the preserved-spans failure behavior.

## Testing

- Added `midStreamHighlightFailurePreservesPreviouslyHighlightedSpans` to `RememberStreamingHighlightedCodeRobolectricTest`: drives two sequential highlight runs through `ShadowWebView` (run 1 succeeds, run 2 fails with a null JS result) and asserts the returned `AnnotatedString` still carries run-1 spans on the unchanged prefix while the new token text renders immediately.
- **Revert-checked**: the new test fails against the old `highlighted = null` behavior and passes with the fix.
- The ordering guard is not directly testable through `ShadowWebView` (the engine mutex prevents two concurrently pending JS callbacks); it is covered implicitly by the full suite.
- `formatKotlin`, `lintKotlin`, `markdownlint-cli CHANGELOG.md`, full `:compose-highlight:testDebugUnitTest`, and both `assembleDebug` builds pass.

## Notes

- No public API signature changes; behavior-only fix within `@ExperimentalHighlightApi` surface.
- CHANGELOG updated under `[Unreleased]` -> `### Fixed`.