### PR TITLE
docs: standardize supported language references to 190+ and update version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - **Upgraded bundled highlight.js to 11.12.0** - Updated the bundled JavaScript engine from 11.11.1 to 11.12.0,
   bringing grammar improvements for Python, Rust, C/C++, Java, and Go, new language aliases for Kotlin (`ktm`, `ktx`),
   backreference fixes in the parser engine, and added 2 new themes (`equinox` and `vs-dark`) to the sample app (#446).
+- **Standardized supported language references to 190+ languages** - Updated documentation, PRD specifications,
+  and test comments to consistently describe the bundled grammar capability as 190+ languages.
 
 ### Infrastructure
 

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/engine/HighlightEngineTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/engine/HighlightEngineTest.kt
@@ -395,7 +395,7 @@ class HighlightEngineTest {
     fun highlightJsVersionMatchesVersionFormat() =
         runBlocking {
             val version = engine.highlightJsVersion().getOrThrow()
-            // Format: digits and dots, e.g. "11.11.1"
+            // Format: digits and dots, e.g. "11.12.0"
             assertThat(version).matches("\\d+\\.\\d+.*")
         }
 

--- a/resources/prd-compose-syntax-highlight.html
+++ b/resources/prd-compose-syntax-highlight.html
@@ -181,7 +181,7 @@
 <table>
   <thead><tr><th>File</th><th>Description</th><th>Size</th></tr></thead>
   <tbody>
-    <tr><td><code>highlight.min.js</code></td><td>Highlight.js v11.11.1, 192 languages</td><td>~1.04 MB</td></tr>
+    <tr><td><code>highlight.min.js</code></td><td>Highlight.js v11.12.0, 190+ languages</td><td>~1.08 MB</td></tr>
     <tr><td><code>bridge.html</code></td><td>HTML page with <code>highlightCode()</code></td><td>~300 B</td></tr>
     <tr><td><code>themes/tomorrow.css</code></td><td>Base16 Tomorrow (light)</td><td>~3 KB</td></tr>
     <tr><td><code>themes/tomorrow-night.css</code></td><td>Base16 Tomorrow Night (dark)</td><td>~3 KB</td></tr>
@@ -520,7 +520,7 @@ LaunchedEffect(code) {
 
 <ul class="checklist">
   <li><code>SyntaxHighlightedCode(code, language)</code> renders colored code with a single line</li>
-  <li>All 192 Highlight.js languages produce highlighted output</li>
+  <li>All 190+ Highlight.js languages produce highlighted output</li>
   <li>Light/dark themes switch instantly without re-highlighting</li>
   <li>Code is natively selectable (long-press)</li>
   <li>Copy button copies raw unstyled code</li>

--- a/resources/prd-compose-syntax-highlight.md
+++ b/resources/prd-compose-syntax-highlight.md
@@ -130,7 +130,7 @@ Code ("def foo():") + lang ("python")
 
 | File | Description | Size |
 |------|-------------|------|
-| `highlight.min.js` | Highlight.js v11.11.1, full 192-language bundle | ~1.04 MB |
+| `highlight.min.js` | Highlight.js v11.12.0, full 190+ language bundle | ~1.08 MB |
 | `bridge.html` | HTML page with `highlightCode()`, `listLanguages()`, and `hljsVersion()` JS functions | ~600 bytes |
 | `themes/tomorrow.css` | Base16 Tomorrow (light theme) | ~3 KB |
 | `themes/tomorrow-night.css` | Base16 Tomorrow Night (dark theme) | ~3 KB |
@@ -170,7 +170,7 @@ function hljsVersion() {
 
 **Theme CSS files**: Use the standard Highlight.js Base16 theme format. The library's CSS parser works with any hljs theme CSS file — users can drop in custom themes.
 
-**Downloading highlight.min.js**: Download from https://highlightjs.org/ — select "all 192 languages" when building the bundle, or use the CDN full bundle.
+**Downloading highlight.min.js**: Download from https://highlightjs.org/ - select all languages (190+) when building the bundle, or use the CDN full bundle.
 
 ---
 
@@ -216,7 +216,7 @@ class HighlightEngine(context: Context) {
     // Cached after the first call — no extra WebView round-trip on subsequent calls.
     suspend fun supportedLanguages(): Result<List<String>>
 
-    // Returns the version string of the bundled Highlight.js (e.g. "11.11.1").
+    // Returns the version string of the bundled Highlight.js (e.g. "11.12.0").
     // Cached after the first call.
     suspend fun highlightJsVersion(): Result<String>
 
@@ -880,7 +880,7 @@ Build in this sequence — each step is independently testable:
 The library is complete when:
 
 - [ ] `SyntaxHighlightedCode(code = "...", language = "python")` renders colored code in a Compose app with a single line of code
-- [ ] All 192 Highlight.js languages produce highlighted output
+- [ ] All 190+ Highlight.js languages produce highlighted output
 - [ ] Light and dark themes switch instantly without re-highlighting
 - [ ] Code is natively selectable (long-press to select text)
 - [ ] Copy button works and copies raw (unstyled) code

--- a/scripts/upgrade-hljs.sh
+++ b/scripts/upgrade-hljs.sh
@@ -73,8 +73,9 @@ ROOT_THEME_COUNT=$(find "$REPO_ROOT/sample/src/main/assets/themes" -maxdepth 1 -
 # Update HighlightEngine.kt KDoc example
 sedi "s/(e\.g\. \"$CURRENT_VERSION\")/(e.g. \"$NEW_VERSION\")/" "$REPO_ROOT/compose-highlight/src/main/kotlin/dev/hossain/highlight/engine/HighlightEngine.kt"
 
-# Update HighlightEngineRobolectricTest.kt
+# Update HighlightEngineRobolectricTest.kt and HighlightEngineTest.kt
 sedi "s/\"$CURRENT_VERSION\"/\"$NEW_VERSION\"/g" "$REPO_ROOT/compose-highlight/src/test/kotlin/dev/hossain/highlight/engine/HighlightEngineRobolectricTest.kt"
+sedi "s/e\.g\. \"$CURRENT_VERSION\"/e.g. \"$NEW_VERSION\"/g" "$REPO_ROOT/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/engine/HighlightEngineTest.kt"
 
 # Update sample themes README.md
 sedi "s/version \*\*$CURRENT_VERSION\*\*/version \*\*$NEW_VERSION\*\*/g" "$REPO_ROOT/sample/src/main/assets/themes/README.md"


### PR DESCRIPTION
## Summary

Standardizes Highlight.js supported language references across the repository to **190+ languages** and updates remaining 11.11.1 / 192 version references.

### Changes
- Standardized documentation and PRD files (`resources/prd-compose-syntax-highlight.md`, `resources/prd-compose-syntax-highlight.html`) to describe the language support as **190+ languages** instead of exact numbers that fluctuate between minor releases.
- Updated remaining `11.11.1` version references to `11.12.0` in `HighlightEngineTest.kt` comments and PRD tables.
- Enhanced `scripts/upgrade-hljs.sh` to also keep `HighlightEngineTest.kt` version comments synchronized on future upgrades.
- Added entry to `CHANGELOG.md` under `[Unreleased]`.

### Verification
- `./gradlew formatKotlin lintKotlin` passed
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug :compose-highlight:test` passed
- `npx markdownlint-cli CHANGELOG.md` passed
