### PR TITLE
docs: add streaming feature to landing page and document streaming error handling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ That's it. `HighlightThemeProvider` automatically picks Tomorrow (light) or Tomo
 
 ## Key features
 
+- **Streaming / LLM code** - zero-latency progressive rendering for AI chat token streams via `StreamingSyntaxHighlightedCode`
 - **Wide language coverage** - use any language supported by the bundled Highlight.js build
 - **Light + dark themes** - automatic system-mode switching, or manual override
 - **Built-in themes** - Tomorrow, Tomorrow Night, Atom One Dark, Atom One Light, GitHub Light, GitHub Dark, Dracula Dark, Alucard Light

--- a/docs/reference/streaming-syntax-highlighted-code.md
+++ b/docs/reference/streaming-syntax-highlighted-code.md
@@ -71,6 +71,15 @@ Unlike `SyntaxHighlightedCode` (which uses fade-in animations and resets in-flig
 - `onHighlightComplete` - Optional callback invoked with `HighlightResult` on successful highlight cycle.
 - `onError` - Optional callback invoked with `HighlightException` on failure.
 
+## Error handling
+
+`onError` is observational - rendering never breaks when the highlight engine fails:
+
+- **Spans are preserved:** a mid-stream failure (e.g. a transient WebView timeout) keeps the last successful snapshot,
+  so already-colored lines do not flash back to plain text.
+- **Automatic retry:** the next debounce or newline-triggered cycle retries highlighting with the latest text.
+- **Plain-text start:** if highlighting has never succeeded, incoming text still renders immediately as unstyled monospace text.
+
 ## Opting in
 
 `StreamingSyntaxHighlightedCode`, `rememberStreamingHighlightedCode`, and `StreamingSyntaxHighlightedCodeDefaults` are annotated with `@ExperimentalHighlightApi`:


### PR DESCRIPTION
Follow-up to the 0.35.0 docs audit of `StreamingSyntaxHighlightedCode` coverage. The docs were current on parameters and navigation, but two gaps remained:

## Changes

1. **`docs/index.md`** - Added a streaming bullet to the Key features list. The flagship LLM/streaming capability (added in 0.34.0, extended in 0.35.0) was advertised in the README but missing from the docs landing page - the first page visitors see.
2. **`docs/reference/streaming-syntax-highlighted-code.md`** - Added an **Error handling** section documenting the failure behavior shipped in #444: `onError` is observational, previously highlighted spans are preserved on mid-stream failures (no flash to plain text), the next debounce/newline cycle retries automatically, and text always renders immediately even before the first successful highlight.

## Validation

- `zensical build --clean` - no issues (installed in an isolated venv, same `pip install .` path CI uses)
- Docs-only change: CI\s change-detection runs the docs validation path only; the Android build path is skipped