### PR TITLE
chore: prepare release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-09-03
+
 ### Fixed
 
 - **Sample app editor and search fields obscured by soft keyboard** - Added `imePadding` to the root content

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ native Compose `AnnotatedString`. Supports 190+ languages with no custom lexers 
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.35.0")
+    implementation("dev.hossain:compose-highlight:0.36.0")
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 
 ## Recent highlights
 
+### 0.36.0 - Highlight.js 11.12.0 & Sample UX Enhancements
+
+- Upgraded bundled Highlight.js engine from 11.11.1 to 11.12.0 with grammar fixes for Python, Rust, C/C++, Java, and Go
+- Added new Kotlin language aliases (`ktm`, `ktx`) and 2 new themes (`equinox` and `vs-dark`) to the sample app
+- Fixed soft keyboard obscuring editor and search fields in the sample app by applying `imePadding` and refining insets
+- Added manual "Stream" button control to the sample app LLM/Streaming demo tab
+- Streamlined Highlight.js upgrade tooling with automated weekly upstream release monitoring
+
 ### 0.35.0 - Newline-aware streaming & progressive backfill
 
 - Added newline-aware debouncing and progressive line backfilling for `StreamingSyntaxHighlightedCode` and `rememberStreamingHighlightedCode`
@@ -36,14 +44,6 @@ For release artifacts and APK downloads, see the [GitHub Releases page](https://
 - Aligned Dracula and Alucard built-in themes to be fully spec-compliant with correct color and selector mappings
 - Renamed `rememberTomorrowTheme()` to `rememberTomorrowLightTheme()` for naming consistency across light/dark suffix theme helpers
 - Removed dead legacy parser code from `HtmlParser.kt` to shrink AAR size and improve code coverage metrics
-
-### 0.31.0 - Scroll hoisting, preview fixes, and CI hardening
-
-- Added scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor` for programmatic scroll control
-- Fixed Compose Preview crashes by blocking WebView initialization in `@Preview` composables across the editor, read-only blocks, and theme provider
-- Fixed `HighlightResult.spanCount` semantics and CSS `#RRGGBBAA` color parsing order
-- Stabilized `SyntaxHighlightedTextEditor` callbacks, remembered focus/scroll modifiers, and added `modifier` parameters to the default copy button and language badge slot helpers
-- Hardened CI with release builds, Maven publication smoke test, and Compose compiler report verification
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ In your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.35.0")
+    implementation("dev.hossain:compose-highlight:0.36.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.hossain:compose-highlight:0.35.0")
+    implementation("dev.hossain:compose-highlight:0.36.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --enable-native-access=ALL-UN
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-VERSION_NAME=0.35.0
+VERSION_NAME=0.36.0
 # vanniktech/gradle-maven-publish-plugin configuration
 # SONATYPE_HOST: which Sonatype endpoint to use (CENTRAL_PORTAL for new accounts)
 # mavenCentralAutomaticPublishing: auto-release after upload without manual close step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "android-compose-highlight-docs"
 description = "Documentation site for Compose Highlight for Android"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
     # https://github.com/zensical/zensical/releases
     # https://pypi.org/project/zensical/

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "dev.hossain.highlight.sample"
         minSdk = 24
         targetSdk = 36
-        versionCode = 42
-        versionName = "0.35.0"
+        versionCode = 43
+        versionName = "0.36.0"
         buildConfigField("String", "LIB_VERSION_NAME", "\"${project.findProperty("VERSION_NAME") ?: versionName}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

Prepares release **0.36.0**.

### Release Highlights

#### Highlights
- **Upgraded bundled Highlight.js to 11.12.0** - Updated the bundled JavaScript engine from 11.11.1 to 11.12.0, bringing grammar improvements for Python, Rust, C/C++, Java, and Go, new language aliases for Kotlin (`ktm`, `ktx`), backreference fixes in the parser engine, and added 2 new themes (`equinox` and `vs-dark`) to the sample app (#446).
- **Fixed sample app keyboard obscuring editor and search fields** - Added `imePadding` to the root content container in `SampleScreen` and refined window inset consumption so that the active scroll viewport shrinks above the software keyboard, allowing `BringIntoView` to scroll focused editors and search fields into view (#451).
- **Sample app LLM/Streaming tab stream button control** - Removed automatic streaming on tab navigation, requiring users to explicitly tap the "Stream" button to start real-time token streaming (#451).
- **Standardized supported language references to 190+ languages** - Updated documentation, PRD specifications, and test comments to consistently describe the bundled grammar capability as 190+ languages (#450).
- **Streamlined Highlight.js upgrade tooling and automated release detection** - Added `scripts/upgrade-hljs.sh` orchestrator, `scripts/bundle-hljs.mjs` for reproducible esbuild bundling, `scripts/refresh-sample-themes.sh`, and `scripts/validate-bridge.sh` for local bridge contract checks. Added weekly GitHub Actions workflow `.github/workflows/check-hljs-updates.yml` to automatically track upstream releases (#448, #449).

### Files Updated
- `gradle.properties` - `VERSION_NAME` -> `0.36.0`
- `README.md` - dependency snippet -> `0.36.0`
- `docs/index.md` - dependency snippet -> `0.36.0`
- `docs/getting-started.md` - dependency snippet -> `0.36.0`
- `sample/build.gradle.kts` - `versionName` -> `0.36.0`, `versionCode` -> `43`
- `pyproject.toml` - `version` -> `0.36.0`
- `CHANGELOG.md` - `[Unreleased]` -> `[0.36.0] - 2026-09-03`
- `docs/changelog.md` - added `0.36.0` highlights, pruned `0.31.0`

### Verification
- `./gradlew formatKotlin lintKotlin` passed
- `./gradlew :compose-highlight:assembleDebug :sample:assembleDebug` passed
- `./gradlew :compose-highlight:test` passed
- `npx markdownlint-cli CHANGELOG.md` passed
