### PR TITLE
test: adopt Dejavu for automated recomposition stability testing (#461)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,6 +47,10 @@ npx markdownlint-cli --fix CHANGELOG.md
 ./gradlew :compose-highlight:connectedAndroidTest \
   -P android.testInstrumentationRunnerArguments.class=dev.hossain.highlight.benchmark.HighlightEngineBenchmark
 
+# Run recomposition stability tests on a connected device (powered by Dejavu)
+./gradlew :compose-highlight:connectedAndroidTest \
+  -P android.testInstrumentationRunnerArguments.class=dev.hossain.highlight.ui.SyntaxHighlightedCodeRecompositionTest
+
 # Generate Dokka API docs → docs/api/
 ./gradlew :compose-highlight:dokkaGeneratePublicationHtml
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Infrastructure
 
+- **Adopted Dejavu for automated recomposition testing** - Integrated `me.mmckenna.dejavu` (0.5.0) as an internal
+  test dependency and added recomposition test suites to verify that `SyntaxHighlightedCode`,
+  `StreamingSyntaxHighlightedCode`, and `SyntaxHighlightedTextEditor` properly honor Compose compiler skipping
+  contracts and stay stable during parent and sibling recompositions (#461).
 - **Refined JaCoCo code coverage exclusions** - Excluded generated theme mappings (`GeneratedThemes*`),
   Android manifests, and Compose synthetic artifacts from code coverage reports in `:compose-highlight`.
 

--- a/compose-highlight/build.gradle.kts
+++ b/compose-highlight/build.gradle.kts
@@ -171,6 +171,10 @@ if (providers.gradleProperty("runBenchmark").orNull == "true") {
     }
 }
 
+composeCompiler {
+    includeSourceInformation = true
+}
+
 if (providers.gradleProperty("composeReports").orNull == "true") {
     composeCompiler {
         reportsDestination = layout.buildDirectory.dir("compose_compiler")
@@ -216,6 +220,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.espresso.core) // force upgrade from 3.5.0 → 3.7.0
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.benchmark.junit4)
+    androidTestImplementation(libs.dejavu)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
@@ -48,11 +48,13 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
                         onClick = { counter++ },
                         modifier = Modifier.testTag("increment_button"),
                     ) {
-                        Text(
-                            text = "Counter: $counter",
-                            modifier = Modifier.testTag("counter_text"),
-                        )
+                        Text("Increment")
                     }
+
+                    Text(
+                        text = "Counter: $counter",
+                        modifier = Modifier.testTag("counter_text"),
+                    )
 
                     StreamingSyntaxHighlightedCode(
                         code = "fun stream() = 42",

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
@@ -1,0 +1,109 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import dev.hossain.highlight.engine.HighlightTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Recomposition stability tests for [StreamingSyntaxHighlightedCode] using Dejavu.
+ *
+ * Verifies that streaming updates, debounce cycles, and parent recompositions
+ * adhere to Compose compiler skipping and stability contracts.
+ */
+@OptIn(ExperimentalHighlightApi::class)
+@RunWith(AndroidJUnit4::class)
+class StreamingSyntaxHighlightedCodeRecompositionTest {
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule()
+
+    @Test
+    fun parentStateChange_streamingCodeSkipsRecomposition() {
+        composeTestRule.setContent {
+            var counter by remember { mutableIntStateOf(0) }
+
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                Column {
+                    Button(
+                        onClick = { counter++ },
+                        modifier = Modifier.testTag("increment_button"),
+                    ) {
+                        Text(
+                            text = "Counter: $counter",
+                            modifier = Modifier.testTag("counter_text"),
+                        )
+                    }
+
+                    StreamingSyntaxHighlightedCode(
+                        code = "fun stream() = 42",
+                        language = "kotlin",
+                        modifier = Modifier.testTag("streaming-syntax-highlighted-code"),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Trigger a recomposition in parent via counter
+        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.waitForIdle()
+
+        // Counter text recomposes once
+        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+
+        // Streaming block parameters did not change - must skip recomposition entirely
+        composeTestRule.onNodeWithTag("streaming-syntax-highlighted-code").assertStable()
+    }
+
+    @Test
+    fun codeUpdate_recomposesExactlyOnce() {
+        var codeState by mutableStateOf("fun hello() {")
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                StreamingSyntaxHighlightedCode(
+                    code = codeState,
+                    language = "kotlin",
+                    modifier = Modifier.testTag("streaming-syntax-highlighted-code"),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Simulate streaming token arrival
+        composeTestRule.runOnIdle {
+            codeState = "fun hello() { println(\"hi\") }"
+        }
+        composeTestRule.waitForIdle()
+
+        // Must recompose exactly once for the new code string
+        composeTestRule.onNodeWithTag("streaming-syntax-highlighted-code").assertRecompositions(exactly = 1)
+    }
+}

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
@@ -51,10 +51,7 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
                         Text("Increment")
                     }
 
-                    Text(
-                        text = "Counter: $counter",
-                        modifier = Modifier.testTag("counter_text"),
-                    )
+                    CounterLabel(count = counter)
 
                     StreamingSyntaxHighlightedCode(
                         code = "fun stream() = 42",
@@ -107,5 +104,15 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
 
         // Must recompose exactly once for the new code string
         composeTestRule.onNodeWithTag("streaming-syntax-highlighted-code").assertRecompositions(exactly = 1)
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun CounterLabel(count: Int) {
+        androidx.compose.material3.Text(
+            text = "Counter: $count",
+            modifier =
+                androidx.compose.ui.Modifier
+                    .testTag("counter_text"),
+        )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
@@ -47,12 +47,12 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
                 Column {
                     Button(
                         onClick = { counter++ },
-                        modifier = Modifier.testTag("increment_button"),
+                        modifier = Modifier.testTag("streaming_increment_button"),
                     ) {
                         Text("Increment")
                     }
 
-                    CounterLabel(count = counter)
+                    StreamingCounterLabel(count = counter)
 
                     StreamingSyntaxHighlightedCode(
                         code = "fun stream() = 42",
@@ -67,11 +67,11 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
         composeTestRule.resetRecompositionCounts()
 
         // Trigger a recomposition in parent via counter
-        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.onNodeWithTag("streaming_increment_button").performClick()
         composeTestRule.waitForIdle()
 
         // Counter text recomposes once
-        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+        composeTestRule.onNodeWithTag("streaming_counter_text").assertRecompositions(exactly = 1)
 
         // Streaming block parameters did not change - must skip recomposition entirely
         composeTestRule.onNodeWithTag("streaming-syntax-highlighted-code").assertStable()
@@ -108,10 +108,10 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
     }
 
     @Composable
-    private fun CounterLabel(count: Int) {
+    private fun StreamingCounterLabel(count: Int) {
         Text(
             text = "Counter: $count",
-            modifier = Modifier.testTag("counter_text"),
+            modifier = Modifier.testTag("streaming_counter_text"),
         )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/StreamingSyntaxHighlightedCodeRecompositionTest.kt
@@ -3,6 +3,7 @@ package dev.hossain.highlight.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -106,13 +107,11 @@ class StreamingSyntaxHighlightedCodeRecompositionTest {
         composeTestRule.onNodeWithTag("streaming-syntax-highlighted-code").assertRecompositions(exactly = 1)
     }
 
-    @androidx.compose.runtime.Composable
+    @Composable
     private fun CounterLabel(count: Int) {
-        androidx.compose.material3.Text(
+        Text(
             text = "Counter: $count",
-            modifier =
-                androidx.compose.ui.Modifier
-                    .testTag("counter_text"),
+            modifier = Modifier.testTag("counter_text"),
         )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
@@ -50,10 +50,7 @@ class SyntaxHighlightedCodeRecompositionTest {
                         Text("Increment")
                     }
 
-                    Text(
-                        text = "Counter: $counter",
-                        modifier = Modifier.testTag("counter_text"),
-                    )
+                    CounterLabel(count = counter)
 
                     SyntaxHighlightedCode(
                         code = "val message = \"Hello, World!\"",
@@ -148,5 +145,15 @@ class SyntaxHighlightedCodeRecompositionTest {
 
         // Block B's inputs were unchanged - must remain completely stable
         composeTestRule.onNodeWithTag("code_block_b").assertStable()
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun CounterLabel(count: Int) {
+        androidx.compose.material3.Text(
+            text = "Counter: $count",
+            modifier =
+                androidx.compose.ui.Modifier
+                    .testTag("counter_text"),
+        )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
@@ -1,0 +1,150 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import dev.hossain.highlight.engine.HighlightTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Recomposition stability tests for [SyntaxHighlightedCode] using Dejavu.
+ *
+ * Enforces Compose compiler skipping contracts to ensure that parent recompositions,
+ * sibling state changes, and shared providers do not cause unnecessary recomposition churn.
+ */
+@RunWith(AndroidJUnit4::class)
+class SyntaxHighlightedCodeRecompositionTest {
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule()
+
+    @Test
+    fun parentStateChange_syntaxHighlightedCodeSkipsRecomposition() {
+        composeTestRule.setContent {
+            var counter by remember { mutableIntStateOf(0) }
+
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                Column {
+                    Button(
+                        onClick = { counter++ },
+                        modifier = Modifier.testTag("increment_button"),
+                    ) {
+                        Text(
+                            text = "Counter: $counter",
+                            modifier = Modifier.testTag("counter_text"),
+                        )
+                    }
+
+                    SyntaxHighlightedCode(
+                        code = "val message = \"Hello, World!\"",
+                        language = "kotlin",
+                        modifier = Modifier.testTag("syntax-highlighted-code"),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Trigger a recomposition in the parent via counter state change
+        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.waitForIdle()
+
+        // The counter text inside the button should have recomposed
+        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+
+        // SyntaxHighlightedCode parameters did not change - must skip recomposition entirely
+        composeTestRule.onNodeWithTag("syntax-highlighted-code").assertStable()
+    }
+
+    @Test
+    fun codeParameterChange_recomposesExactlyOnce() {
+        var codeState by mutableStateOf("val x = 1")
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                SyntaxHighlightedCode(
+                    code = codeState,
+                    language = "kotlin",
+                    modifier = Modifier.testTag("syntax-highlighted-code"),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Change the code parameter
+        composeTestRule.runOnIdle {
+            codeState = "val x = 2"
+        }
+        composeTestRule.waitForIdle()
+
+        // Must recompose exactly once in response to the input change
+        composeTestRule.onNodeWithTag("syntax-highlighted-code").assertRecompositions(exactly = 1)
+    }
+
+    @Test
+    fun multipleCodeBlocksInSharedProvider_oneBlockUpdateDoesNotRecomposeSibling() {
+        var codeA by mutableStateOf("val a = 10")
+        val codeB = "val b = 20"
+
+        composeTestRule.setContent {
+            HighlightThemeProvider(
+                lightHighlightTheme = HighlightTheme.tomorrow(),
+                darkHighlightTheme = HighlightTheme.tomorrowNight(),
+            ) {
+                Column {
+                    SyntaxHighlightedCode(
+                        code = codeA,
+                        language = "kotlin",
+                        modifier = Modifier.testTag("code_block_a"),
+                    )
+
+                    SyntaxHighlightedCode(
+                        code = codeB,
+                        language = "kotlin",
+                        modifier = Modifier.testTag("code_block_b"),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Mutate block A's input
+        composeTestRule.runOnIdle {
+            codeA = "val a = 99"
+        }
+        composeTestRule.waitForIdle()
+
+        // Block A should recompose once
+        composeTestRule.onNodeWithTag("code_block_a").assertRecompositions(exactly = 1)
+
+        // Block B's inputs were unchanged - must remain completely stable
+        composeTestRule.onNodeWithTag("code_block_b").assertStable()
+    }
+}

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
@@ -3,6 +3,7 @@ package dev.hossain.highlight.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -147,13 +148,11 @@ class SyntaxHighlightedCodeRecompositionTest {
         composeTestRule.onNodeWithTag("code_block_b").assertStable()
     }
 
-    @androidx.compose.runtime.Composable
+    @Composable
     private fun CounterLabel(count: Int) {
-        androidx.compose.material3.Text(
+        Text(
             text = "Counter: $count",
-            modifier =
-                androidx.compose.ui.Modifier
-                    .testTag("counter_text"),
+            modifier = Modifier.testTag("counter_text"),
         )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
@@ -46,12 +46,12 @@ class SyntaxHighlightedCodeRecompositionTest {
                 Column {
                     Button(
                         onClick = { counter++ },
-                        modifier = Modifier.testTag("increment_button"),
+                        modifier = Modifier.testTag("code_increment_button"),
                     ) {
                         Text("Increment")
                     }
 
-                    CounterLabel(count = counter)
+                    CodeCounterLabel(count = counter)
 
                     SyntaxHighlightedCode(
                         code = "val message = \"Hello, World!\"",
@@ -66,11 +66,11 @@ class SyntaxHighlightedCodeRecompositionTest {
         composeTestRule.resetRecompositionCounts()
 
         // Trigger a recomposition in the parent via counter state change
-        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.onNodeWithTag("code_increment_button").performClick()
         composeTestRule.waitForIdle()
 
-        // The counter text inside the button should have recomposed
-        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+        // The counter text should have recomposed
+        composeTestRule.onNodeWithTag("code_counter_text").assertRecompositions(exactly = 1)
 
         // SyntaxHighlightedCode parameters did not change - must skip recomposition entirely
         composeTestRule.onNodeWithTag("syntax-highlighted-code").assertStable()
@@ -149,10 +149,10 @@ class SyntaxHighlightedCodeRecompositionTest {
     }
 
     @Composable
-    private fun CounterLabel(count: Int) {
+    private fun CodeCounterLabel(count: Int) {
         Text(
             text = "Counter: $count",
-            modifier = Modifier.testTag("counter_text"),
+            modifier = Modifier.testTag("code_counter_text"),
         )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedCodeRecompositionTest.kt
@@ -47,11 +47,13 @@ class SyntaxHighlightedCodeRecompositionTest {
                         onClick = { counter++ },
                         modifier = Modifier.testTag("increment_button"),
                     ) {
-                        Text(
-                            text = "Counter: $counter",
-                            modifier = Modifier.testTag("counter_text"),
-                        )
+                        Text("Increment")
                     }
+
+                    Text(
+                        text = "Counter: $counter",
+                        modifier = Modifier.testTag("counter_text"),
+                    )
 
                     SyntaxHighlightedCode(
                         code = "val message = \"Hello, World!\"",

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
@@ -47,11 +47,13 @@ class SyntaxHighlightedTextEditorRecompositionTest {
                         onClick = { counter++ },
                         modifier = Modifier.testTag("increment_button"),
                     ) {
-                        Text(
-                            text = "Counter: $counter",
-                            modifier = Modifier.testTag("counter_text"),
-                        )
+                        Text("Increment")
                     }
+
+                    Text(
+                        text = "Counter: $counter",
+                        modifier = Modifier.testTag("counter_text"),
+                    )
 
                     SyntaxHighlightedTextEditor(
                         value = editorValue,

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
@@ -46,12 +46,12 @@ class SyntaxHighlightedTextEditorRecompositionTest {
                 Column {
                     Button(
                         onClick = { counter++ },
-                        modifier = Modifier.testTag("increment_button"),
+                        modifier = Modifier.testTag("editor_increment_button"),
                     ) {
                         Text("Increment")
                     }
 
-                    CounterLabel(count = counter)
+                    EditorCounterLabel(count = counter)
 
                     SyntaxHighlightedTextEditor(
                         value = editorValue,
@@ -67,11 +67,11 @@ class SyntaxHighlightedTextEditorRecompositionTest {
         composeTestRule.resetRecompositionCounts()
 
         // Trigger a recomposition in parent via counter
-        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.onNodeWithTag("editor_increment_button").performClick()
         composeTestRule.waitForIdle()
 
         // Counter text recomposes once
-        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+        composeTestRule.onNodeWithTag("editor_counter_text").assertRecompositions(exactly = 1)
 
         // Editor inputs did not change - must skip recomposition entirely
         composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertStable()
@@ -106,10 +106,10 @@ class SyntaxHighlightedTextEditorRecompositionTest {
     }
 
     @Composable
-    private fun CounterLabel(count: Int) {
+    private fun EditorCounterLabel(count: Int) {
         Text(
             text = "Counter: $count",
-            modifier = Modifier.testTag("counter_text"),
+            modifier = Modifier.testTag("editor_counter_text"),
         )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
@@ -1,0 +1,107 @@
+package dev.hossain.highlight.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Recomposition stability tests for [SyntaxHighlightedTextEditor] using Dejavu.
+ *
+ * Verifies that the editor composable skips recompositions when parent state updates,
+ * and recomposes only when its input [TextFieldValue] or parameters change.
+ */
+@OptIn(ExperimentalHighlightApi::class)
+@RunWith(AndroidJUnit4::class)
+class SyntaxHighlightedTextEditorRecompositionTest {
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule()
+
+    @Test
+    fun parentStateChange_editorSkipsRecomposition() {
+        var editorValue by mutableStateOf(TextFieldValue("val x = 1"))
+
+        composeTestRule.setContent {
+            var counter by remember { mutableIntStateOf(0) }
+
+            HighlightThemeProvider {
+                Column {
+                    Button(
+                        onClick = { counter++ },
+                        modifier = Modifier.testTag("increment_button"),
+                    ) {
+                        Text(
+                            text = "Counter: $counter",
+                            modifier = Modifier.testTag("counter_text"),
+                        )
+                    }
+
+                    SyntaxHighlightedTextEditor(
+                        value = editorValue,
+                        onValueChange = { editorValue = it },
+                        language = "kotlin",
+                        modifier = Modifier.testTag("syntax-highlighted-text-editor"),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Trigger a recomposition in parent via counter
+        composeTestRule.onNodeWithTag("increment_button").performClick()
+        composeTestRule.waitForIdle()
+
+        // Counter text recomposes once
+        composeTestRule.onNodeWithTag("counter_text").assertRecompositions(exactly = 1)
+
+        // Editor inputs did not change - must skip recomposition entirely
+        composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertStable()
+    }
+
+    @Test
+    fun valueChange_recomposesExactlyOnce() {
+        var editorValue by mutableStateOf(TextFieldValue("val x = 1"))
+
+        composeTestRule.setContent {
+            HighlightThemeProvider {
+                SyntaxHighlightedTextEditor(
+                    value = editorValue,
+                    onValueChange = { editorValue = it },
+                    language = "kotlin",
+                    modifier = Modifier.testTag("syntax-highlighted-text-editor"),
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.resetRecompositionCounts()
+
+        // Simulate typing
+        composeTestRule.runOnIdle {
+            editorValue = TextFieldValue("val x = 2")
+        }
+        composeTestRule.waitForIdle()
+
+        // Recomposes once for the new TextFieldValue
+        composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertRecompositions(exactly = 1)
+    }
+}

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
@@ -50,10 +50,7 @@ class SyntaxHighlightedTextEditorRecompositionTest {
                         Text("Increment")
                     }
 
-                    Text(
-                        text = "Counter: $counter",
-                        modifier = Modifier.testTag("counter_text"),
-                    )
+                    CounterLabel(count = counter)
 
                     SyntaxHighlightedTextEditor(
                         value = editorValue,
@@ -105,5 +102,15 @@ class SyntaxHighlightedTextEditorRecompositionTest {
 
         // Recomposes once for the new TextFieldValue
         composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertRecompositions(exactly = 1)
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun CounterLabel(count: Int) {
+        androidx.compose.material3.Text(
+            text = "Counter: $count",
+            modifier =
+                androidx.compose.ui.Modifier
+                    .testTag("counter_text"),
+        )
     }
 }

--- a/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
+++ b/compose-highlight/src/androidTest/kotlin/dev/hossain/highlight/ui/SyntaxHighlightedTextEditorRecompositionTest.kt
@@ -3,6 +3,7 @@ package dev.hossain.highlight.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -104,13 +105,11 @@ class SyntaxHighlightedTextEditorRecompositionTest {
         composeTestRule.onNodeWithTag("syntax-highlighted-text-editor").assertRecompositions(exactly = 1)
     }
 
-    @androidx.compose.runtime.Composable
+    @Composable
     private fun CounterLabel(count: Int) {
-        androidx.compose.material3.Text(
+        Text(
             text = "Counter: $count",
-            modifier =
-                androidx.compose.ui.Modifier
-                    .testTag("counter_text"),
+            modifier = Modifier.testTag("counter_text"),
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidxTestExt = "1.3.0"
 androidxTestRunner = "1.7.0"
 androidxWebkit = "1.17.0"
 coroutines = "1.11.0"
+dejavu = "0.5.0"
 dokka = "2.2.0"
 junit = "4.13.2"
 json = "20260814"
@@ -42,6 +43,7 @@ androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core",
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidxWebkit" }
+dejavu = { module = "me.mmckenna.dejavu:dejavu", version.ref = "dejavu" }
 junit = { module = "junit:junit", version.ref = "junit" }
 json = { module = "org.json:json", version.ref = "json" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
### Summary

Closes #461.

Integrates **[Dejavu](https://github.com/mttmcknn/dejavu)** (`0.5.0`) as an internal `androidTestImplementation` dependency to verify and enforce Jetpack Compose recomposition stability contracts in CI.

### Changes Made

1. **Dependency Added**:
   - Added `dejavu = "0.5.0"` and `dejavu = { module = "me.mmckenna.dejavu:dejavu", version.ref = "dejavu" }` to `gradle/libs.versions.toml`.
   - Added `androidTestImplementation(libs.dejavu)` to `compose-highlight/build.gradle.kts`.
   - Enabled `composeCompiler { includeSourceInformation = true }` to support Dejavu testTag-to-source diagnostics.

2. **Recomposition Test Suites**:
   - `SyntaxHighlightedCodeRecompositionTest`:
     - Asserts that parent recompositions cleanly skip `SyntaxHighlightedCode` (`assertStable()`).
     - Asserts that changing `code` triggers exactly one recomposition.
     - Asserts that updating one code block inside a shared `HighlightThemeProvider` does not recompose sibling blocks.
   - `StreamingSyntaxHighlightedCodeRecompositionTest`:
     - Asserts that streaming blocks skip recomposition when parent state changes.
     - Asserts that code parameter updates recompose exactly once.
   - `SyntaxHighlightedTextEditorRecompositionTest`:
     - Asserts that parent state updates do not trigger recomposition in the editor.
     - Asserts that `TextFieldValue` updates recompose as expected.

3. **Documentation & Changelog**:
   - Updated `CHANGELOG.md` under `[Unreleased] -> Infrastructure`.
   - Added connected recomposition test command to `AGENTS.md` and `.github/copilot-instructions.md`.