### PR TITLE
fix(sample): apply imePadding so keyboard does not obscure editor and search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - **Upgraded bundled highlight.js to 11.12.0** - Updated the bundled JavaScript engine from 11.11.1 to 11.12.0,
   bringing grammar improvements for Python, Rust, C/C++, Java, and Go, new language aliases for Kotlin (`ktm`, `ktx`),
   backreference fixes in the parser engine, and added 2 new themes (`equinox` and `vs-dark`) to the sample app (#446).
+- **Sample app LLM/Streaming tab stream button control** - Removed automatic streaming on tab navigation,
+  requiring users to explicitly tap the "Stream" button to start real-time token streaming.
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sample app editor and search fields obscured by soft keyboard** - Added `imePadding` to the root content
+  container in `SampleScreen` and refined window inset consumption so that the active scroll viewport shrinks
+  above the software keyboard, allowing `BringIntoView` to scroll focused editors and search fields into view.
+
 ### Changed
 
 - **Upgraded bundled highlight.js to 11.12.0** - Updated the bundled JavaScript engine from 11.11.1 to 11.12.0,

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/SampleScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -196,7 +197,8 @@ internal fun SampleScreen(viewModel: SampleViewModel = viewModel()) {
                     Modifier
                         .fillMaxSize()
                         .padding(top = innerPadding.calculateTopPadding())
-                        .consumeWindowInsets(innerPadding),
+                        .consumeWindowInsets(PaddingValues(top = innerPadding.calculateTopPadding()))
+                        .imePadding(),
             ) {
                 val selectedTabIndex = activeTabIndex.coerceIn(tabs.indices)
                 PrimaryScrollableTabRow(selectedTabIndex = selectedTabIndex) {

--- a/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
+++ b/sample/src/main/kotlin/dev/hossain/highlight/sample/sections/StreamingSection.kt
@@ -149,7 +149,6 @@ internal fun StreamingSection() {
     }
 
     DisposableEffect(Unit) {
-        startStreaming(currentSnippetCode)
         onDispose {
             streamingJob?.cancel()
         }
@@ -214,7 +213,7 @@ internal fun StreamingSection() {
                     contentDescription = null,
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                Text(if (isStreaming) "Streaming..." else "Re-stream")
+                Text(if (isStreaming) "Streaming..." else "Stream")
             }
 
             OutlinedButton(


### PR DESCRIPTION
## Summary

1. **Fixes sample app IME overlap**: Fixes an issue where tapping the editor in the "Live Editor" tab (or search fields in other tabs) caused the software keyboard to open over the input area without scrolling it into view.
2. **Improves LLM/Streaming tab UX**: Disables automatic streaming on tab composition, requiring users to explicitly tap the "Stream" button to start streaming.

### Changes

#### IME & Insets Fix
- In edge-to-edge Compose (`enableEdgeToEdge()`), `adjustResize` draws behind system bars and the keyboard while providing `WindowInsets.ime`.
- Added `Modifier.imePadding()` to the root content `Column` in `SampleScreen.kt`.
- Restricted `consumeWindowInsets` to only the top padding actually applied by `Column`.
- When the keyboard appears, the scroll container's viewport now contracts to end directly above the keyboard, enabling `BringIntoView` to automatically scroll the editor and cursor into view.

#### Streaming UX Improvement
- In `StreamingSection.kt`, removed `startStreaming()` from `DisposableEffect(Unit)` so it no longer auto-streams when opening the tab.
- Renamed the button label from "Re-stream" to "Stream" when idle.

### Verification
- `./gradlew formatKotlin lintKotlin` passed
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug` passed
- `./gradlew :compose-highlight:test` passed
- `npx markdownlint-cli CHANGELOG.md` passed
